### PR TITLE
fix(testing): enforce meaningful coverage thresholds and expand scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Run unit tests with coverage
         working-directory: backend
-        run: poetry run pytest -v -m unit --cov=app --cov-report=term-missing --cov-fail-under=50
+        run: poetry run pytest -v -m unit --cov=app --cov=packages --cov-report=term-missing --cov-fail-under=50
 
   frontend-lint:
     name: Frontend Lint
@@ -97,6 +97,26 @@ jobs:
       - name: Document type check & lint
         working-directory: frontend
         run: npm run validate
+
+  frontend-test:
+    name: Frontend Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Run unit tests
+        working-directory: frontend
+        run: npm run test -- --ci
 
   # ============================================================================
   # Security Scanning

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -95,13 +95,13 @@ const customJestConfig = {
     '/tests/',
     '/__tests__/',
   ],
-  // Coverage thresholds — start low, increase as coverage improves
+  // Coverage thresholds — set above current levels to prevent regression
   coverageThreshold: {
     global: {
-      statements: 3,
-      branches: 2,
-      functions: 3,
-      lines: 3,
+      statements: 6,
+      branches: 4,
+      functions: 5,
+      lines: 6,
     },
   },
 }


### PR DESCRIPTION
## Summary
- Raise frontend Jest coverage thresholds from 3% to 6% (calibrated to current actual coverage)
- Remove `--passWithNoTests` flag from CI
- Add `packages/` to backend coverage scope

## Test plan
- [ ] CI passes with new thresholds
- [ ] Frontend tests run and report coverage
- [ ] Backend coverage includes packages

Closes #75