### PR TITLE
perf(backend): replace SELECT * with explicit column projections

### DIFF
--- a/backend/app/analytics.py
+++ b/backend/app/analytics.py
@@ -407,7 +407,11 @@ async def get_session_summary(
             client = get_admin_supabase_client()
 
         # Get all events for this session
-        query = client.table("events").select("*").eq("session_id", session_id)
+        query = (
+            client.table("events")
+            .select("id, user_id, session_id, event_name, event_data, created_at")
+            .eq("session_id", session_id)
+        )
 
         # If authenticated, filter by user_id for security
         if user:

--- a/backend/app/api/blog.py
+++ b/backend/app/api/blog.py
@@ -9,6 +9,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query
 from loguru import logger
 from pydantic import BaseModel, Field
+from supabase import PostgrestAPIError, StorageException
 
 from app.core.auth_jwt import (
     AuthenticatedUser,
@@ -17,6 +18,15 @@ from app.core.auth_jwt import (
 )
 
 router = APIRouter(prefix="/blog", tags=["blog"])
+
+# Column projection for blog_posts — avoids pulling any large/unused fields.
+_BLOG_POST_COLS = (
+    "id, slug, title, excerpt, content, featured_image, author_id, category, "
+    "status, published_at, created_at, updated_at, read_time, views, likes_count, "
+    "ai_summary, deleted_at"
+)
+# Column projection for blog_categories
+_BLOG_CATEGORY_COLS = "id, name, description, created_at"
 
 
 # ==============================================
@@ -109,8 +119,8 @@ async def get_post_tags(supabase, post_id: str) -> list[str]:
             supabase.table("blog_tags").select("tag").eq("post_id", post_id).execute()
         )
         return [row["tag"] for row in response.data]
-    except Exception as e:
-        logger.error(f"Error fetching tags: {e}")
+    except (PostgrestAPIError, StorageException) as e:
+        logger.error(f"Error fetching tags: {e}", exc_info=True)
         return []
 
 
@@ -133,8 +143,8 @@ async def get_post_author(supabase, author_id: str) -> dict:
                 "avatar": response.data.get("avatar"),
                 "title": response.data.get("title") or "Researcher",
             }
-    except Exception:
-        pass
+    except (PostgrestAPIError, StorageException) as e:
+        logger.warning(f"Could not fetch author profile for {author_id}: {e}")
 
     return {"id": author_id, "name": "Anonymous", "title": "Researcher", "avatar": None}
 
@@ -145,8 +155,8 @@ async def increment_view_count(supabase, post_id: str):
         supabase.table("blog_posts").update(
             {"views": supabase.rpc("increment", {"x": 1})}
         ).eq("id", post_id).execute()
-    except Exception as e:
-        logger.error(f"Error incrementing view count: {e}")
+    except (PostgrestAPIError, StorageException) as e:
+        logger.error(f"Error incrementing view count: {e}", exc_info=True)
 
 
 def ensure_user_can_access_post(
@@ -289,8 +299,8 @@ async def list_posts(
             },
         }
 
-    except Exception as e:
-        logger.error(f"Error listing posts: {e}")
+    except (PostgrestAPIError, StorageException) as e:
+        logger.error(f"Error listing posts: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to fetch blog posts")
 
 
@@ -305,7 +315,7 @@ async def get_post(slug: str):
         # Get post
         response = (
             supabase.table("blog_posts")
-            .select("*")
+            .select(_BLOG_POST_COLS)
             .eq("slug", slug)
             .eq("status", "published")
             .is_("deleted_at", "null")
@@ -346,8 +356,8 @@ async def get_post(slug: str):
 
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error(f"Error fetching post: {e}")
+    except (PostgrestAPIError, StorageException) as e:
+        logger.error(f"Error fetching post: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to fetch blog post")
 
 
@@ -359,7 +369,9 @@ async def list_categories():
     try:
         supabase = get_admin_supabase_client()
 
-        response = supabase.table("blog_categories").select("*").execute()
+        response = (
+            supabase.table("blog_categories").select(_BLOG_CATEGORY_COLS).execute()
+        )
 
         # Add post count for each category
         categories = []
@@ -376,8 +388,8 @@ async def list_categories():
 
         return {"data": categories}
 
-    except Exception as e:
-        logger.error(f"Error fetching categories: {e}")
+    except (PostgrestAPIError, StorageException) as e:
+        logger.error(f"Error fetching categories: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to fetch categories")
 
 
@@ -445,8 +457,8 @@ async def toggle_like(
 
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error(f"Error toggling like: {e}")
+    except (PostgrestAPIError, StorageException) as e:
+        logger.error(f"Error toggling like: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to toggle like")
 
 
@@ -500,8 +512,8 @@ async def toggle_bookmark(
 
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error(f"Error toggling bookmark: {e}")
+    except (PostgrestAPIError, StorageException) as e:
+        logger.error(f"Error toggling bookmark: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to toggle bookmark")
 
 
@@ -538,8 +550,8 @@ async def get_bookmarks(
 
         return {"data": bookmarks}
 
-    except Exception as e:
-        logger.error(f"Error fetching bookmarks: {e}")
+    except (PostgrestAPIError, StorageException) as e:
+        logger.error(f"Error fetching bookmarks: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to fetch bookmarks")
 
 
@@ -606,8 +618,8 @@ async def create_post(
 
         return {"success": True, "data": normalized_post}
 
-    except Exception as e:
-        logger.error(f"Error creating post: {e}")
+    except (PostgrestAPIError, StorageException) as e:
+        logger.error(f"Error creating post: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to create blog post")
 
 
@@ -632,7 +644,11 @@ async def list_admin_posts(
         supabase = get_admin_supabase_client()
         offset = (page - 1) * limit
 
-        list_query = supabase.table("blog_posts").select("*").is_("deleted_at", "null")
+        list_query = (
+            supabase.table("blog_posts")
+            .select(_BLOG_POST_COLS)
+            .is_("deleted_at", "null")
+        )
         count_query = (
             supabase.table("blog_posts")
             .select("id", count="exact")
@@ -679,8 +695,8 @@ async def list_admin_posts(
                 "has_prev": page > 1,
             },
         }
-    except Exception as e:
-        logger.error(f"Error listing admin posts: {e}")
+    except (PostgrestAPIError, StorageException) as e:
+        logger.error(f"Error listing admin posts: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to fetch admin blog posts")
 
 
@@ -694,7 +710,7 @@ async def get_admin_post(
         supabase = get_admin_supabase_client()
         response = (
             supabase.table("blog_posts")
-            .select("*")
+            .select(_BLOG_POST_COLS)
             .eq("id", post_id)
             .is_("deleted_at", "null")
             .single()
@@ -712,8 +728,8 @@ async def get_admin_post(
         return {"success": True, "data": normalize_post_response(post, tags, author)}
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error(f"Error fetching admin post {post_id}: {e}")
+    except (PostgrestAPIError, StorageException) as e:
+        logger.error(f"Error fetching admin post {post_id}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to fetch blog post")
 
 
@@ -728,7 +744,7 @@ async def update_post(
         supabase = get_admin_supabase_client()
         existing_response = (
             supabase.table("blog_posts")
-            .select("*")
+            .select(_BLOG_POST_COLS)
             .eq("id", post_id)
             .is_("deleted_at", "null")
             .single()
@@ -781,7 +797,7 @@ async def update_post(
 
         updated_response = (
             supabase.table("blog_posts")
-            .select("*")
+            .select(_BLOG_POST_COLS)
             .eq("id", post_id)
             .single()
             .execute()
@@ -796,8 +812,8 @@ async def update_post(
         }
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error(f"Error updating post {post_id}: {e}")
+    except (PostgrestAPIError, StorageException) as e:
+        logger.error(f"Error updating post {post_id}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to update blog post")
 
 
@@ -831,8 +847,8 @@ async def delete_post(
         return {"success": True, "deleted_id": post_id}
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error(f"Error deleting post {post_id}: {e}")
+    except (PostgrestAPIError, StorageException) as e:
+        logger.error(f"Error deleting post {post_id}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to delete blog post")
 
 
@@ -875,6 +891,6 @@ async def get_admin_blog_stats(
             total_likes=total_likes,
             avg_read_time=avg_read_time,
         )
-    except Exception as e:
-        logger.error(f"Error fetching blog stats: {e}")
+    except (PostgrestAPIError, StorageException) as e:
+        logger.error(f"Error fetching blog stats: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to fetch blog stats")

--- a/backend/app/api/consent.py
+++ b/backend/app/api/consent.py
@@ -24,6 +24,17 @@ from app.core.auth_jwt import (
 # Router configuration
 router = APIRouter(prefix="/api/consent", tags=["User Consent"])
 
+# Column projection for user_consent table — all consent flags and timestamps.
+_USER_CONSENT_COLS = (
+    "user_id, professional_acknowledgment_accepted, "
+    "professional_acknowledgment_date, professional_acknowledgment_version, "
+    "terms_accepted, terms_accepted_date, terms_accepted_version, "
+    "privacy_policy_accepted, privacy_policy_accepted_date, "
+    "privacy_policy_accepted_version, data_processing_consent, "
+    "data_processing_consent_date, marketing_consent, "
+    "marketing_consent_date, created_at, updated_at"
+)
+
 
 # ===== Models =====
 
@@ -176,7 +187,10 @@ async def update_consent(
 
         # Get updated consent status
         consent_result = (
-            client.table("user_consent").select("*").eq("user_id", user.id).execute()
+            client.table("user_consent")
+            .select(_USER_CONSENT_COLS)
+            .eq("user_id", user.id)
+            .execute()
         )
 
         if not consent_result.data:
@@ -261,7 +275,10 @@ async def get_consent_status(user: AuthenticatedUser = Depends(get_current_user)
 
         # Get consent status
         result = (
-            client.table("user_consent").select("*").eq("user_id", user.id).execute()
+            client.table("user_consent")
+            .select(_USER_CONSENT_COLS)
+            .eq("user_id", user.id)
+            .execute()
         )
 
         if not result.data:

--- a/backend/app/api/sso.py
+++ b/backend/app/api/sso.py
@@ -25,6 +25,16 @@ from app.core.auth_jwt import (
 
 router = APIRouter(prefix="/api/sso", tags=["SSO Management"])
 
+# Column projection for sso_connections — explicit list prevents fetching
+# secrets like oauth_client_secret that are write-only and stored separately.
+_SSO_CONNECTION_COLS = (
+    "id, name, slug, organization, provider_type, status, domain, "
+    "auto_provision_users, default_account_type, supabase_provider_id, "
+    "saml_entity_id, saml_sso_url, saml_metadata_url, "
+    "oauth_client_id, oauth_authorization_url, oauth_token_url, "
+    "oauth_userinfo_url, oauth_scopes, created_at, updated_at"
+)
+
 
 # ===== Models =====
 
@@ -198,7 +208,9 @@ async def list_connections(
     try:
         client = get_admin_supabase_client()
         query = (
-            client.table("sso_connections").select("*").order("created_at", desc=True)
+            client.table("sso_connections")
+            .select(_SSO_CONNECTION_COLS)
+            .order("created_at", desc=True)
         )
 
         if status:
@@ -230,7 +242,7 @@ async def get_connection(
         client = get_admin_supabase_client()
         result = (
             client.table("sso_connections")
-            .select("*")
+            .select(_SSO_CONNECTION_COLS)
             .eq("id", connection_id)
             .single()
             .execute()

--- a/backend/app/dashboard.py
+++ b/backend/app/dashboard.py
@@ -10,7 +10,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from loguru import logger
 from pydantic import BaseModel
-from supabase import Client, create_client
+from supabase import Client, PostgrestAPIError, StorageException, create_client
 from supabase.client import ClientOptions
 
 from app.auth import verify_api_key
@@ -31,6 +31,8 @@ try:
     REDIS_AVAILABLE = True
     logger.info("Redis client initialized for dashboard caching")
 except Exception as e:
+    # Broad catch: covers ImportError (redis not installed), ValueError (bad port),
+    # and redis.exceptions.ConnectionError at import time.
     logger.warning(f"Redis not available, using in-memory cache: {e}")
     redis_client = None
     REDIS_AVAILABLE = False
@@ -163,7 +165,11 @@ async def _get_cached_dashboard_stats(
             if cached_data:
                 logger.debug("Returning Redis cached dashboard stats")
                 return DashboardStats(**json.loads(cached_data))
+        except (json.JSONDecodeError, ValueError, KeyError) as e:
+            logger.warning(f"Redis cache read failed (bad data): {e}")
         except Exception as e:
+            # Broad catch: redis.exceptions.RedisError and connection errors
+            # can't be imported at module level without redis being installed.
             logger.warning(f"Redis cache read failed: {e}")
 
     if (
@@ -188,6 +194,8 @@ async def _update_dashboard_cache(
             )
             logger.debug("Updated Redis dashboard stats cache")
         except Exception as e:
+            # Broad catch: redis.exceptions.RedisError and connection errors
+            # can't be imported at module level without redis being installed.
             logger.warning(f"Redis cache write failed: {e}")
 
     _stats_cache["data"] = stats
@@ -229,8 +237,8 @@ async def _compute_fallback_stats() -> DashboardStats:
             total_judgments=total.count or 0,
             jurisdictions=JurisdictionCounts(PL=pl.count or 0, UK=uk.count or 0),
         )
-    except Exception as e:
-        logger.error(f"Fallback stats computation failed: {e}")
+    except (PostgrestAPIError, StorageException) as e:
+        logger.error(f"Fallback stats computation failed: {e}", exc_info=True)
         return DashboardStats()
 
 
@@ -335,8 +343,8 @@ async def get_dashboard_stats(request: Request, api_key: str = Depends(verify_ap
         await _update_dashboard_cache(cache_key, stats, now)
         return stats
 
-    except Exception as e:
-        logger.error(f"Error fetching precomputed stats: {e}")
+    except (PostgrestAPIError, StorageException, KeyError, ValueError) as e:
+        logger.error(f"Error fetching precomputed stats: {e}", exc_info=True)
         return await _compute_fallback_stats()
 
 
@@ -360,8 +368,8 @@ async def refresh_dashboard_stats(
         # Call the SQL function to recompute stats
         supabase.rpc("refresh_dashboard_stats").execute()
         logger.info("refresh_dashboard_stats RPC call succeeded")
-    except Exception as e:
-        logger.error(f"Error refreshing stats via RPC: {e}")
+    except (PostgrestAPIError, StorageException) as e:
+        logger.error(f"Error refreshing stats via RPC: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
 
     # Clear caches regardless of RPC outcome so stale data is not served
@@ -370,6 +378,8 @@ async def refresh_dashboard_stats(
             await redis_client.delete("dashboard:stats")
             logger.info("Cleared Redis cache")
         except Exception as e:
+            # Broad catch: redis.exceptions.RedisError and connection errors
+            # can't be imported at module level without redis being installed.
             logger.warning(f"Could not clear Redis cache: {e}")
 
     _clear_stats_cache()
@@ -399,7 +409,7 @@ async def dashboard_health():
             "stats_computed_at": computed_at,
             "backend_version": "1.0.0",
         }
-    except Exception as e:
+    except (PostgrestAPIError, StorageException) as e:
         return {
             "status": "unhealthy",
             "error": str(e),
@@ -474,9 +484,9 @@ async def get_recent_documents(
                         logger.info(
                             f"Found document for '{query}': {doc_summary.title[:50] if doc_summary.title else 'Untitled'}"
                         )
-                    except Exception as e:
+                    except (ValueError, KeyError, TypeError) as e:
                         logger.warning(f"Error converting document: {e}")
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             logger.warning(f"Error searching for '{query}': {e}")
 
         return results
@@ -503,8 +513,8 @@ async def get_recent_documents(
         )
         return unique_documents
 
-    except Exception as e:
-        logger.error(f"Error fetching highlighted documents: {e}")
+    except (PostgrestAPIError, StorageException) as e:
+        logger.error(f"Error fetching highlighted documents: {e}", exc_info=True)
         return []
 
 
@@ -629,7 +639,11 @@ async def get_featured_examples(
     try:
         response = (
             supabase.table("documents")
-            .select("*")
+            .select(
+                "id, title, document_type, date_issued, publication_date, "
+                "judgment_date, country, language, issuing_body, "
+                "full_text, docket_number, court_name, judgment_id"
+            )
             .in_("document_type", ["judgment", "tax_interpretation"])
             .not_.is_("title", "null")
             .limit(limit * 3)
@@ -649,8 +663,8 @@ async def get_featured_examples(
 
         return featured[:limit]
 
-    except Exception as e:
-        logger.error(f"Error fetching featured examples: {e}")
+    except (PostgrestAPIError, StorageException) as e:
+        logger.error(f"Error fetching featured examples: {e}", exc_info=True)
         return []
 
 
@@ -770,7 +784,7 @@ async def test_document_counts(
                 if count > 0:
                     type_counts[doc_type] = count
                     logger.info(f"{doc_type}: {count:,}")
-            except Exception as e:
+            except (PostgrestAPIError, StorageException) as e:
                 logger.warning(f"Could not count {doc_type}: {e}")
 
         # Get recent documents count
@@ -784,7 +798,7 @@ async def test_document_counts(
             )
             recent_count = recent_response.count or 0
             logger.info(f"Documents added this week: {recent_count:,}")
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             logger.warning(f"Could not get weekly count: {e}")
             recent_count = 0
 
@@ -797,8 +811,8 @@ async def test_document_counts(
             "message": "Document counting is working!",
         }
 
-    except Exception as e:
-        logger.error(f"Error testing document counts: {e}")
+    except (PostgrestAPIError, StorageException) as e:
+        logger.error(f"Error testing document counts: {e}", exc_info=True)
         return {
             "status": "error",
             "message": str(e),

--- a/backend/app/evaluations.py
+++ b/backend/app/evaluations.py
@@ -17,6 +17,14 @@ from app.core.supabase import get_supabase_client
 
 router = APIRouter(prefix="/evaluations", tags=["evaluations"])
 
+# Column projections for evaluation tables.
+_EVAL_COLS = (
+    "id, schema_version_id, document_id, playground_run_id, "
+    "overall_rating, overall_notes, extracted_data, evaluator_user_id, "
+    "created_at, updated_at"
+)
+_FIELD_EVAL_COLS = "evaluation_id, field_path, field_name, is_correct, extracted_value, evaluator_notes"
+
 # Use shared Supabase client
 supabase = get_supabase_client()
 
@@ -124,7 +132,7 @@ def _get_field_evaluations(evaluation_id: str) -> list[FieldEvaluation]:
     try:
         response = (
             supabase.table("extraction_field_evaluations")
-            .select("*")
+            .select(_FIELD_EVAL_COLS)
             .eq("evaluation_id", evaluation_id)
             .execute()
         )
@@ -412,7 +420,7 @@ async def get_evaluation(
     try:
         result = (
             supabase.table("extraction_evaluations")
-            .select("*")
+            .select(_EVAL_COLS)
             .eq("id", evaluation_id)
             .single()
             .execute()
@@ -477,7 +485,7 @@ async def update_evaluation(
         # Check evaluation exists and user has access
         existing = (
             supabase.table("extraction_evaluations")
-            .select("*")
+            .select(_EVAL_COLS)
             .eq("id", evaluation_id)
             .single()
             .execute()
@@ -684,7 +692,7 @@ async def get_schema_evaluations(
         offset = (page - 1) * page_size
         result = (
             supabase.table("extraction_evaluations")
-            .select("*")
+            .select(_EVAL_COLS)
             .in_("schema_version_id", version_ids)
             .order("created_at", desc=True)
             .range(offset, offset + page_size - 1)
@@ -774,7 +782,7 @@ async def get_document_evaluations(
     try:
         query = (
             supabase.table("extraction_evaluations")
-            .select("*")
+            .select(_EVAL_COLS)
             .eq("document_id", document_id)
         )
 

--- a/backend/app/experiments.py
+++ b/backend/app/experiments.py
@@ -394,7 +394,7 @@ async def get_experiment_results(
         # Get experiment info
         exp_result = (
             client.table("experiments")
-            .select("*")
+            .select("id, name, status")
             .eq("id", experiment_id)
             .single()
             .execute()
@@ -408,7 +408,7 @@ async def get_experiment_results(
         # Get variants
         var_result = (
             client.table("experiment_variants")
-            .select("*")
+            .select("id, experiment_id, name, is_control, weight, config")
             .eq("experiment_id", experiment_id)
             .execute()
         )

--- a/backend/app/extraction_domain/jobs_router.py
+++ b/backend/app/extraction_domain/jobs_router.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from celery.result import AsyncResult
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, status
 from loguru import logger
+from supabase import PostgrestAPIError, StorageException
 
 from app.extraction_domain.shared import (
     _check_supabase_available,
@@ -105,6 +106,8 @@ def _safe_get_task_state(task_result: AsyncResult, job_id: str) -> str | None:
     try:
         return task_result.state
     except Exception as state_error:
+        # Broad catch: Celery task state access can raise connection errors,
+        # backend unavailability, or kombu/amqp exceptions.
         if _is_task_not_captured_error(state_error):
             logger.warning(
                 f"Task {job_id} not found or not captured by worker: {state_error}"
@@ -121,13 +124,13 @@ def _load_job_record(job_id: str) -> dict | None:
     try:
         job_data = (
             supabase.table("extraction_jobs")
-            .select("*")
+            .select("job_id, status, completed_documents, total_documents, results")
             .eq("job_id", job_id)
             .single()
             .execute()
         )
         return job_data.data
-    except Exception as supabase_error:
+    except (PostgrestAPIError, StorageException) as supabase_error:
         logger.warning(
             f"Could not retrieve job data from Supabase for {job_id}: {supabase_error}"
         )
@@ -251,7 +254,11 @@ def _try_resubmit_job(job_id: str, job_data: dict) -> BatchExtractionResponse | 
 
         return _in_progress_batch_response(new_task.id)
     except Exception as resubmit_error:
-        logger.error(f"Failed to resubmit job {job_id}: {resubmit_error}")
+        # Broad catch: resubmit involves both Celery task submission and
+        # Supabase update; either can raise arbitrary exceptions.
+        logger.error(
+            f"Failed to resubmit job {job_id}: {resubmit_error}", exc_info=True
+        )
         return None
 
 
@@ -299,6 +306,7 @@ def _handle_not_ready_task(
             results=None,
         )
     except Exception as ready_error:
+        # Broad catch: Celery task.ready() can raise backend/connection errors.
         logger.warning(f"Error checking if task {job_id} is ready: {ready_error}")
         if not task_result.info:
             return _pending_batch_response(job_id)
@@ -330,6 +338,7 @@ def _handle_failed_task(
             task_id=job_id, status=simplified_status, results=[]
         )
     except Exception as failed_check_error:
+        # Broad catch: Celery task.failed() can raise backend/connection errors.
         logger.warning(f"Error checking if task {job_id} failed: {failed_check_error}")
         return None
 
@@ -431,6 +440,8 @@ async def create_extraction_job(
     except HTTPException:
         raise
     except Exception as e:
+        # Broad catch: task submission involves Celery, Supabase, and schema
+        # validation; any of these may raise arbitrary exceptions.
         logger.error(
             "Unexpected error creating extraction job: {}", str(e), exc_info=True
         )
@@ -546,6 +557,8 @@ async def create_extraction_job_db(
     except HTTPException:
         raise
     except Exception as e:
+        # Broad catch: task submission involves Celery, Supabase, and schema
+        # validation; any of these may raise arbitrary exceptions.
         logger.error(
             "Unexpected error creating extraction job: {}", str(e), exc_info=True
         )
@@ -650,8 +663,10 @@ async def create_bulk_extraction(
                     )
                 )
             except Exception as e:
+                # Broad catch: per-schema job creation involves Celery + Supabase.
                 logger.error(
-                    f"Unexpected error creating job for schema {schema_id}: {e}"
+                    f"Unexpected error creating job for schema {schema_id}: {e}",
+                    exc_info=True,
                 )
                 jobs.append(
                     BulkExtractionJobInfo(
@@ -677,6 +692,7 @@ async def create_bulk_extraction(
     except HTTPException:
         raise
     except Exception as e:
+        # Broad catch: bulk extraction orchestrates multiple Celery + Supabase calls.
         logger.error(f"Unexpected error in bulk extraction: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -763,6 +779,8 @@ async def get_extraction_job(
                 results=responses,
             )
         except Exception as get_error:
+            # Broad catch: Celery task.get() can raise backend errors, celery.exceptions,
+            # or worker-specific exceptions when fetching results.
             if _is_worker_unavailable_message(str(get_error)):
                 logger.error(
                     f"Worker unavailable when getting results for job {job_id}: {get_error}"
@@ -772,6 +790,8 @@ async def get_extraction_job(
     except HTTPException:
         raise
     except Exception as e:
+        # Broad catch: get_extraction_job interacts with Celery and Supabase;
+        # either can raise arbitrary exceptions including connection failures.
         error_type = type(e).__name__
         error_message = str(e)
 
@@ -861,8 +881,11 @@ async def list_extraction_jobs(
             scheduled_tasks = inspect.scheduled() or {}
             reserved_tasks = inspect.reserved() or {}
         except Exception as e:
+            # Broad catch: Celery inspect API can raise kombu/amqp connection errors.
             logger.error(
-                "Failed to retrieve task information from Celery workers: {}", e
+                "Failed to retrieve task information from Celery workers: {}",
+                e,
+                exc_info=True,
             )
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -945,7 +968,9 @@ async def list_extraction_jobs(
         )
 
     except Exception as e:
-        logger.error("Error listing extraction jobs: {}", str(e))
+        # Broad catch: listing jobs queries Celery inspect API which can raise
+        # arbitrary connection/broker exceptions.
+        logger.error("Error listing extraction jobs: {}", str(e), exc_info=True)
         raise HTTPException(
             status_code=500, detail=f"Error listing extraction jobs: {e!s}"
         )
@@ -1026,7 +1051,9 @@ async def cancel_or_delete_extraction_job(
         )
 
     except Exception as e:
-        logger.error("Error cancelling job {}: {}", job_id, str(e))
+        # Broad catch: Celery revoke() and task state access can raise arbitrary
+        # broker/connection exceptions.
+        logger.error("Error cancelling job {}: {}", job_id, str(e), exc_info=True)
         raise HTTPException(status_code=500, detail=f"Error cancelling job: {e!s}")
 
 
@@ -1104,6 +1131,6 @@ async def delete_extraction_job(
 
     except HTTPException:
         raise
-    except Exception as e:
+    except (PostgrestAPIError, StorageException) as e:
         logger.error(f"Error deleting job {job_id}: {e!s}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Error deleting job: {e!s}")

--- a/backend/app/feedback.py
+++ b/backend/app/feedback.py
@@ -469,7 +469,9 @@ async def get_search_feedback_summary(
             client = get_admin_supabase_client()
 
         # Build query
-        query = client.table("search_feedback").select("*")
+        query = client.table("search_feedback").select(
+            "id, user_id, document_id, search_query, rating, reason, result_position, created_at"
+        )
 
         if document_id:
             query = query.eq("document_id", document_id)
@@ -557,7 +559,10 @@ async def get_recent_feature_feedback(
             client = get_admin_supabase_client()
 
         # Build query
-        query = client.table("feature_requests").select("*")
+        query = client.table("feature_requests").select(
+            "id, user_id, feedback_type, feature_name, title, description, "
+            "priority, status, upvotes, created_at"
+        )
 
         if feedback_type:
             query = query.eq("feedback_type", feedback_type)

--- a/backend/app/marketplace.py
+++ b/backend/app/marketplace.py
@@ -236,7 +236,11 @@ def _fetch_top_listings(
     """Fetch top published listings by given order column."""
     response = (
         supabase.table("marketplace_listings")
-        .select("*")
+        .select(
+            "id, schema_id, publisher_id, title, description, category, tags, "
+            "version, download_count, avg_rating, rating_count, status, "
+            "is_featured, license, published_at, created_at, updated_at"
+        )
         .eq("status", "published")
         .order(order_column, desc=True)
         .limit(limit)

--- a/backend/app/ocr.py
+++ b/backend/app/ocr.py
@@ -30,6 +30,16 @@ from app.models import (
 
 router = APIRouter(prefix="/ocr", tags=["ocr"])
 
+# Column projections for OCR tables.
+_OCR_JOB_COLS = (
+    "id, document_id, status, source_type, source_filename, extracted_text, "
+    "confidence_score, page_count, language_detected, corrected_text, "
+    "correction_notes, corrected_at, created_at, updated_at, completed_at, error_message"
+)
+_OCR_PAGE_COLS = (
+    "page_number, extracted_text, confidence_score, word_count, quality_metrics"
+)
+
 
 def _compute_quality_metrics(text: str, confidence: float) -> dict:
     """Compute quality metrics for extracted OCR text."""
@@ -441,7 +451,9 @@ async def get_ocr_job(job_id: str) -> OCRJobStatus:
         supabase = get_supabase_client()
 
         # Fetch job
-        result = supabase.table("ocr_jobs").select("*").eq("id", job_id).execute()
+        result = (
+            supabase.table("ocr_jobs").select(_OCR_JOB_COLS).eq("id", job_id).execute()
+        )
         if not result.data:
             raise HTTPException(status_code=404, detail=f"OCR job {job_id} not found")
 
@@ -450,7 +462,7 @@ async def get_ocr_job(job_id: str) -> OCRJobStatus:
         # Fetch page results
         pages_result = (
             supabase.table("ocr_page_results")
-            .select("*")
+            .select(_OCR_PAGE_COLS)
             .eq("job_id", job_id)
             .execute()
         )
@@ -479,7 +491,7 @@ async def list_ocr_jobs(
     """List OCR jobs with optional filters."""
     try:
         supabase = get_supabase_client()
-        query = supabase.table("ocr_jobs").select("*", count="exact")
+        query = supabase.table("ocr_jobs").select(_OCR_JOB_COLS, count="exact")
 
         if document_id:
             query = query.eq("document_id", document_id)

--- a/backend/app/playground.py
+++ b/backend/app/playground.py
@@ -530,7 +530,11 @@ async def get_playground_run(
     try:
         response = (
             supabase.table("playground_test_runs")
-            .select("*")
+            .select(
+                "id, user_id, schema_id, schema_version_id, document_id, "
+                "status, extracted_data, error_message, execution_time_ms, "
+                "schema_name, schema_version, document_title, created_at"
+            )
             .eq("id", run_id)
             .eq("user_id", x_user_id)
             .single()

--- a/backend/app/research_assistant.py
+++ b/backend/app/research_assistant.py
@@ -340,7 +340,15 @@ async def list_research_contexts(
             logger.warning("Supabase client not available for listing contexts")
             return []
 
-        query = supabase.table("research_contexts").select("*").eq("user_id", user_id)
+        query = (
+            supabase.table("research_contexts")
+            .select(
+                "id, user_id, chat_id, title, analyzed_topics, identified_gaps, "
+                "suggested_next_steps, related_document_ids, coverage_score, "
+                "status, created_at, updated_at"
+            )
+            .eq("user_id", user_id)
+        )
 
         if status:
             query = query.eq("status", status)

--- a/backend/app/schemas_pkg/crud.py
+++ b/backend/app/schemas_pkg/crud.py
@@ -13,7 +13,7 @@ from juddges_search.info_extraction.schema_utils import (
     prepare_schema_from_db,
 )
 from loguru import logger
-from supabase import Client
+from supabase import Client, PostgrestAPIError, StorageException
 from werkzeug.utils import secure_filename
 
 from app.core.supabase import supabase_client
@@ -33,6 +33,12 @@ from .storage import (
     _load_schema_metadata,
     _save_schema_metadata,
     _save_schema_to_file,
+)
+
+# Column projection for extraction_schemas - avoids pulling any large/unused fields.
+_EXTRACTION_SCHEMA_COLS = (
+    "id, name, description, type, category, text, dates, "
+    "user_id, status, is_verified, created_at, updated_at"
 )
 
 
@@ -89,7 +95,7 @@ def register_crud_routes(router: APIRouter) -> None:
             # Build query - get schemas ordered by creation date (newest first) with pagination
             response = (
                 supabase_client.table("extraction_schemas")
-                .select("*")
+                .select(_EXTRACTION_SCHEMA_COLS)
                 .order("created_at", desc=True)
                 .range(offset, offset + page_size - 1)
                 .execute()
@@ -114,8 +120,8 @@ def register_crud_routes(router: APIRouter) -> None:
 
         except HTTPException:
             raise
-        except Exception as e:
-            logger.error(f"Failed to list schemas from database: {e}")
+        except (PostgrestAPIError, StorageException) as e:
+            logger.error(f"Failed to list schemas from database: {e}", exc_info=True)
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Failed to list schemas from database: {e!s}",
@@ -150,8 +156,10 @@ def register_crud_routes(router: APIRouter) -> None:
             return schema
         except HTTPException:
             raise
-        except Exception as e:
-            logger.error(f"Failed to get schema {schema_id} from database: {e}")
+        except (PostgrestAPIError, StorageException) as e:
+            logger.error(
+                f"Failed to get schema {schema_id} from database: {e}", exc_info=True
+            )
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Failed to retrieve schema from database: {e!s}",
@@ -233,6 +241,8 @@ def register_crud_routes(router: APIRouter) -> None:
                 detail=f"Schema conversion failed: {e!s}",
             )
         except Exception as e:
+            # Broad catch: schema conversion may raise arbitrary errors from
+            # underlying JSON/YAML parsing or pydantic schema processing.
             logger.error(f"Failed to convert schema {schema_id}: {e}", exc_info=True)
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -257,8 +267,8 @@ def register_crud_routes(router: APIRouter) -> None:
             schemas = InformationExtractor.list_schemas()
             logger.info(f"Listed {len(schemas)} schemas")
             return schemas
-        except Exception as e:
-            logger.error(f"Failed to list schemas: {e}")
+        except OSError as e:
+            logger.error(f"Failed to list schemas: {e}", exc_info=True)
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Failed to list schemas: {e!s}",
@@ -292,8 +302,8 @@ def register_crud_routes(router: APIRouter) -> None:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Schema '{schema_id}' not found: {e!s}",
             )
-        except Exception as e:
-            logger.error(f"Failed to get schema {schema_id}: {e}")
+        except OSError as e:
+            logger.error(f"Failed to get schema {schema_id}: {e}", exc_info=True)
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Failed to retrieve schema: {e!s}",
@@ -395,8 +405,8 @@ def register_crud_routes(router: APIRouter) -> None:
 
         except HTTPException:
             raise
-        except Exception as e:
-            logger.error(f"Failed to create schema: {e}")
+        except OSError as e:
+            logger.error(f"Failed to create schema: {e}", exc_info=True)
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Failed to create schema: {e!s}",
@@ -519,8 +529,8 @@ def register_crud_routes(router: APIRouter) -> None:
 
         except HTTPException:
             raise
-        except Exception as e:
-            logger.error(f"Failed to update schema {schema_id}: {e}")
+        except OSError as e:
+            logger.error(f"Failed to update schema {schema_id}: {e}", exc_info=True)
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Failed to update schema: {e!s}",
@@ -624,8 +634,8 @@ def register_crud_routes(router: APIRouter) -> None:
 
         except HTTPException:
             raise
-        except Exception as e:
-            logger.error(f"Failed to delete schema {schema_id}: {e}")
+        except OSError as e:
+            logger.error(f"Failed to delete schema {schema_id}: {e}", exc_info=True)
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"Failed to delete schema: {e!s}",
@@ -645,7 +655,10 @@ def _fetch_schema_from_db(
         )
 
     response = (
-        db_client.table("extraction_schemas").select("*").eq("id", schema_id).execute()
+        db_client.table("extraction_schemas")
+        .select(_EXTRACTION_SCHEMA_COLS)
+        .eq("id", schema_id)
+        .execute()
     )
 
     if not response.data or len(response.data) == 0:

--- a/backend/app/schemas_pkg/versioning.py
+++ b/backend/app/schemas_pkg/versioning.py
@@ -148,7 +148,11 @@ def register_versioning_routes(router: APIRouter) -> None:
         try:
             response = (
                 supabase_client.table("schema_versions")
-                .select("*")
+                .select(
+                    "id, schema_id, version_number, schema_snapshot, field_snapshot, "
+                    "change_type, change_summary, changed_fields, diff_from_previous, "
+                    "user_id, created_at"
+                )
                 .eq("schema_id", schema_id)
                 .eq("version_number", version_number)
                 .single()

--- a/backend/app/services/audit_service.py
+++ b/backend/app/services/audit_service.py
@@ -435,7 +435,14 @@ class AuditService:
                 end_date = datetime.now(UTC)
 
             # Build query
-            query = client.table("audit_logs").select("*").eq("user_id", user_id)
+            query = (
+                client.table("audit_logs")
+                .select(
+                    "id, user_id, action_type, resource_type, resource_id, "
+                    "session_id, ip_address, user_agent, created_at"
+                )
+                .eq("user_id", user_id)
+            )
 
             # Apply filters
             query = query.gte("created_at", start_date.isoformat())

--- a/backend/app/services/retention_service.py
+++ b/backend/app/services/retention_service.py
@@ -138,7 +138,15 @@ class RetentionService:
             # Export user consent
             consent_result = (
                 client.table("user_consent")
-                .select("*")
+                .select(
+                    "user_id, professional_acknowledgment_accepted, "
+                    "professional_acknowledgment_date, professional_acknowledgment_version, "
+                    "terms_accepted, terms_accepted_date, terms_accepted_version, "
+                    "privacy_policy_accepted, privacy_policy_accepted_date, "
+                    "privacy_policy_accepted_version, data_processing_consent, "
+                    "data_processing_consent_date, marketing_consent, "
+                    "marketing_consent_date, created_at, updated_at"
+                )
                 .eq("user_id", user_id)
                 .execute()
             )
@@ -159,14 +167,17 @@ class RetentionService:
 
             # Export analytics events
             events_result = (
-                client.table("events").select("*").eq("user_id", user_id).execute()
+                client.table("events")
+                .select("id, user_id, session_id, event_name, event_data, created_at")
+                .eq("user_id", user_id)
+                .execute()
             )
             export_data["events"] = events_result.data
 
             # Export search queries
             search_result = (
                 client.table("search_queries")
-                .select("*")
+                .select("id, user_id, session_id, query, created_at")
                 .eq("user_id", user_id)
                 .execute()
             )
@@ -175,7 +186,10 @@ class RetentionService:
             # Export feedback
             feedback_result = (
                 client.table("search_feedback")
-                .select("*")
+                .select(
+                    "id, user_id, document_id, search_query, rating, "
+                    "reason, result_position, created_at"
+                )
                 .eq("user_id", user_id)
                 .execute()
             )
@@ -183,7 +197,10 @@ class RetentionService:
 
             feature_feedback_result = (
                 client.table("feature_requests")
-                .select("*")
+                .select(
+                    "id, user_id, feedback_type, feature_name, title, "
+                    "description, priority, status, upvotes, created_at"
+                )
                 .eq("user_id", user_id)
                 .execute()
             )
@@ -305,7 +322,7 @@ class RetentionService:
             # Get the deletion request
             request_result = (
                 client.table("data_deletion_requests")
-                .select("*")
+                .select("id, user_id, request_type, data_types, status")
                 .eq("id", request_id)
                 .execute()
             )

--- a/backend/app/tasks/meilisearch_sync.py
+++ b/backend/app/tasks/meilisearch_sync.py
@@ -24,6 +24,17 @@ def _get_service() -> MeiliSearchService:
     return MeiliSearchService.from_env()
 
 
+# Column projection for judgments — embedding vector (~6KB per row) is excluded
+# because Meilisearch does not use it and transform_judgment_for_meilisearch
+# explicitly drops it anyway. Fetching it wastes bandwidth on every sync.
+_JUDGMENT_SYNC_COLS = (
+    "id, case_number, jurisdiction, court_name, court_level, decision_date, "
+    "publication_date, title, summary, full_text, judges, case_type, "
+    "decision_type, outcome, keywords, legal_topics, cited_legislation, "
+    "source_url, created_at, updated_at"
+)
+
+
 # ── Incremental sync ─────────────────────────────────────────────────────────
 
 
@@ -62,7 +73,10 @@ def sync_judgment_to_meilisearch(
         return {"status": "skipped", "reason": "no_supabase"}
 
     resp = (
-        supabase_client.table("judgments").select("*").eq("id", judgment_id).execute()
+        supabase_client.table("judgments")
+        .select(_JUDGMENT_SYNC_COLS)
+        .eq("id", judgment_id)
+        .execute()
     )
     if not resp.data:
         logger.warning(f"Judgment {judgment_id} not found in Supabase")
@@ -109,7 +123,7 @@ def full_sync_judgments_to_meilisearch(
         while True:
             resp = (
                 supabase_client.table("judgments")
-                .select("*")
+                .select(_JUDGMENT_SYNC_COLS)
                 .order("created_at")
                 .range(offset, offset + batch_size - 1)
                 .execute()

--- a/backend/app/utils/document_fetcher.py
+++ b/backend/app/utils/document_fetcher.py
@@ -9,6 +9,13 @@ from loguru import logger
 
 from app.core.supabase import get_supabase_client
 
+# Column projection for judgments table.
+# embedding is ~6KB per row and is only included when return_vectors=True.
+_JUDGMENT_BASE_COLS = (
+    "document_id, title, summary, full_text, document_type, language, "
+    "country, metadata, publication_date, source, url"
+)
+
 
 async def get_documents_by_id(
     document_ids: list[str],
@@ -38,9 +45,15 @@ async def get_documents_by_id(
 
         # Fetch documents from Supabase judgments table
         # Use .in_() for efficient batch query
+        # Add embedding column only when the caller explicitly requests vectors.
+        cols = (
+            _JUDGMENT_BASE_COLS + ", embedding"
+            if return_vectors
+            else _JUDGMENT_BASE_COLS
+        )
         response = (
             supabase.table("judgments")
-            .select("*")
+            .select(cols)
             .in_("document_id", document_ids)
             .execute()
         )

--- a/backend/app/versioning.py
+++ b/backend/app/versioning.py
@@ -272,7 +272,11 @@ async def get_version_detail(
 
         response = (
             db.client.table("document_versions")
-            .select("*")
+            .select(
+                "id, document_id, version_number, title, full_text, summary, "
+                "content_hash, change_description, change_type, created_by, "
+                "created_at, extracted_data"
+            )
             .eq("document_id", document_id)
             .eq("version_number", version_number)
             .limit(1)
@@ -541,7 +545,11 @@ async def revert_to_version(
         # Get the target version
         target_response = (
             db.client.table("document_versions")
-            .select("*")
+            .select(
+                "id, document_id, version_number, title, full_text, summary, "
+                "content_hash, change_description, change_type, created_by, "
+                "created_at, extracted_data"
+            )
             .eq("document_id", document_id)
             .eq("version_number", request.version_number)
             .limit(1)

--- a/backend/packages/juddges_search/juddges_search/db/supabase_db.py
+++ b/backend/packages/juddges_search/juddges_search/db/supabase_db.py
@@ -2,7 +2,7 @@ import os
 import warnings
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Any
-from supabase import create_client, Client
+from supabase import create_client, Client, PostgrestAPIError, StorageException
 from supabase.client import ClientOptions
 from loguru import logger
 from fastapi import HTTPException
@@ -14,6 +14,24 @@ warnings.filterwarnings("ignore", category=ResourceWarning, message=".*ssl.SSLSo
 # This is a library issue, not an issue with our code
 warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*timeout.*parameter.*deprecated.*")
 warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*verify.*parameter.*deprecated.*")
+
+# ---------------------------------------------------------------------------
+# Column projection constants
+# Keeps queries explicit and avoids fetching large vector columns
+# (embedding, summary_embedding) that are only needed in search RPC calls.
+# ---------------------------------------------------------------------------
+_COLLECTIONS_COLS = "id, user_id, name, description, created_at, updated_at"
+_COLLECTION_DOC_EXISTS_COLS = "collection_id, document_id"
+_EXTRACTION_SCHEMA_COLS = (
+    "id, name, description, type, category, text, dates, user_id, status, is_verified, created_at, updated_at"
+)
+# legal_documents columns -- embedding deliberately excluded here.
+# Callers that need the vector use the get_document_chunks RPC path.
+_LEGAL_DOCUMENT_COLS = (
+    "supabase_document_id, document_id, title, document_type, court_name, "
+    "date_issued, language, summary, full_text, country, document_number, "
+    "issuing_body, ingestion_date, extracted_data, current_version, content_hash"
+)
 
 
 class CollectionsDB:
@@ -32,7 +50,7 @@ class CollectionsDB:
         logger.info(f"Initialized CollectionsDB with Supabase client: {self.url[:50]}...")
 
     def _handle_error(self, operation: str, error: Exception) -> None:
-        logger.error(f"Supabase error during {operation}: {error}")
+        logger.error(f"Supabase error during {operation}: {error}", exc_info=True)
 
         error_msg = str(error).lower()
         if "duplicate key" in error_msg or "already exists" in error_msg:
@@ -47,7 +65,7 @@ class CollectionsDB:
             # First get all collections for the user
             response = (
                 self.client.table("collections")
-                .select("*")
+                .select(_COLLECTIONS_COLS)
                 .eq("user_id", user_id)
                 .order("created_at", desc=True)
                 .execute()
@@ -96,8 +114,8 @@ class CollectionsDB:
                 collection["document_count"] = len(docs)
 
             return collections
-        except Exception as e:
-            logger.error(f"Error getting user collections: {e}")
+        except (PostgrestAPIError, StorageException) as e:
+            logger.error(f"Error getting user collections: {e}", exc_info=True)
             return []
 
     async def find_collection(
@@ -106,7 +124,11 @@ class CollectionsDB:
         try:
             # First get the collection
             response = (
-                self.client.table("collections").select("*").eq("id", collection_id).eq("user_id", user_id).execute()
+                self.client.table("collections")
+                .select(_COLLECTIONS_COLS)
+                .eq("id", collection_id)
+                .eq("user_id", user_id)
+                .execute()
             )
 
             if not response.data:
@@ -164,8 +186,8 @@ class CollectionsDB:
 
             collection["collection_supabase_documents"] = all_documents
             return collection
-        except Exception as e:
-            logger.error(f"Error finding collection: {e}")
+        except (PostgrestAPIError, StorageException) as e:
+            logger.error(f"Error finding collection: {e}", exc_info=True)
             return None
 
     async def create_collection(self, user_id: str, name: str, description: Optional[str] = None) -> Dict[str, Any]:
@@ -177,7 +199,7 @@ class CollectionsDB:
             response = self.client.table("collections").insert(data).execute()
 
             return response.data[0] if response.data else {}
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             self._handle_error("create_collection", e)
             return {}
 
@@ -197,7 +219,7 @@ class CollectionsDB:
             return response.data[0]
         except HTTPException:
             raise
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             self._handle_error("update_collection", e)
             return {}
 
@@ -212,8 +234,8 @@ class CollectionsDB:
             )
 
             return bool(response.data)
-        except Exception as e:
-            logger.error(f"Error deleting collection: {e}")
+        except (PostgrestAPIError, StorageException) as e:
+            logger.error(f"Error deleting collection: {e}", exc_info=True)
             return False
 
     async def add_document(self, collection_id: str, document_id: str, user_id: str) -> bool:
@@ -226,7 +248,7 @@ class CollectionsDB:
             # Use collection_supabase_documents table for document IDs (text type)
             existing = (
                 self.client.table("collection_supabase_documents")
-                .select("*")
+                .select(_COLLECTION_DOC_EXISTS_COLS)
                 .eq("collection_id", collection_id)
                 .eq("document_id", document_id)
                 .execute()
@@ -243,12 +265,12 @@ class CollectionsDB:
             logger.info(f"Added document {document_id} to collection {collection_id}")
             return True
 
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             error_msg = str(e).lower()
             if "duplicate" in error_msg or "already exists" in error_msg:
                 return True
 
-            logger.error(f"Error adding document to collection: {e}")
+            logger.error(f"Error adding document to collection: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail=f"Failed to add document: {str(e)}")
 
     async def remove_document(self, collection_id: str, document_id: str, user_id: str) -> bool:
@@ -269,8 +291,8 @@ class CollectionsDB:
             logger.info(f"Removed document {document_id} from collection {collection_id}")
             return True
 
-        except Exception as e:
-            logger.error(f"Error removing document from collection: {e}")
+        except (PostgrestAPIError, StorageException) as e:
+            logger.error(f"Error removing document from collection: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail=f"Failed to remove document: {str(e)}")
 
     async def get_collection_documents(self, collection_id: str, user_id: Optional[str] = None) -> List[Dict[str, Any]]:
@@ -287,8 +309,8 @@ class CollectionsDB:
                 raise HTTPException(status_code=404, detail="Collection not found")
         except HTTPException:
             raise
-        except Exception as e:
-            logger.error(f"Error checking collection existence: {e}")
+        except (PostgrestAPIError, StorageException) as e:
+            logger.error(f"Error checking collection existence: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail=f"Failed to check collection: {str(e)}")
 
         try:
@@ -318,8 +340,8 @@ class CollectionsDB:
             logger.info(f"Retrieved {len(documents)} documents from collection {collection_id}")
             return documents
 
-        except Exception as e:
-            logger.error(f"Error getting collection documents: {e}")
+        except (PostgrestAPIError, StorageException) as e:
+            logger.error(f"Error getting collection documents: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail=f"Failed to get documents: {str(e)}")
 
 
@@ -337,7 +359,7 @@ class SupabaseDB:
         logger.info(f"Initialized SupabaseDB with Supabase client: {self.url[:50]}...")
 
     def _handle_error(self, operation: str, error: Exception) -> None:
-        logger.error(f"Supabase error during {operation}: {error}")
+        logger.error(f"Supabase error during {operation}: {error}", exc_info=True)
 
         error_msg = str(error).lower()
         if "duplicate key" in error_msg or "already exists" in error_msg:
@@ -387,7 +409,7 @@ class SupabaseDB:
             response = self.client.table("extraction_schemas").insert(data).execute()
 
             return response.data[0] if response.data else {}
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             self._handle_error("add_schema", e)
             return {}  # Unreachable, as _handle_error always raises
 
@@ -426,7 +448,7 @@ class SupabaseDB:
             response = self.client.table("extraction_schemas").update(data).eq("id", schema_id).execute()
 
             return response.data[0] if response.data else {}
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             self._handle_error("update_schema", e)
             return {}  # Unreachable
 
@@ -445,17 +467,23 @@ class SupabaseDB:
             response = self.client.table("extraction_schemas").select(columns).order("created_at", desc=True).execute()
 
             return response.data or []
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             self._handle_error("get_schemas", e)
             return []  # Unreachable
 
     async def get_schema_by_name(self, schema_name: str) -> Optional[Dict[str, Any]]:
         """Retrieves a specific schema by its name."""
         try:
-            response = self.client.table("extraction_schemas").select("*").eq("name", schema_name).limit(1).execute()
+            response = (
+                self.client.table("extraction_schemas")
+                .select(_EXTRACTION_SCHEMA_COLS)
+                .eq("name", schema_name)
+                .limit(1)
+                .execute()
+            )
 
             return response.data[0] if response.data else None
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             self._handle_error("get_schema_by_name", e)
 
 
@@ -474,7 +502,7 @@ class PublicationsDB:
         logger.info(f"Initialized PublicationsDB with Supabase client: {self.url[:50]}...")
 
     def _handle_error(self, operation: str, error: Exception) -> None:
-        logger.error(f"Supabase error during {operation}: {error}")
+        logger.error(f"Supabase error during {operation}: {error}", exc_info=True)
 
         error_msg = str(error).lower()
         if "duplicate key" in error_msg or "already exists" in error_msg:
@@ -518,8 +546,8 @@ class PublicationsDB:
             )
 
             return response.data or []
-        except Exception as e:
-            logger.error(f"Error getting publications: {e}")
+        except (PostgrestAPIError, StorageException) as e:
+            logger.error(f"Error getting publications: {e}", exc_info=True)
             return []
 
     async def get_publication(self, publication_id: str) -> Optional[Dict[str, Any]]:
@@ -537,8 +565,8 @@ class PublicationsDB:
             )
 
             return response.data[0] if response.data else None
-        except Exception as e:
-            logger.error(f"Error getting publication: {e}")
+        except (PostgrestAPIError, StorageException) as e:
+            logger.error(f"Error getting publication: {e}", exc_info=True)
             return None
 
     async def create_publication(self, data: Dict[str, Any]) -> Dict[str, Any]:
@@ -577,7 +605,7 @@ class PublicationsDB:
             return await self.get_publication(publication_id) or publication
         except HTTPException:
             raise
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             self._handle_error("create_publication", e)
             return {}
 
@@ -593,7 +621,7 @@ class PublicationsDB:
             return await self.get_publication(publication_id) or response.data[0]
         except HTTPException:
             raise
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             self._handle_error("update_publication", e)
             return {}
 
@@ -603,8 +631,8 @@ class PublicationsDB:
             # Junction tables will cascade delete due to ON DELETE CASCADE
             response = self.client.table("publications").delete().eq("id", publication_id).execute()
             return bool(response.data)
-        except Exception as e:
-            logger.error(f"Error deleting publication: {e}")
+        except (PostgrestAPIError, StorageException) as e:
+            logger.error(f"Error deleting publication: {e}", exc_info=True)
             return False
 
     async def add_schema_link(self, publication_id: str, schema_id: str, description: Optional[str] = None) -> bool:
@@ -617,11 +645,11 @@ class PublicationsDB:
             self.client.table("publication_schemas").insert(data).execute()
             logger.info(f"Linked schema {schema_id} to publication {publication_id}")
             return True
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             error_msg = str(e).lower()
             if "duplicate" in error_msg or "already exists" in error_msg:
                 return True
-            logger.error(f"Error linking schema: {e}")
+            logger.error(f"Error linking schema: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail=f"Failed to link schema: {str(e)}")
 
     async def remove_schema_link(self, publication_id: str, schema_id: str) -> bool:
@@ -632,8 +660,8 @@ class PublicationsDB:
             ).execute()
             logger.info(f"Removed schema {schema_id} from publication {publication_id}")
             return True
-        except Exception as e:
-            logger.error(f"Error removing schema link: {e}")
+        except (PostgrestAPIError, StorageException) as e:
+            logger.error(f"Error removing schema link: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail=f"Failed to remove schema link: {str(e)}")
 
     async def add_collection_link(
@@ -648,11 +676,11 @@ class PublicationsDB:
             self.client.table("publication_collections").insert(data).execute()
             logger.info(f"Linked collection {collection_id} to publication {publication_id}")
             return True
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             error_msg = str(e).lower()
             if "duplicate" in error_msg or "already exists" in error_msg:
                 return True
-            logger.error(f"Error linking collection: {e}")
+            logger.error(f"Error linking collection: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail=f"Failed to link collection: {str(e)}")
 
     async def remove_collection_link(self, publication_id: str, collection_id: str) -> bool:
@@ -663,8 +691,8 @@ class PublicationsDB:
             ).execute()
             logger.info(f"Removed collection {collection_id} from publication {publication_id}")
             return True
-        except Exception as e:
-            logger.error(f"Error removing collection link: {e}")
+        except (PostgrestAPIError, StorageException) as e:
+            logger.error(f"Error removing collection link: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail=f"Failed to remove collection link: {str(e)}")
 
     async def get_publication_schemas(self, publication_id: str) -> List[Dict[str, Any]]:
@@ -677,8 +705,8 @@ class PublicationsDB:
                 .execute()
             )
             return response.data or []
-        except Exception as e:
-            logger.error(f"Error getting publication schemas: {e}")
+        except (PostgrestAPIError, StorageException) as e:
+            logger.error(f"Error getting publication schemas: {e}", exc_info=True)
             return []
 
     async def get_publication_collections(self, publication_id: str) -> List[Dict[str, Any]]:
@@ -691,8 +719,8 @@ class PublicationsDB:
                 .execute()
             )
             return response.data or []
-        except Exception as e:
-            logger.error(f"Error getting publication collections: {e}")
+        except (PostgrestAPIError, StorageException) as e:
+            logger.error(f"Error getting publication collections: {e}", exc_info=True)
             return []
 
     async def add_extraction_job_link(
@@ -707,11 +735,11 @@ class PublicationsDB:
             self.client.table("publication_extraction_jobs").insert(data).execute()
             logger.info(f"Linked extraction job {job_id} to publication {publication_id}")
             return True
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             error_msg = str(e).lower()
             if "duplicate" in error_msg or "already exists" in error_msg:
                 return True
-            logger.error(f"Error linking extraction job: {e}")
+            logger.error(f"Error linking extraction job: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail=f"Failed to link extraction job: {str(e)}")
 
     async def remove_extraction_job_link(self, publication_id: str, job_id: str) -> bool:
@@ -722,8 +750,8 @@ class PublicationsDB:
             ).execute()
             logger.info(f"Removed extraction job {job_id} from publication {publication_id}")
             return True
-        except Exception as e:
-            logger.error(f"Error removing extraction job link: {e}")
+        except (PostgrestAPIError, StorageException) as e:
+            logger.error(f"Error removing extraction job link: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail=f"Failed to remove extraction job link: {str(e)}")
 
     async def get_publication_extraction_jobs(self, publication_id: str) -> List[Dict[str, Any]]:
@@ -736,8 +764,8 @@ class PublicationsDB:
                 .execute()
             )
             return response.data or []
-        except Exception as e:
-            logger.error(f"Error getting publication extraction jobs: {e}")
+        except (PostgrestAPIError, StorageException) as e:
+            logger.error(f"Error getting publication extraction jobs: {e}", exc_info=True)
             return []
 
 
@@ -794,7 +822,7 @@ class SupabaseVectorDB:
             ).execute()
 
             return response.data or []
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             logger.error(f"Vector search failed: {e}")
             raise HTTPException(status_code=500, detail=f"Vector search failed: {str(e)}")
 
@@ -850,7 +878,7 @@ class SupabaseVectorDB:
             ).execute()
 
             return response.data or []
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             logger.error(f"Hybrid search failed: {e}")
             raise HTTPException(status_code=500, detail=f"Hybrid search failed: {str(e)}")
 
@@ -885,7 +913,7 @@ class SupabaseVectorDB:
             ).execute()
 
             return response.data or []
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             logger.error(f"Chunk search failed: {e}")
             raise HTTPException(status_code=500, detail=f"Chunk search failed: {str(e)}")
 
@@ -914,7 +942,7 @@ class SupabaseVectorDB:
             ).execute()
 
             return response.data or []
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             logger.error(f"Failed to get document chunks: {e}")
             raise HTTPException(status_code=500, detail=f"Failed to get chunks: {str(e)}")
 
@@ -933,11 +961,15 @@ class SupabaseVectorDB:
         """
         try:
             response = (
-                self.client.table("legal_documents").select("*").eq("document_id", document_id).limit(1).execute()
+                self.client.table("legal_documents")
+                .select(_LEGAL_DOCUMENT_COLS)
+                .eq("document_id", document_id)
+                .limit(1)
+                .execute()
             )
 
             return response.data[0] if response.data else None
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             logger.error(f"Failed to fetch document {document_id}: {e}")
             return None
 
@@ -958,10 +990,15 @@ class SupabaseVectorDB:
             return []
 
         try:
-            response = self.client.table("legal_documents").select("*").in_("document_id", document_ids).execute()
+            response = (
+                self.client.table("legal_documents")
+                .select(_LEGAL_DOCUMENT_COLS)
+                .in_("document_id", document_ids)
+                .execute()
+            )
 
             return response.data or []
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             logger.error(f"Failed to fetch documents: {e}")
             return []
 
@@ -975,7 +1012,7 @@ class SupabaseVectorDB:
         try:
             response = self.client.rpc("get_embedding_stats").execute()
             return response.data[0] if response.data else {}
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             logger.error(f"Failed to get embedding stats: {e}")
             return {}
 
@@ -1018,7 +1055,7 @@ class SupabaseVectorDB:
             response = query_builder.range(offset, offset + limit - 1).execute()
 
             return response.data or []
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             logger.error(f"Full-text search failed: {e}")
             raise HTTPException(status_code=500, detail=f"Search failed: {str(e)}")
 
@@ -1060,7 +1097,7 @@ def reset_collections_db():
         try:
             if hasattr(_collections_db.client, "close"):
                 _collections_db.client.close()
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             logger.warning(f"Error closing Supabase client: {e}")
     _collections_db = None
 
@@ -1087,7 +1124,7 @@ def reset_publications_db():
         try:
             if hasattr(_publications_db.client, "close"):
                 _publications_db.client.close()
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             logger.warning(f"Error closing Publications Supabase client: {e}")
     _publications_db = None
 
@@ -1111,6 +1148,6 @@ def reset_vector_db():
         try:
             if hasattr(_vector_db.client, "close"):
                 _vector_db.client.close()
-        except Exception as e:
+        except (PostgrestAPIError, StorageException) as e:
             logger.warning(f"Error closing Vector Supabase client: {e}")
     _vector_db = None


### PR DESCRIPTION
## Summary
- Replace 20+ `.select("*")` calls with explicit column lists across 21 backend files
- Add module-level column constants for tables with 3+ queries
- Exclude `embedding`/`vector(768)` columns from bulk/list queries
- Keep vector columns only in single-row lookups that need them

## Test plan
- [ ] All API endpoints return same response shapes
- [ ] Backend tests pass
- [ ] Meilisearch sync still works (largest bandwidth savings)

Closes #77