### PR TITLE
chore(backend): fix dead code and add radon complexity CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,16 @@ jobs:
         working-directory: backend
         run: poetry run ruff check .
 
+      - name: Check code complexity
+        working-directory: backend
+        run: |
+          poetry run radon cc app/ packages/ -a -nc --total-average 2>&1 | tail -5
+          # Fail if any function has complexity grade F (>40)
+          if poetry run radon cc app/ packages/ -nc -n F 2>&1 | grep -q "F "; then
+            echo "ERROR: Functions with Grade F complexity detected"
+            exit 1
+          fi
+
   backend-test:
     name: Backend Unit Tests
     runs-on: ubuntu-latest

--- a/backend/app/ingestion/chunk_documents.py
+++ b/backend/app/ingestion/chunk_documents.py
@@ -429,12 +429,14 @@ class DocumentChunker:
             f"Found {len(existing_ids)} judgments already chunked, skipping them"
         )
 
-        while True:
+        has_more = True
+        while has_more:
             remaining = (
                 limit - self.stats["documents_processed"] if limit else self.batch_size
             )
             if limit and remaining <= 0:
-                break
+                has_more = False
+                continue
             batch_limit = min(self.batch_size, remaining)
             judgments = self.get_judgments_without_chunks(
                 limit=batch_limit,
@@ -443,7 +445,8 @@ class DocumentChunker:
 
             if not judgments:
                 logger.info("No more judgments to process")
-                break
+                has_more = False
+                continue
 
             await self.process_batch(judgments)
 


### PR DESCRIPTION
## Summary
- Fix Vulture-flagged unreachable code in `chunk_documents.py` (while True/break → while has_more)
- Add radon complexity check to CI (fail on Grade F functions)
- xml_converter tests already existed from prior work

Closes #81