### PR TITLE
docs: unify branching and release flow across canonical docs (#129)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,13 +214,21 @@ Next.js 15 with App Router:
 - `docker-compose.yml` has both `image:` and `build:` on each service — `image:` for Hub pulls, `build:` for local builds
 - Version tag controlled by `JUDDGES_IMAGE_TAG` env var (defaults to `latest`)
 
-**Versioning**: Git tags (`v0.1.0`, `v1.0.0`) are the source of truth. The build script reads the latest tag and auto-increments.
+**Versioning**: Git tags `prod-v*` (`prod-v0.1.0`, `prod-v1.0.0`, …) are the source of truth for production releases. The build script reads the latest `prod-v*` tag and auto-increments. (Legacy `v*` tags exist from before the rename — the script falls back to them only if no `prod-v*` tag is found.)
+
+**Branching & Release Flow** (canonical — same as root `README.md`):
+- `main` is production. Only release PRs (from `develop`) and `hotfix/*` PRs land here. Production deploys **only** from `main` via `prod-v*` tag pushes.
+- `develop` is the integration branch. Feature/fix branches start from `develop` and PR back into `develop`. Pushing to `develop` triggers the `deploy-dev` CI job (builds `dev-latest` images, no prod impact).
+- Releasing means: open `release: vX.Y.Z` PR from `develop` → `main`, merge, then run `./scripts/build_and_push_prod.sh` from a clean `main`. Pushing the resulting `prod-vX.Y.Z` tag triggers the `deploy-prod` CI job.
+- Hotfixes branch from `main`, PR back to `main`, then back-merge `main` → `develop`.
+- **Never open a feature PR directly against `main`.** When helping the user with branching commands, default to creating new branches from `develop`.
 
 **Deployment Flow**:
-1. Developer runs `build_and_push_prod.sh` locally (loads `.env` for frontend build args)
-2. Images pushed to Docker Hub
-3. On production host, run `deploy_prod.sh` to pull and restart
-4. Deploy history logged to `.deploy-history` for rollback support
+1. After a `develop` → `main` release PR is merged, the developer runs `build_and_push_prod.sh` from `main` (loads `.env` for frontend build args)
+2. The script creates a `prod-vX.Y.Z` git tag and (optionally) pushes it
+3. The tag push triggers GitHub Actions `deploy-prod`, which builds and pushes versioned + `:latest` images to Docker Hub
+4. On production host, run `deploy_prod.sh` to pull and restart
+5. Deploy history logged to `.deploy-history` for rollback support
 
 ## Key Files
 

--- a/README.md
+++ b/README.md
@@ -246,15 +246,60 @@ The deploy script pulls images, restarts containers via `docker-compose.yml`, wa
 
 ### Versioning
 
-Versions are tracked as git tags (`v0.1.0`, `v1.0.0`, etc.). The build script reads the latest tag, increments it, and creates a new tag after a successful push.
+Production versions are tracked as `prod-v*` git tags (`prod-v0.1.0`, `prod-v1.0.0`, …). The build script reads the latest `prod-v*` tag, increments it, and creates a new annotated tag from `main`. Pushing the tag is what triggers the production deploy in CI (see [Branching & Release Flow](#branching--release-flow) below).
+
+## Branching & Release Flow
+
+This repo uses a two-branch model:
+
+- **`main`** — production. Only `develop` → `main` release PRs and `hotfix/*` PRs land here. Pushing a `prod-v*` tag from `main` is the only thing that builds production images and deploys to prod.
+- **`develop`** — integration. All in-progress feature work lands here. Pushes to `develop` build `dev-latest` images (no production impact).
+
+### Day-to-day work (features, fixes)
+
+```bash
+git checkout develop && git pull
+git checkout -b feature/your-change          # or fix/your-bug
+# ... commit, push ...
+git push -u origin feature/your-change
+# Open a PR into develop (NOT main)
+```
+
+### Cutting a release
+
+```bash
+# 1. Open a PR from develop → main titled "release: vX.Y.Z" and merge it.
+
+# 2. From a clean main, run the build script:
+git checkout main && git pull
+./scripts/build_and_push_prod.sh             # patch bump (or: minor / major / 1.2.3)
+
+# 3. The script creates and (optionally) pushes the prod-vX.Y.Z tag.
+#    Pushing the tag triggers the deploy-prod GitHub Actions job, which
+#    builds and publishes the versioned + :latest images.
+
+# 4. On the production host:
+./scripts/deploy_prod.sh                     # pull :latest and restart
+```
+
+### Hotfixes
+
+```bash
+git checkout main && git pull
+git checkout -b hotfix/critical-thing
+# ... fix, commit, PR into main, merge ...
+# Cut the patch release as above, then back-merge main → develop:
+git checkout develop && git pull
+git merge main && git push
+```
 
 ## Contributing
 
-1. Fork the repository
-2. Create a feature branch: `git checkout -b feature/amazing-feature`
-3. Commit your changes: `git commit -m 'Add amazing feature'`
-4. Push to the branch: `git push origin feature/amazing-feature`
-5. Open a Pull Request
+1. Fork the repository (or branch directly if you have write access)
+2. Create your branch from **`develop`**: `git checkout develop && git pull && git checkout -b feature/amazing-feature`
+3. Commit your changes: `git commit -m "feat: add amazing feature"`
+4. Push: `git push origin feature/amazing-feature`
+5. Open a Pull Request **into `develop`** (never directly into `main`)
 
 ## License
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -152,12 +152,16 @@ See `.env.sample` for required configuration variables:
 
 ## Contributing
 
-1. Create a feature branch from `main`
+This project uses a two-branch flow: `develop` is the integration branch, `main` is production-only. Feature work targets `develop`.
+
+1. Branch from `develop`: `git checkout develop && git pull && git checkout -b feature/your-change`
 2. Write tests for new functionality
 3. Ensure all tests pass: `poetry run pytest`
 4. Format code: `poetry run ruff format .`
 5. Run linting: `poetry run ruff check .`
-6. Submit pull request
+6. Open a pull request **into `develop`** (never directly into `main`)
+
+Releases roll up by opening a `release: vX.Y.Z` PR from `develop` → `main`; production deploys are tag-driven (`prod-v*` tags cut from `main`). See the root `README.md` and `docs/how-to/deployment.md` for the full release flow.
 
 ## License
 

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -284,18 +284,26 @@ Closes #123"
 
 ## Pull Request Process
 
+> **Branching model**: this project uses two long-lived branches. `develop` is the integration branch where all feature work lands. `main` is reserved for production releases — only release PRs (from `develop`) and `hotfix/*` PRs are merged into `main`. **All feature/fix PRs must target `develop`, not `main`.** See the root `README.md` for the full release flow.
+
 ### Before Creating a PR
 
-1. **Update your fork:**
+1. **Update your fork's `develop`:**
    ```bash
    git fetch upstream
-   git checkout main
-   git merge upstream/main
+   git checkout develop
+   git merge upstream/develop
    ```
 
-2. **Create a feature branch:**
+2. **Create a feature branch from `develop`:**
    ```bash
    git checkout -b feature/your-feature-name
+   ```
+
+   For a production hotfix instead, branch from `main`:
+   ```bash
+   git checkout main && git merge upstream/main
+   git checkout -b hotfix/your-fix-name
    ```
 
 3. **Make your changes:**
@@ -329,7 +337,7 @@ Closes #123"
    git push origin feature/your-feature-name
    ```
 
-2. **Open a Pull Request** on GitHub
+2. **Open a Pull Request** on GitHub — set the base branch to **`develop`** (or `main` only for `hotfix/*` branches)
 
 3. **Fill out the PR template:**
 

--- a/docs/getting-started/DEVELOPER_ONBOARDING.md
+++ b/docs/getting-started/DEVELOPER_ONBOARDING.md
@@ -348,15 +348,20 @@ frontend/app/
 
 ## Development Workflow
 
+> **Branching model**: `develop` is the integration branch — all feature/fix work happens there. `main` is reserved for production releases (and only release PRs from `develop` or `hotfix/*` PRs land on it). See the root `README.md` and `docs/how-to/deployment.md` for the full release flow.
+
 ### Making Changes
 
-#### 1. Create Feature Branch
+#### 1. Create Feature Branch from `develop`
 
 ```bash
+git checkout develop && git pull
 git checkout -b feature/your-feature-name
 # OR for bug fixes
 git checkout -b fix/bug-description
 ```
+
+> Branch from `main` only when working on a production hotfix (`hotfix/<name>`). All other work starts from `develop`.
 
 #### 2. Make Changes
 
@@ -439,6 +444,7 @@ git push origin feature/your-feature-name
 ```
 
 Then create a Pull Request on GitHub with:
+- **Base branch set to `develop`** (use `main` only for `hotfix/*` PRs)
 - Clear title describing the change
 - Description of what changed and why
 - Link to related issues

--- a/docs/how-to/deployment.md
+++ b/docs/how-to/deployment.md
@@ -138,11 +138,14 @@ docker compose up -d --build
 
 ## 5. Versioned Releases (SemVer)
 
+> **Important**: Releases are cut from `main` only. Before running this script, the work to be released must already be merged from `develop` into `main` via a release PR (`release: vX.Y.Z`). See [Section 13 — CI/CD Pipeline](#13-cicd-pipeline) for the full branching flow.
+
 The release flow is handled by `scripts/build_and_push_prod.sh`. It performs version bumping, file sync, Docker build + push, and git tagging in a single interactive script.
 
 ### Usage
 
 ```bash
+git checkout main && git pull                  # always run from clean main
 ./scripts/build_and_push_prod.sh              # Auto-increment patch (0.0.2 -> 0.0.3)
 ./scripts/build_and_push_prod.sh patch         # Same as above
 ./scripts/build_and_push_prod.sh minor         # Increment minor (0.0.3 -> 0.1.0)
@@ -152,7 +155,7 @@ The release flow is handled by `scripts/build_and_push_prod.sh`. It performs ver
 
 ### What the script does
 
-1. Reads the latest `v*` git tag to determine current version
+1. Reads the latest `prod-v*` git tag to determine current version (legacy `v*` fallback)
 2. Calculates the next version based on bump type
 3. Confirms with the user before proceeding
 4. **Syncs version** across all project files (see table below)
@@ -162,8 +165,8 @@ The release flow is handled by `scripts/build_and_push_prod.sh`. It performs ver
    - `<username>/juddges-frontend:<version>`
    - `<username>/juddges-backend:<version>`
 8. Commits the version-synced files with message `release: v<version>`
-9. Creates an annotated git tag `v<version>`
-10. Optionally pushes the commit and tag to origin
+9. Creates an annotated git tag `prod-v<version>`
+10. Optionally pushes the commit and tag to origin (the tag push triggers the `deploy-prod` CI job)
 
 ### Version files kept in sync
 
@@ -506,20 +509,53 @@ Push to develop/main or PR
           └─────────────────┘
 ```
 
+### Branching Model
+
+Two long-lived branches:
+
+- **`main`** — production. Only release PRs (from `develop`) and `hotfix/*` PRs land here. Production images are built **only** when a `prod-v*` tag is pushed (and tags should always be cut from `main`).
+- **`develop`** — integration. All in-progress feature work lands here. A push to `develop` triggers `deploy-dev`, which publishes `dev-latest` images to Docker Hub (no production impact).
+
+Short-lived branches:
+
+- `feature/<name>`, `fix/<name>` — branch from `develop`, PR back into `develop`.
+- `hotfix/<name>` — branch from `main`, PR back into `main`. After release, back-merge `main` → `develop` so the fix isn't lost on the next release.
+
+> **Never open a feature PR directly against `main`.** Branch protection on `main` should be configured to enforce this; see the project root README for the canonical flow.
+
 ### Release Flow
 
 ```bash
-# 1. Develop features on feature branches
-git checkout -b feature/my-feature develop
+# 1. Open a PR from develop → main titled "release: vX.Y.Z" and merge it via GitHub.
+#    All feature/fix work that should ship in this release must already be in develop.
 
-# 2. Merge to develop (triggers dev deployment)
-git checkout develop && git merge feature/my-feature
+# 2. Build, tag, and push from a clean main:
+git checkout main && git pull
+./scripts/build_and_push_prod.sh                # creates prod-vX.Y.Z tag
 
-# 3. When ready for production, build and tag
-./scripts/build_and_push_prod.sh
+# 3. Pushing the prod-v* tag (the script offers to do this) triggers
+#    the deploy-prod CI job, which builds versioned + :latest images.
+git push origin prod-vX.Y.Z                     # if you didn't push from the script
 
-# 4. Push the tag (triggers prod deployment via CI)
-git push origin prod-v0.2.0
+# 4. On the production host:
+./scripts/deploy_prod.sh                        # pulls :latest and restarts containers
+```
+
+### Hotfix Flow
+
+```bash
+# 1. Branch from main:
+git checkout main && git pull
+git checkout -b hotfix/<short-name>
+
+# 2. Fix, commit, open a PR into main, merge.
+
+# 3. Cut a patch release exactly as in the Release Flow above
+#    (./scripts/build_and_push_prod.sh, deploy_prod.sh on the host).
+
+# 4. Back-merge main → develop so the hotfix is included in the next release:
+git checkout develop && git pull
+git merge main && git push
 ```
 
 ---


### PR DESCRIPTION
Two-branch model documented consistently in README, CLAUDE.md, backend README, deployment guide, contributing guide, and developer onboarding:

- main is production-only; deploys are triggered by prod-v* tag pushes
- develop is the integration branch; feature/fix branches start there and PR back to develop
- hotfix/* branches start from main, PR back to main, then back-merge to develop
- Releases are PRs from develop to main, then build_and_push_prod.sh cuts the prod-v* tag from a clean main

Also corrects stale v* tag references to prod-v* in README and CLAUDE.md (matches the actual convention enforced in scripts/build_and_push_prod.sh and the deploy-prod CI job).