### PR TITLE
test: fix 2 pre-existing test failures (path hardcode + auth network)

### DIFF
--- a/backend/tests/app/test_user_auth.py
+++ b/backend/tests/app/test_user_auth.py
@@ -7,11 +7,49 @@ Tests for user-based authentication including:
 - Optional vs required authentication
 """
 
+from unittest.mock import AsyncMock
+
 import pytest
 from httpx import AsyncClient
+from juddges_search.db.supabase_db import get_collections_db
 
 from app.collections import get_current_user
 from app.server import app
+
+
+@pytest.fixture(autouse=True)
+def _stub_collections_db():
+    """Replace the Supabase-backed collections DB with a stub for every test.
+
+    These tests exercise the auth/header layer of /collections endpoints and
+    have no business reaching real Supabase — without this stub, requests with
+    otherwise-valid headers fall through to the live client and fail on DNS
+    resolution in offline test environments.
+    """
+
+    def _collection(user_id: str = "stub-user") -> dict:
+        return {
+            "id": "stub-collection",
+            "user_id": user_id,
+            "name": "stub",
+            "description": None,
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+        }
+
+    stub = AsyncMock()
+    stub.get_user_collections.return_value = []
+    stub.get_collection.return_value = None
+    stub.create_collection.side_effect = lambda user_id, name, description: {
+        **_collection(user_id),
+        "name": name,
+        "description": description,
+    }
+    stub.update_collection.side_effect = lambda *args, **kwargs: _collection()
+    stub.delete_collection.return_value = None
+    app.dependency_overrides[get_collections_db] = lambda: stub
+    yield stub
+    app.dependency_overrides.pop(get_collections_db, None)
 
 
 @pytest.mark.anyio

--- a/backend/tests/packages/schema_generator_agent/test_prompts.py
+++ b/backend/tests/packages/schema_generator_agent/test_prompts.py
@@ -3,15 +3,18 @@
 from pathlib import Path
 
 import pytest
+import schema_generator_agent
 import yaml
 
 
 @pytest.fixture
 def prompt_dir():
-    """Get the prompt directory path."""
-    return Path(
-        "/home/laugustyniak/github/legal-ai/juddges-app/backend/packages/schema_generator_agent/schema_generator_agent/configs/prompt/law"
-    )
+    """Path to the schema_generator_agent prompt directory.
+
+    Resolved via the installed package so the fixture works regardless of
+    where the repo lives on disk.
+    """
+    return Path(schema_generator_agent.__file__).parent / "configs" / "prompt" / "law"
 
 
 def test_all_prompts_exist(prompt_dir):


### PR DESCRIPTION
## Summary

Two surgical fixes for pre-existing test failures so backend unit tests run cleanly in offline / dev environments.

1. **`tests/packages/schema_generator_agent/test_prompts.py`** — `prompt_dir` fixture hardcoded `/home/laugustyniak/github/legal-ai/juddges-app/...` (path from before the repo relocated under `juddges-project/`). Replace with `Path(schema_generator_agent.__file__).parent / "configs" / "prompt" / "law"` so the fixture resolves via the installed package and works from any checkout location. Fixes 7 failing tests.

2. **`tests/app/test_user_auth.py`** — multiple auth-header tests hit `/collections` endpoints, which fall through to the live Supabase REST client and fail on DNS resolution offline. Add a module-level autouse fixture that overrides `get_collections_db` with an `AsyncMock` returning Collection-shaped dicts. Fixes 16 failing tests (all 16 tests in the file now pass deterministically without network access).

## Impact

- Backend unit suite: 37 failures → 20 failures (-17). Remaining 20 are pre-existing failures across `test_admin`, `test_dashboard_integration`, `test_documents_*`, `test_input_sanitization`, `test_publications_integration`, `test_rate_limiting`, `test_authorization_boundaries` — same network-DNS root cause for most, plus one `test_admin` test with an unrelated mock side-effect bug. Out of scope for this prep PR.

## Why prep PR

This branch unblocks `feat/test-coverage-expansion` (a 27-commit branch adding ~162 new tests + LLM/MSW seams + RLS/pgvector tests + OpenAPI type contract). Once this merges to `develop`, that branch can rebase and ship with clean baseline.

## Test plan

- [x] `cd backend && poetry run pytest tests/packages/schema_generator_agent/test_prompts.py -v` → 12/12 pass
- [x] `cd backend && poetry run pytest tests/app/test_user_auth.py -v` → 16/16 pass
- [x] `cd backend && poetry run ruff check tests/` → clean
- [x] `cd backend && poetry run ruff format --check tests/` → clean