### PR TITLE
fix(migration): drop old search_judgments_hybrid overload before re-create

### DIFF
--- a/supabase/migrations/20260407000001_add_ef_search_parameter.sql
+++ b/supabase/migrations/20260407000001_add_ef_search_parameter.sql
@@ -3,7 +3,20 @@
 -- =============================================================================
 -- Allows callers to tune HNSW recall vs speed via ef_search_value parameter.
 -- Default remains 100 (unchanged behavior).
+--
+-- Note: CREATE OR REPLACE only matches by full signature, so adding a new
+-- parameter would create a second overload instead of replacing. Drop the
+-- prior 19-arg version first so the COMMENT below is unambiguous.
 -- =============================================================================
+
+DROP FUNCTION IF EXISTS public.search_judgments_hybrid(
+    vector, text, text,
+    text[], text[], text[], text[], text[], text[],
+    text[], text[], text[],
+    date, date,
+    double precision, double precision,
+    int, int, int
+);
 
 CREATE OR REPLACE FUNCTION public.search_judgments_hybrid(
     -- Search parameters


### PR DESCRIPTION
## Summary

- `CREATE OR REPLACE FUNCTION` matches by full signature, so adding the new `ef_search_value` parameter to `search_judgments_hybrid` created a *second overload* instead of replacing the prior 19-arg version. The trailing bare `COMMENT ON FUNCTION public.search_judgments_hybrid IS ...` then became ambiguous (`SQLSTATE 42725 — function name is not unique`) and the migration aborted.
- Add an explicit `DROP FUNCTION IF EXISTS public.search_judgments_hybrid(<19-arg signature>)` before the `CREATE OR REPLACE` so the migration applies cleanly on both fresh databases and on environments where the original 19-arg function exists.

## Production verification

This was discovered while applying the 4 backlog migrations to prod (`mfrxnqqbqkloguggegvh`) as part of issue #131. After this fix, `npx supabase db push --linked` applied both `20260407` and `20260429074740` cleanly. Post-apply checks on prod confirm:

- `pg_proc` shows a single `search_judgments_hybrid` overload with 20 args including `ef_search_value integer DEFAULT 100`
- `supabase_migrations.schema_migrations` now lists all 4 backlog migrations (`20260403`, `20260404`, `20260407`, `20260429074740`)
- Issue #131 RLS hardening is live (admin-only writes on `judgments`, RLS enabled on `document_chunks`)

## Test plan

- [x] Verified locally that the migration file applies on prod via `npx supabase db push --linked`
- [x] Post-apply diagnostic confirms a single function overload exists (no duplicate)
- [x] Migration 4's built-in self-verification block (lines 192-217) reported `RLS hardening verified: document_chunks RLS on, judgments writes admin-only`