### PR TITLE
feat(base-schema): extend filterable + searchable surface, add NL filter generator

### DIFF
--- a/backend/app/extraction_domain/nl_filter_generator.py
+++ b/backend/app/extraction_domain/nl_filter_generator.py
@@ -1,0 +1,318 @@
+"""Natural-language → base-schema filter generator.
+
+Converts a user's plain-English (or Polish) question into the JSON `p_filters`
+shape accepted by the Postgres RPC `filter_documents_by_extracted_data` (defined
+in supabase/migrations/20260226000001_create_judgment_base_extractions_table.sql
+and extended by 20260505000001_extend_base_schema_filterable_searchable.sql).
+
+The output is validated by Pydantic; every enum-constrained field uses
+`Literal[...]` mirroring the CHECK constraints in the migration, so an LLM
+that hallucinates an unknown value triggers a parse error and a retry rather
+than poisoning the query.
+
+Usage:
+
+    from app.extraction_domain.nl_filter_generator import (
+        generate_base_schema_filter,
+    )
+
+    result = await generate_base_schema_filter(
+        "list cases with at least 2 co-defendants where the offender confessed"
+    )
+    payload = result.to_rpc_payload()
+    # payload == {
+    #     "filters": {"co_def_acc_num": {"min": 2}, "did_offender_confess": True},
+    #     "text_query": None,
+    # }
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+from juddges_search.llms import get_default_llm
+from langchain_core.prompts import ChatPromptTemplate
+from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:
+    from langchain_openai import ChatOpenAI
+
+# ---------------------------------------------------------------------------
+# Enum literals — must match CHECK constraints in
+# supabase/migrations/20260226000001_create_judgment_base_extractions_table.sql
+# ---------------------------------------------------------------------------
+
+Appellant = Literal["offender", "attorney_general", "other"]
+PleaPoint = Literal[
+    "police_presence",
+    "first_court_appearance",
+    "before_trial",
+    "first_day_of_trial",
+    "after_first_day_of_trial",
+    "dont_know",
+]
+RemandDecision = Literal[
+    "unconditional_bail", "conditional_bail", "remanded_in_custody", "dont_know"
+]
+SentenceServe = Literal["serve_concurrent", "serve_consecutive", "serve_unknown"]
+Gender = Literal["gender_male", "gender_female", "gender_unknown"]
+Intoxication = Literal["intox_alcohol", "intox_drugs", "intox_unknown"]
+VictimType = Literal["individual_person", "organisation"]
+PreSentReport = Literal["low", "medium", "high", "dont_know"]
+OffenderJob = Literal[
+    "employed",
+    "self_employed",
+    "unemployed",
+    "student",
+    "retired",
+    "other",
+    "dont_know",
+]
+OffenderHome = Literal[
+    "fixed_address", "homeless", "temporary_accommodation", "dont_know"
+]
+OffenderVictimRel = Literal["stranger", "relative", "acquaintance", "dont_know"]
+AppealAgainst = Literal[
+    "appeal_conviction_unsafe",
+    "appeal_sentence_excessive",
+    "appeal_sentence_lenient",
+    "appeal_other",
+    "appeal_unknown",
+]
+AppealOutcome = Literal[
+    "outcome_dismissed_or_refused",
+    "outcome_conviction_quashed",
+    "outcome_sentence_more_severe",
+    "outcome_sentence_more_lenient",
+    "outcome_other",
+    "outcome_unknown",
+]
+
+
+# ---------------------------------------------------------------------------
+# Range helpers (mirror the {"min": ..., "max": ...} / {"from":, "to":} shapes
+# already accepted by the RPC)
+# ---------------------------------------------------------------------------
+
+
+class NumericRange(BaseModel):
+    """Inclusive numeric range. Either bound may be omitted."""
+
+    model_config = ConfigDict(extra="forbid")
+    min: float | None = Field(default=None, description="Inclusive lower bound.")
+    max: float | None = Field(default=None, description="Inclusive upper bound.")
+
+
+class DateRange(BaseModel):
+    """Inclusive ISO-date range. Either bound may be omitted."""
+
+    model_config = ConfigDict(extra="forbid")
+    from_: str | None = Field(
+        default=None,
+        alias="from",
+        description="Inclusive ISO date YYYY-MM-DD.",
+    )
+    to: str | None = Field(default=None, description="Inclusive ISO date YYYY-MM-DD.")
+
+
+# ---------------------------------------------------------------------------
+# Top-level filter model — mirrors filter_documents_by_extracted_data params
+# ---------------------------------------------------------------------------
+
+
+class BaseSchemaFilter(BaseModel):
+    """Structured filter for the base-schema RPC.
+
+    Every field is optional. Only set a field when the user's query *clearly*
+    implies it. Never invent values for fields the user did not mention.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    # --- scalar enums (IN-list) ------------------------------------------------
+    appellant: list[Appellant] | None = None
+    plea_point: list[PleaPoint] | None = None
+    remand_decision: list[RemandDecision] | None = None
+    victim_type: list[VictimType] | None = None
+    pre_sent_report: list[PreSentReport] | None = None
+    offender_job_offence: list[OffenderJob] | None = None
+    offender_home_offence: list[OffenderHome] | None = None
+    offender_victim_relationship: list[OffenderVictimRel] | None = None
+
+    # --- multi-value enums (array overlap) ------------------------------------
+    appeal_against: list[AppealAgainst] | None = None
+    appeal_outcome: list[AppealOutcome] | None = None
+    sentence_serve: list[SentenceServe] | None = None
+    offender_gender: list[Gender] | None = None
+    offender_intox_offence: list[Intoxication] | None = None
+    victim_gender: list[Gender] | None = None
+    victim_intox_offence: list[Intoxication] | None = None
+
+    # --- free-text array overlap ---------------------------------------------
+    keywords: list[str] | None = None
+    convict_offences: list[str] | None = None
+    acquit_offences: list[str] | None = None
+    appeal_ground: list[str] | None = None
+    sentences_received: list[str] | None = None
+    what_ancilliary_orders: list[str] | None = None
+    pros_evid_type_trial: list[str] | None = None
+    def_evid_type_trial: list[str] | None = None
+    agg_fact_sent: list[str] | None = None
+    mit_fact_sent: list[str] | None = None
+    sent_guide_which: list[str] | None = None
+    reason_quash_conv: list[str] | None = None
+    reason_sent_excessive: list[str] | None = None
+    reason_sent_lenient: list[str] | None = None
+    reason_dismiss: list[str] | None = None
+    convict_plea_dates: list[str] | None = None
+
+    # --- booleans -------------------------------------------------------------
+    did_offender_confess: bool | None = None
+    vic_impact_statement: bool | None = None
+
+    # --- numerics (eq or range) -----------------------------------------------
+    num_victims: NumericRange | float | None = None
+    case_number: NumericRange | float | None = None
+    victim_age_offence: NumericRange | float | None = None
+    co_def_acc_num: NumericRange | float | None = None
+
+    # --- date -----------------------------------------------------------------
+    date_of_appeal_court_judgment: DateRange | str | None = None
+
+    # --- substring (ILIKE) ----------------------------------------------------
+    case_name: str | None = None
+    neutral_citation_number: str | None = None
+    appeal_court_judges_names: str | None = None
+    offender_representative_name: str | None = None
+
+    # --- full-text query (separate parameter, not part of `p_filters`) -------
+    text_query: str | None = Field(
+        default=None,
+        description=(
+            "Plain text to match against base_search_tsv via websearch_to_tsquery. "
+            "Use only when the user wants free-text search across case name, "
+            "judges, charges, courts, etc."
+        ),
+    )
+
+    def to_rpc_payload(self) -> dict[str, Any]:
+        """Return the body shape expected by `POST /api/extractions/base-schema/filter`.
+
+        Splits `text_query` from the JSONB `filters` blob, drops None values, and
+        converts NumericRange / DateRange instances into plain dicts so the JSON
+        round-trip matches what `filter_documents_by_extracted_data` expects.
+        """
+        dumped = self.model_dump(exclude_none=True, by_alias=True)
+        text_query = dumped.pop("text_query", None)
+        return {"filters": dumped, "text_query": text_query}
+
+
+# ---------------------------------------------------------------------------
+# Prompt
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT = """You translate a user's natural-language question about UK
+and Polish criminal-court judgments into a structured filter for the
+`filter_documents_by_extracted_data` Postgres RPC.
+
+You MUST follow these rules:
+
+1. Only set a field when the user's query *clearly* implies it. If unsure,
+   leave the field out (null). Never guess values.
+2. Enum-constrained fields accept only the listed values — never invent
+   new ones. Map common phrasing to the closest enum value.
+3. For numeric fields, prefer ranges over equality. "at least N" → {"min": N};
+   "no more than N" → {"max": N}; "between N and M" → {"min": N, "max": M};
+   "exactly N" → equality (just a number).
+4. For dates, use ISO format YYYY-MM-DD. "in 2024" → from 2024-01-01 to
+   2024-12-31. "since 2023" → from 2023-01-01.
+5. `text_query` is for free-text search across case name, judges, charges,
+   courts, keywords. Use it only when the user is asking for content
+   *mentioning* something. If the user is filtering by a structured field,
+   use the structured filter and leave text_query null.
+6. `case_name`, `neutral_citation_number`, `appeal_court_judges_names`,
+   `offender_representative_name` are SUBSTRING matches (ILIKE). Strip
+   honorifics ("Lord Justice", "Mrs Justice", "Sędzia") — keep the surname
+   that's most distinctive.
+7. Free-text array fields (`keywords`, `convict_offences`, `agg_fact_sent`,
+   `mit_fact_sent`, …) are not enum-constrained; you may add reasonable
+   short tokens but err toward leaving them null when the user hasn't been
+   specific.
+
+Enum reference (mirror these exactly):
+
+- appellant: offender | attorney_general | other
+- plea_point: police_presence | first_court_appearance | before_trial |
+  first_day_of_trial | after_first_day_of_trial | dont_know
+- remand_decision: unconditional_bail | conditional_bail |
+  remanded_in_custody | dont_know
+- sentence_serve: serve_concurrent | serve_consecutive | serve_unknown
+- offender_gender / victim_gender: gender_male | gender_female | gender_unknown
+- offender_intox_offence / victim_intox_offence: intox_alcohol | intox_drugs |
+  intox_unknown
+- victim_type: individual_person | organisation
+- pre_sent_report: low | medium | high | dont_know
+- offender_job_offence: employed | self_employed | unemployed | student |
+  retired | other | dont_know
+- offender_home_offence: fixed_address | homeless | temporary_accommodation |
+  dont_know
+- offender_victim_relationship: stranger | relative | acquaintance | dont_know
+- appeal_against: appeal_conviction_unsafe | appeal_sentence_excessive |
+  appeal_sentence_lenient | appeal_other | appeal_unknown
+- appeal_outcome: outcome_dismissed_or_refused | outcome_conviction_quashed |
+  outcome_sentence_more_severe | outcome_sentence_more_lenient |
+  outcome_other | outcome_unknown
+
+Examples:
+
+user: "list cases with at least 2 co-defendants where the offender confessed"
+→ co_def_acc_num: {"min": 2}, did_offender_confess: true
+
+user: "successful appeals where the conviction was quashed in 2025"
+→ appeal_outcome: ["outcome_conviction_quashed"],
+  date_of_appeal_court_judgment: {"from": "2025-01-01", "to": "2025-12-31"}
+
+user: "robbery cases involving a knife"
+→ text_query: "robbery knife"
+
+user: "female offenders under the influence of drugs, victim was a relative"
+→ offender_gender: ["gender_female"],
+  offender_intox_offence: ["intox_drugs"],
+  offender_victim_relationship: ["relative"]
+
+user: "judgments by Lord Justice Edis"
+→ appeal_court_judges_names: "Edis"
+
+user: "homeless offender, unemployed, with a guilty plea mitigating factor"
+→ offender_home_offence: ["homeless"],
+  offender_job_offence: ["unemployed"],
+  mit_fact_sent: ["guilty_plea"]
+
+Return JSON matching the schema exactly. Set unused fields to null.
+"""
+
+NL_FILTER_PROMPT = ChatPromptTemplate.from_messages(
+    [("system", SYSTEM_PROMPT), ("human", "{query}")]
+)
+
+
+# ---------------------------------------------------------------------------
+# Chain factory + entry point
+# ---------------------------------------------------------------------------
+
+
+def create_nl_filter_chain(llm: ChatOpenAI | None = None):
+    """Build the LangChain pipeline that emits a validated BaseSchemaFilter."""
+    if llm is None:
+        llm = get_default_llm(use_mini_model=True)
+    structured = llm.with_structured_output(BaseSchemaFilter)
+    return NL_FILTER_PROMPT | structured
+
+
+async def generate_base_schema_filter(
+    query: str,
+    llm: ChatOpenAI | None = None,
+) -> BaseSchemaFilter:
+    """Translate a natural-language question into a validated filter."""
+    chain = create_nl_filter_chain(llm)
+    return await chain.ainvoke({"query": query})

--- a/backend/app/workers.py
+++ b/backend/app/workers.py
@@ -29,9 +29,12 @@ from app.schemas_pkg import _fetch_schema_from_db
 from app.utils.document_fetcher import get_documents_by_id
 
 load_dotenv()
-BROKER_URL = os.environ["CELERY_BROKER_URL"]
-BACKEND_URL = os.environ["CELERY_BACKEND_URL"]
-PROJECT_NAME = os.environ["CELERY_PROJECT_NAME"]
+# Safe defaults so `import app.workers` succeeds in environments without Celery
+# config (CI test collection, schema/type tooling). Real workers/beat set these
+# explicitly; production compose files pass them through.
+BROKER_URL = os.environ.get("CELERY_BROKER_URL", "memory://")
+BACKEND_URL = os.environ.get("CELERY_BACKEND_URL", "cache+memory://")
+PROJECT_NAME = os.environ.get("CELERY_PROJECT_NAME", "juddges")
 LLM_BASE_URL = os.getenv("LLM_BASE_URL")
 
 celery_app = Celery(PROJECT_NAME, broker=BROKER_URL, backend=BACKEND_URL)

--- a/backend/tests/app/test_nl_filter_generator.py
+++ b/backend/tests/app/test_nl_filter_generator.py
@@ -1,0 +1,194 @@
+"""Unit tests for the NL → base-schema filter generator.
+
+Covers:
+- BaseSchemaFilter schema validation (Literal constraints reject unknown enums).
+- to_rpc_payload() shape matches what filter_documents_by_extracted_data accepts.
+- generate_base_schema_filter() wires the LLM chain and returns a parsed model
+  (LLM is mocked).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from app.extraction_domain.nl_filter_generator import (
+    BaseSchemaFilter,
+    DateRange,
+    NumericRange,
+    create_nl_filter_chain,
+    generate_base_schema_filter,
+)
+
+# ---------------------------------------------------------------------------
+# Schema construction & validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBaseSchemaFilterValidation:
+    def test_empty_filter_is_valid(self):
+        f = BaseSchemaFilter()
+        assert f.to_rpc_payload() == {"filters": {}, "text_query": None}
+
+    def test_numeric_min_filter(self):
+        f = BaseSchemaFilter(co_def_acc_num=NumericRange(min=2))
+        payload = f.to_rpc_payload()
+        assert payload["filters"] == {"co_def_acc_num": {"min": 2.0}}
+        assert payload["text_query"] is None
+
+    def test_numeric_equality_filter(self):
+        f = BaseSchemaFilter(num_victims=3)
+        payload = f.to_rpc_payload()
+        assert payload["filters"] == {"num_victims": 3.0}
+
+    def test_date_range_uses_from_alias(self):
+        f = BaseSchemaFilter(
+            date_of_appeal_court_judgment=DateRange.model_validate(
+                {"from": "2025-01-01", "to": "2025-12-31"}
+            )
+        )
+        payload = f.to_rpc_payload()
+        assert payload["filters"]["date_of_appeal_court_judgment"] == {
+            "from": "2025-01-01",
+            "to": "2025-12-31",
+        }
+
+    def test_text_query_split_from_filters(self):
+        f = BaseSchemaFilter(
+            text_query="robbery knife", offender_gender=["gender_female"]
+        )
+        payload = f.to_rpc_payload()
+        assert payload["text_query"] == "robbery knife"
+        assert payload["filters"] == {"offender_gender": ["gender_female"]}
+
+    def test_unknown_enum_rejected(self):
+        with pytest.raises(ValidationError):
+            BaseSchemaFilter(
+                appeal_outcome=["outcome_quashed"]
+            )  # missing 'conviction_'
+
+    def test_unknown_top_level_field_rejected(self):
+        with pytest.raises(ValidationError):
+            BaseSchemaFilter.model_validate({"foo_bar": "baz"})
+
+    def test_substring_strings_pass_through(self):
+        f = BaseSchemaFilter(appeal_court_judges_names="Edis")
+        assert f.to_rpc_payload()["filters"] == {"appeal_court_judges_names": "Edis"}
+
+    def test_boolean_flags(self):
+        f = BaseSchemaFilter(did_offender_confess=True, vic_impact_statement=False)
+        payload = f.to_rpc_payload()
+        # exclude_none keeps False (it is not None)
+        assert payload["filters"] == {
+            "did_offender_confess": True,
+            "vic_impact_statement": False,
+        }
+
+    def test_composite_query_serialises_round_trip(self):
+        f = BaseSchemaFilter(
+            offender_gender=["gender_female"],
+            offender_intox_offence=["intox_drugs"],
+            co_def_acc_num=NumericRange(min=1),
+            appeal_court_judges_names="Holroyde",
+            date_of_appeal_court_judgment=DateRange.model_validate(
+                {"from": "2024-01-01"}
+            ),
+            text_query="firearm",
+        )
+        payload = f.to_rpc_payload()
+        assert payload["text_query"] == "firearm"
+        assert payload["filters"] == {
+            "offender_gender": ["gender_female"],
+            "offender_intox_offence": ["intox_drugs"],
+            "co_def_acc_num": {"min": 1.0},
+            "appeal_court_judges_names": "Holroyde",
+            "date_of_appeal_court_judgment": {"from": "2024-01-01"},
+        }
+
+
+# ---------------------------------------------------------------------------
+# NumericRange / DateRange
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRangeHelpers:
+    def test_numeric_range_open_upper(self):
+        r = NumericRange(min=2)
+        assert r.model_dump(exclude_none=True) == {"min": 2.0}
+
+    def test_numeric_range_both_bounds(self):
+        r = NumericRange(min=1, max=10)
+        assert r.model_dump(exclude_none=True) == {"min": 1.0, "max": 10.0}
+
+    def test_date_range_aliases_from(self):
+        r = DateRange.model_validate({"from": "2025-01-01", "to": "2025-12-31"})
+        dumped = r.model_dump(exclude_none=True, by_alias=True)
+        assert dumped == {"from": "2025-01-01", "to": "2025-12-31"}
+
+    def test_numeric_range_rejects_extra_fields(self):
+        with pytest.raises(ValidationError):
+            NumericRange.model_validate({"min": 1, "extra": "no"})
+
+
+# ---------------------------------------------------------------------------
+# Chain wiring (LLM mocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGenerateBaseSchemaFilter:
+    @pytest.mark.asyncio
+    async def test_returns_parsed_filter(self):
+        expected = BaseSchemaFilter(
+            co_def_acc_num=NumericRange(min=2),
+            did_offender_confess=True,
+        )
+        mock_chain = MagicMock()
+        mock_chain.ainvoke = AsyncMock(return_value=expected)
+
+        with patch(
+            "app.extraction_domain.nl_filter_generator.create_nl_filter_chain",
+            return_value=mock_chain,
+        ):
+            result = await generate_base_schema_filter(
+                "list cases with at least 2 co-defendants where the offender confessed"
+            )
+
+        assert result == expected
+        assert result.to_rpc_payload() == {
+            "filters": {
+                "co_def_acc_num": {"min": 2.0},
+                "did_offender_confess": True,
+            },
+            "text_query": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_passes_query_to_chain(self):
+        mock_chain = MagicMock()
+        mock_chain.ainvoke = AsyncMock(return_value=BaseSchemaFilter())
+
+        with patch(
+            "app.extraction_domain.nl_filter_generator.create_nl_filter_chain",
+            return_value=mock_chain,
+        ):
+            await generate_base_schema_filter("anything")
+
+        mock_chain.ainvoke.assert_awaited_once_with({"query": "anything"})
+
+    def test_create_chain_uses_default_llm(self):
+        with patch(
+            "app.extraction_domain.nl_filter_generator.get_default_llm"
+        ) as mock_factory:
+            mock_llm = MagicMock()
+            mock_llm.with_structured_output = MagicMock(return_value=MagicMock())
+            mock_factory.return_value = mock_llm
+
+            create_nl_filter_chain()
+
+        mock_factory.assert_called_once_with(use_mini_model=True)
+        mock_llm.with_structured_output.assert_called_once_with(BaseSchemaFilter)

--- a/docs/how-to/test-base-schema-filter-queries.md
+++ b/docs/how-to/test-base-schema-filter-queries.md
@@ -1,0 +1,290 @@
+# How to test the base-schema filter RPC
+
+This guide gives 10 worked example queries that exercise every tier of the
+`filter_documents_by_extracted_data` RPC after the migration in
+`supabase/migrations/20260505000001_extend_base_schema_filterable_searchable.sql`.
+
+Each example shows:
+
+- The natural-language **intent** a user would express.
+- The **JSON `p_filters`** body to send to `POST /api/extractions/base-schema/filter`.
+- The equivalent **direct SQL** for running via `psql`/Supabase SQL editor.
+
+Run them after the migration has applied and at least a handful of rows have
+`base_extraction_status = 'completed'`. All RPCs hard-filter to completed
+extractions.
+
+## Query 1 — Numeric `min` filter (Tier 1)
+
+**Intent:** "List judgments with at least 2 co-defendants."
+
+```json
+{
+  "filters": { "co_def_acc_num": { "min": 2 } },
+  "limit": 50
+}
+```
+
+```sql
+SELECT id, case_number, title, decision_date
+FROM filter_documents_by_extracted_data(
+  '{"co_def_acc_num": {"min": 2}}'::jsonb, NULL, 50, 0
+);
+```
+
+## Query 2 — Conjunction of new scalar enums (Tier 1)
+
+**Intent:** "Cases where the offender was unemployed and homeless at the time of offence."
+
+```json
+{
+  "filters": {
+    "offender_job_offence": ["unemployed"],
+    "offender_home_offence": ["homeless"]
+  },
+  "limit": 50
+}
+```
+
+```sql
+SELECT id, base_offender_job_offence, base_offender_home_offence
+FROM filter_documents_by_extracted_data(
+  '{"offender_job_offence": ["unemployed"], "offender_home_offence": ["homeless"]}'::jsonb,
+  NULL, 50, 0
+);
+```
+
+## Query 3 — Combined boolean + array (Tier 1)
+
+**Intent:** "Cases with a victim impact statement where the victim was intoxicated by alcohol or drugs."
+
+```json
+{
+  "filters": {
+    "vic_impact_statement": true,
+    "victim_intox_offence": ["intox_alcohol", "intox_drugs"]
+  },
+  "limit": 50
+}
+```
+
+```sql
+SELECT id, base_victim_intox_offence
+FROM filter_documents_by_extracted_data(
+  '{"vic_impact_statement": true, "victim_intox_offence": ["intox_alcohol", "intox_drugs"]}'::jsonb,
+  NULL, 50, 0
+);
+```
+
+## Query 4 — Aggravating + mitigating array overlap (Tier 1)
+
+**Intent:** "Sentencing decisions citing both an aggravating factor of weapon use and a mitigating factor of guilty plea."
+
+```json
+{
+  "filters": {
+    "agg_fact_sent": ["weapon_used", "use_of_weapon"],
+    "mit_fact_sent": ["guilty_plea"]
+  },
+  "limit": 50
+}
+```
+
+```sql
+SELECT id, base_agg_fact_sent, base_mit_fact_sent
+FROM filter_documents_by_extracted_data(
+  '{"agg_fact_sent": ["weapon_used", "use_of_weapon"], "mit_fact_sent": ["guilty_plea"]}'::jsonb,
+  NULL, 50, 0
+);
+```
+
+> Free-text array values (`agg_fact_sent`, `mit_fact_sent`, …) are not enum-constrained.
+> Use `GET /api/extractions/base-schema/facets/agg_fact_sent` to discover real values.
+
+## Query 5 — Offender–victim relationship + remand decision (Tier 1)
+
+**Intent:** "Cases involving relatives where the offender was remanded in custody."
+
+```json
+{
+  "filters": {
+    "offender_victim_relationship": ["relative"],
+    "remand_decision": ["remanded_in_custody"]
+  },
+  "limit": 50
+}
+```
+
+```sql
+SELECT id, base_offender_victim_relationship, base_remand_decision
+FROM filter_documents_by_extracted_data(
+  '{"offender_victim_relationship": ["relative"], "remand_decision": ["remanded_in_custody"]}'::jsonb,
+  NULL, 50, 0
+);
+```
+
+## Query 6 — Date range + multi-value appeal outcome
+
+**Intent:** "Successful appeals (conviction quashed or sentence reduced) decided in 2025."
+
+```json
+{
+  "filters": {
+    "appeal_outcome": ["outcome_conviction_quashed", "outcome_sentence_more_lenient"],
+    "date_of_appeal_court_judgment": { "from": "2025-01-01", "to": "2025-12-31" }
+  },
+  "limit": 100
+}
+```
+
+```sql
+SELECT id, base_appeal_outcome, base_date_of_appeal_court_judgment
+FROM filter_documents_by_extracted_data(
+  '{"appeal_outcome": ["outcome_conviction_quashed", "outcome_sentence_more_lenient"],
+    "date_of_appeal_court_judgment": {"from": "2025-01-01", "to": "2025-12-31"}}'::jsonb,
+  NULL, 100, 0
+);
+```
+
+## Query 7 — Substring on judge name (Tier 3 — uses new trgm index)
+
+**Intent:** "Cases heard by a judge whose name contains 'Edis'."
+
+```json
+{
+  "filters": { "appeal_court_judges_names": "Edis" },
+  "limit": 50
+}
+```
+
+```sql
+SELECT id, base_appeal_court_judges_names
+FROM filter_documents_by_extracted_data(
+  '{"appeal_court_judges_names": "Edis"}'::jsonb, NULL, 50, 0
+);
+
+-- Verify the trigram index is used:
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT id FROM judgments
+WHERE base_extraction_status = 'completed'
+  AND base_appeal_court_judges_names ILIKE '%Edis%';
+```
+
+## Query 8 — Indexed FTS via `base_search_tsv` (Tier 2)
+
+**Intent:** "Find judgments mentioning robbery and a knife."
+
+```json
+{
+  "filters": {},
+  "text_query": "robbery knife",
+  "limit": 50
+}
+```
+
+```sql
+SELECT id, case_number, title
+FROM filter_documents_by_extracted_data(
+  '{}'::jsonb, 'robbery knife', 50, 0
+);
+
+-- Verify the GIN index on base_search_tsv is used:
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT id FROM judgments
+WHERE base_extraction_status = 'completed'
+  AND base_search_tsv @@ websearch_to_tsquery('simple', 'robbery knife');
+```
+
+Before this migration the same query did `to_tsvector(...) @@ ...` inline at
+query time — full table scan. After: GIN index lookup.
+
+## Query 9 — Cross-tier composite (Tier 1 + 2 + 3)
+
+**Intent:** "Female offender, drugs intoxicated, at least 1 co-defendant, search text 'firearm', heard by Lord Justice Holroyde, decided 2024 onwards."
+
+```json
+{
+  "filters": {
+    "offender_gender": ["gender_female"],
+    "offender_intox_offence": ["intox_drugs"],
+    "co_def_acc_num": { "min": 1 },
+    "appeal_court_judges_names": "Holroyde",
+    "date_of_appeal_court_judgment": { "from": "2024-01-01" }
+  },
+  "text_query": "firearm",
+  "limit": 50
+}
+```
+
+```sql
+SELECT id, base_case_name, base_appeal_court_judges_names, base_co_def_acc_num
+FROM filter_documents_by_extracted_data(
+  '{
+    "offender_gender": ["gender_female"],
+    "offender_intox_offence": ["intox_drugs"],
+    "co_def_acc_num": {"min": 1},
+    "appeal_court_judges_names": "Holroyde",
+    "date_of_appeal_court_judgment": {"from": "2024-01-01"}
+  }'::jsonb,
+  'firearm', 50, 0
+);
+```
+
+## Query 10 — Pagination + total count
+
+**Intent:** "Page 3 (rows 100–149) of all completed extractions, with the global total count."
+
+```json
+{
+  "filters": {},
+  "limit": 50,
+  "offset": 100
+}
+```
+
+```sql
+SELECT id, total_count
+FROM filter_documents_by_extracted_data('{}'::jsonb, NULL, 50, 100);
+```
+
+`total_count` is computed via `COUNT(*) OVER()` so you get the unpaginated
+total on every row — useful for rendering a paginator without a second
+round-trip.
+
+---
+
+## Smoke-test snippet
+
+Run all 10 in one psql session:
+
+```sql
+\echo 'Q1: co-defendants ≥ 2'
+SELECT count(*) FROM filter_documents_by_extracted_data('{"co_def_acc_num":{"min":2}}'::jsonb, NULL, 1000, 0);
+
+\echo 'Q2: unemployed + homeless'
+SELECT count(*) FROM filter_documents_by_extracted_data('{"offender_job_offence":["unemployed"],"offender_home_offence":["homeless"]}'::jsonb, NULL, 1000, 0);
+
+\echo 'Q3: vis + intoxicated victim'
+SELECT count(*) FROM filter_documents_by_extracted_data('{"vic_impact_statement":true,"victim_intox_offence":["intox_alcohol","intox_drugs"]}'::jsonb, NULL, 1000, 0);
+
+\echo 'Q4: aggravating + mitigating'
+SELECT count(*) FROM filter_documents_by_extracted_data('{"agg_fact_sent":["weapon_used"],"mit_fact_sent":["guilty_plea"]}'::jsonb, NULL, 1000, 0);
+
+\echo 'Q5: relative + custody'
+SELECT count(*) FROM filter_documents_by_extracted_data('{"offender_victim_relationship":["relative"],"remand_decision":["remanded_in_custody"]}'::jsonb, NULL, 1000, 0);
+
+\echo 'Q6: 2025 successful appeals'
+SELECT count(*) FROM filter_documents_by_extracted_data('{"appeal_outcome":["outcome_conviction_quashed","outcome_sentence_more_lenient"],"date_of_appeal_court_judgment":{"from":"2025-01-01","to":"2025-12-31"}}'::jsonb, NULL, 1000, 0);
+
+\echo 'Q7: judge ILIKE'
+SELECT count(*) FROM filter_documents_by_extracted_data('{"appeal_court_judges_names":"Edis"}'::jsonb, NULL, 1000, 0);
+
+\echo 'Q8: FTS robbery knife'
+SELECT count(*) FROM filter_documents_by_extracted_data('{}'::jsonb, 'robbery knife', 1000, 0);
+
+\echo 'Q9: composite'
+SELECT count(*) FROM filter_documents_by_extracted_data('{"offender_gender":["gender_female"],"offender_intox_offence":["intox_drugs"],"co_def_acc_num":{"min":1}}'::jsonb, 'firearm', 1000, 0);
+
+\echo 'Q10: pagination'
+SELECT id, total_count FROM filter_documents_by_extracted_data('{}'::jsonb, NULL, 50, 100);
+```

--- a/supabase/migrations/20260505000001_extend_base_schema_filterable_searchable.sql
+++ b/supabase/migrations/20260505000001_extend_base_schema_filterable_searchable.sql
@@ -1,0 +1,446 @@
+-- =============================================================================
+-- Migration: Extend base-schema filterable + searchable surface
+-- =============================================================================
+-- Exposes all remaining base_* columns through public.filter_documents_by_extracted_data.
+--
+-- Three tiers of work:
+--   Tier 1: B-tree / GIN indexes for every previously-unindexed filterable
+--           column (counts, enums, multi-value arrays, booleans).
+--   Tier 2: A single STORED `base_search_tsv` generated column + GIN index
+--           replacing the on-the-fly `to_tsvector(...) @@ ...` inside the RPC.
+--           This converts the FTS branch from a full table scan into an index
+--           lookup and broadens coverage to ~20 source fields.
+--   Tier 3: Selective pg_trgm GIN indexes on judge / representative names so
+--           users can ILIKE on partial strings without seq-scanning.
+--
+-- Cost (rough, per 1M rows):
+--   Tier 1: ~0.5–0.8 GB across ~15 indexes
+--   Tier 2: ~0.7–1.0 GB for the GIN + ~150 MB for the generated column
+--   Tier 3: ~0.2–0.5 GB across 2 trigram indexes
+-- Write amplification is paid once per judgment at extraction-completion time.
+-- =============================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- -----------------------------------------------------------------------------
+-- Tier 1: filter indexes for previously-unindexed base_* columns
+-- -----------------------------------------------------------------------------
+
+-- Numeric / count
+CREATE INDEX IF NOT EXISTS idx_judgments_base_co_def_acc_num
+    ON public.judgments(base_co_def_acc_num);
+
+-- Scalar enum facets (B-tree)
+CREATE INDEX IF NOT EXISTS idx_judgments_base_offender_job_offence
+    ON public.judgments(base_offender_job_offence);
+CREATE INDEX IF NOT EXISTS idx_judgments_base_offender_home_offence
+    ON public.judgments(base_offender_home_offence);
+CREATE INDEX IF NOT EXISTS idx_judgments_base_offender_victim_relationship
+    ON public.judgments(base_offender_victim_relationship);
+
+-- Boolean filters: partial indexes (only TRUE rows; ~10x smaller than full B-tree)
+CREATE INDEX IF NOT EXISTS idx_judgments_base_did_offender_confess_true
+    ON public.judgments(id) WHERE base_did_offender_confess = TRUE;
+CREATE INDEX IF NOT EXISTS idx_judgments_base_vic_impact_statement_true
+    ON public.judgments(id) WHERE base_vic_impact_statement = TRUE;
+
+-- TEXT[] containment / overlap (GIN)
+CREATE INDEX IF NOT EXISTS idx_judgments_base_convict_plea_dates_gin
+    ON public.judgments USING gin(base_convict_plea_dates);
+CREATE INDEX IF NOT EXISTS idx_judgments_base_what_ancilliary_orders_gin
+    ON public.judgments USING gin(base_what_ancilliary_orders);
+CREATE INDEX IF NOT EXISTS idx_judgments_base_pros_evid_type_trial_gin
+    ON public.judgments USING gin(base_pros_evid_type_trial);
+CREATE INDEX IF NOT EXISTS idx_judgments_base_def_evid_type_trial_gin
+    ON public.judgments USING gin(base_def_evid_type_trial);
+CREATE INDEX IF NOT EXISTS idx_judgments_base_agg_fact_sent_gin
+    ON public.judgments USING gin(base_agg_fact_sent);
+CREATE INDEX IF NOT EXISTS idx_judgments_base_mit_fact_sent_gin
+    ON public.judgments USING gin(base_mit_fact_sent);
+CREATE INDEX IF NOT EXISTS idx_judgments_base_sent_guide_which_gin
+    ON public.judgments USING gin(base_sent_guide_which);
+CREATE INDEX IF NOT EXISTS idx_judgments_base_reason_quash_conv_gin
+    ON public.judgments USING gin(base_reason_quash_conv);
+CREATE INDEX IF NOT EXISTS idx_judgments_base_reason_sent_excessive_gin
+    ON public.judgments USING gin(base_reason_sent_excessive);
+CREATE INDEX IF NOT EXISTS idx_judgments_base_reason_sent_lenient_gin
+    ON public.judgments USING gin(base_reason_sent_lenient);
+
+-- -----------------------------------------------------------------------------
+-- Tier 2: unified base-schema FTS via STORED generated tsvector + GIN
+-- -----------------------------------------------------------------------------
+-- Replaces the on-the-fly `to_tsvector(...) @@ websearch_to_tsquery(...)` block
+-- inside filter_documents_by_extracted_data. Weights:
+--   A — high-signal identifiers (case name, citation, keywords)
+--   B — party / counsel / charged offences / appeal grounds
+--   C — courts / aggravating + mitigating factors
+--   D — sentences received, ancillary orders, mental/job/home narrative fields
+-- All source columns are wrapped in coalesce() so a NULL source never poisons
+-- the generated value to NULL.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE public.judgments
+    ADD COLUMN IF NOT EXISTS base_search_tsv tsvector
+        GENERATED ALWAYS AS (
+            setweight(to_tsvector('simple'::regconfig, coalesce(base_case_name, '')), 'A') ||
+            setweight(to_tsvector('simple'::regconfig, coalesce(base_neutral_citation_number, '')), 'A') ||
+            setweight(to_tsvector('simple'::regconfig, array_to_string(coalesce(base_keywords, ARRAY[]::TEXT[]), ' ')), 'A') ||
+            setweight(to_tsvector('simple'::regconfig, coalesce(base_appeal_court_judges_names, '')), 'B') ||
+            setweight(to_tsvector('simple'::regconfig, coalesce(base_offender_representative_name, '')), 'B') ||
+            setweight(to_tsvector('simple'::regconfig, coalesce(base_crown_attorney_general_representative_name, '')), 'B') ||
+            setweight(to_tsvector('simple'::regconfig, array_to_string(coalesce(base_convict_offences, ARRAY[]::TEXT[]), ' ')), 'B') ||
+            setweight(to_tsvector('simple'::regconfig, array_to_string(coalesce(base_acquit_offences, ARRAY[]::TEXT[]), ' ')), 'B') ||
+            setweight(to_tsvector('simple'::regconfig, array_to_string(coalesce(base_appeal_ground, ARRAY[]::TEXT[]), ' ')), 'B') ||
+            setweight(to_tsvector('simple'::regconfig, coalesce(base_conv_court_names, '')), 'C') ||
+            setweight(to_tsvector('simple'::regconfig, coalesce(base_sent_court_name, '')), 'C') ||
+            setweight(to_tsvector('simple'::regconfig, array_to_string(coalesce(base_agg_fact_sent, ARRAY[]::TEXT[]), ' ')), 'C') ||
+            setweight(to_tsvector('simple'::regconfig, array_to_string(coalesce(base_mit_fact_sent, ARRAY[]::TEXT[]), ' ')), 'C') ||
+            setweight(to_tsvector('simple'::regconfig, array_to_string(coalesce(base_sentences_received, ARRAY[]::TEXT[]), ' ')), 'D') ||
+            setweight(to_tsvector('simple'::regconfig, array_to_string(coalesce(base_what_ancilliary_orders, ARRAY[]::TEXT[]), ' ')), 'D') ||
+            setweight(to_tsvector('simple'::regconfig, coalesce(base_offender_mental_offence, '')), 'D') ||
+            setweight(to_tsvector('simple'::regconfig, coalesce(base_victim_mental_offence, '')), 'D') ||
+            setweight(to_tsvector('simple'::regconfig, coalesce(base_offender_job_offence, '')), 'D') ||
+            setweight(to_tsvector('simple'::regconfig, coalesce(base_offender_home_offence, '')), 'D') ||
+            setweight(to_tsvector('simple'::regconfig, coalesce(base_victim_job_offence, '')), 'D') ||
+            setweight(to_tsvector('simple'::regconfig, coalesce(base_victim_home_offence, '')), 'D')
+        ) STORED;
+
+CREATE INDEX IF NOT EXISTS idx_judgments_base_search_tsv
+    ON public.judgments USING gin(base_search_tsv);
+
+-- -----------------------------------------------------------------------------
+-- Tier 3: selective trigram indexes (substring/typo-tolerant ILIKE lookup)
+-- -----------------------------------------------------------------------------
+-- base_case_name and base_neutral_citation_number are already trgm-indexed
+-- by 20260226000001. Add only fields where users genuinely type partial strings.
+-- -----------------------------------------------------------------------------
+
+CREATE INDEX IF NOT EXISTS idx_judgments_base_appeal_court_judges_trgm
+    ON public.judgments USING gin (base_appeal_court_judges_names gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_judgments_base_offender_representative_trgm
+    ON public.judgments USING gin (base_offender_representative_name gin_trgm_ops);
+
+-- -----------------------------------------------------------------------------
+-- Update filter_documents_by_extracted_data to expose the new filter parameters
+-- and route the FTS branch through base_search_tsv (Tier 2).
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.filter_documents_by_extracted_data(
+    p_filters JSONB DEFAULT '{}'::jsonb,
+    p_text_query TEXT DEFAULT NULL,
+    p_limit INT DEFAULT 50,
+    p_offset INT DEFAULT 0
+)
+RETURNS TABLE (
+    id UUID,
+    case_number TEXT,
+    title TEXT,
+    jurisdiction TEXT,
+    decision_date DATE,
+    extracted_data JSONB,
+    total_count BIGINT
+)
+LANGUAGE plpgsql
+STABLE
+AS $$
+DECLARE
+    -- existing scalar enums
+    v_appellant TEXT[] := public._jsonb_to_text_array(p_filters -> 'appellant');
+    v_appeal_against TEXT[] := public._jsonb_to_text_array(p_filters -> 'appeal_against');
+    v_appeal_outcome TEXT[] := public._jsonb_to_text_array(p_filters -> 'appeal_outcome');
+    v_plea_point TEXT[] := public._jsonb_to_text_array(p_filters -> 'plea_point');
+    v_remand_decision TEXT[] := public._jsonb_to_text_array(p_filters -> 'remand_decision');
+    v_sentence_serve TEXT[] := public._jsonb_to_text_array(p_filters -> 'sentence_serve');
+    v_offender_gender TEXT[] := public._jsonb_to_text_array(p_filters -> 'offender_gender');
+    v_offender_intox_offence TEXT[] := public._jsonb_to_text_array(p_filters -> 'offender_intox_offence');
+    v_victim_gender TEXT[] := public._jsonb_to_text_array(p_filters -> 'victim_gender');
+    v_victim_intox_offence TEXT[] := public._jsonb_to_text_array(p_filters -> 'victim_intox_offence');
+    v_victim_type TEXT[] := public._jsonb_to_text_array(p_filters -> 'victim_type');
+    v_pre_sent_report TEXT[] := public._jsonb_to_text_array(p_filters -> 'pre_sent_report');
+
+    -- new scalar enums
+    v_offender_job_offence TEXT[] := public._jsonb_to_text_array(p_filters -> 'offender_job_offence');
+    v_offender_home_offence TEXT[] := public._jsonb_to_text_array(p_filters -> 'offender_home_offence');
+    v_offender_victim_relationship TEXT[] := public._jsonb_to_text_array(p_filters -> 'offender_victim_relationship');
+
+    -- existing array fields
+    v_keywords TEXT[] := public._jsonb_to_text_array(p_filters -> 'keywords');
+    v_convict_offences TEXT[] := public._jsonb_to_text_array(p_filters -> 'convict_offences');
+    v_acquit_offences TEXT[] := public._jsonb_to_text_array(p_filters -> 'acquit_offences');
+    v_appeal_ground TEXT[] := public._jsonb_to_text_array(p_filters -> 'appeal_ground');
+
+    -- new array fields
+    v_sentences_received TEXT[] := public._jsonb_to_text_array(p_filters -> 'sentences_received');
+    v_what_ancilliary_orders TEXT[] := public._jsonb_to_text_array(p_filters -> 'what_ancilliary_orders');
+    v_pros_evid_type_trial TEXT[] := public._jsonb_to_text_array(p_filters -> 'pros_evid_type_trial');
+    v_def_evid_type_trial TEXT[] := public._jsonb_to_text_array(p_filters -> 'def_evid_type_trial');
+    v_agg_fact_sent TEXT[] := public._jsonb_to_text_array(p_filters -> 'agg_fact_sent');
+    v_mit_fact_sent TEXT[] := public._jsonb_to_text_array(p_filters -> 'mit_fact_sent');
+    v_sent_guide_which TEXT[] := public._jsonb_to_text_array(p_filters -> 'sent_guide_which');
+    v_reason_quash_conv TEXT[] := public._jsonb_to_text_array(p_filters -> 'reason_quash_conv');
+    v_reason_sent_excessive TEXT[] := public._jsonb_to_text_array(p_filters -> 'reason_sent_excessive');
+    v_reason_sent_lenient TEXT[] := public._jsonb_to_text_array(p_filters -> 'reason_sent_lenient');
+    v_reason_dismiss TEXT[] := public._jsonb_to_text_array(p_filters -> 'reason_dismiss');
+    v_convict_plea_dates TEXT[] := public._jsonb_to_text_array(p_filters -> 'convict_plea_dates');
+
+    -- booleans
+    v_did_offender_confess BOOLEAN := NULL;
+    v_vic_impact_statement BOOLEAN := NULL;
+
+    -- existing numerics
+    v_num_victims_eq NUMERIC := NULL;
+    v_num_victims_min NUMERIC := NULL;
+    v_num_victims_max NUMERIC := NULL;
+
+    v_case_number_eq NUMERIC := NULL;
+    v_case_number_min NUMERIC := NULL;
+    v_case_number_max NUMERIC := NULL;
+
+    v_victim_age_eq NUMERIC := NULL;
+    v_victim_age_min NUMERIC := NULL;
+    v_victim_age_max NUMERIC := NULL;
+
+    -- new numeric: co_def_acc_num
+    v_co_def_acc_num_eq NUMERIC := NULL;
+    v_co_def_acc_num_min NUMERIC := NULL;
+    v_co_def_acc_num_max NUMERIC := NULL;
+
+    -- date
+    v_date_eq DATE := NULL;
+    v_date_from DATE := NULL;
+    v_date_to DATE := NULL;
+
+    -- existing substring
+    v_case_name_like TEXT := NULL;
+    v_neutral_citation_like TEXT := NULL;
+
+    -- new substring (Tier 3)
+    v_judges_like TEXT := NULL;
+    v_offender_rep_like TEXT := NULL;
+BEGIN
+    IF p_filters ? 'did_offender_confess' THEN
+        v_did_offender_confess := (p_filters ->> 'did_offender_confess')::BOOLEAN;
+    END IF;
+
+    IF p_filters ? 'vic_impact_statement' THEN
+        v_vic_impact_statement := (p_filters ->> 'vic_impact_statement')::BOOLEAN;
+    END IF;
+
+    IF p_filters ? 'num_victims' THEN
+        IF jsonb_typeof(p_filters -> 'num_victims') = 'object' THEN
+            IF (p_filters -> 'num_victims') ? 'min' THEN
+                v_num_victims_min := (p_filters -> 'num_victims' ->> 'min')::NUMERIC;
+            END IF;
+            IF (p_filters -> 'num_victims') ? 'max' THEN
+                v_num_victims_max := (p_filters -> 'num_victims' ->> 'max')::NUMERIC;
+            END IF;
+        ELSE
+            v_num_victims_eq := (p_filters ->> 'num_victims')::NUMERIC;
+        END IF;
+    END IF;
+
+    IF p_filters ? 'case_number' THEN
+        IF jsonb_typeof(p_filters -> 'case_number') = 'object' THEN
+            IF (p_filters -> 'case_number') ? 'min' THEN
+                v_case_number_min := (p_filters -> 'case_number' ->> 'min')::NUMERIC;
+            END IF;
+            IF (p_filters -> 'case_number') ? 'max' THEN
+                v_case_number_max := (p_filters -> 'case_number' ->> 'max')::NUMERIC;
+            END IF;
+        ELSE
+            v_case_number_eq := (p_filters ->> 'case_number')::NUMERIC;
+        END IF;
+    END IF;
+
+    IF p_filters ? 'victim_age_offence' THEN
+        IF jsonb_typeof(p_filters -> 'victim_age_offence') = 'object' THEN
+            IF (p_filters -> 'victim_age_offence') ? 'min' THEN
+                v_victim_age_min := (p_filters -> 'victim_age_offence' ->> 'min')::NUMERIC;
+            END IF;
+            IF (p_filters -> 'victim_age_offence') ? 'max' THEN
+                v_victim_age_max := (p_filters -> 'victim_age_offence' ->> 'max')::NUMERIC;
+            END IF;
+        ELSE
+            v_victim_age_eq := (p_filters ->> 'victim_age_offence')::NUMERIC;
+        END IF;
+    END IF;
+
+    IF p_filters ? 'co_def_acc_num' THEN
+        IF jsonb_typeof(p_filters -> 'co_def_acc_num') = 'object' THEN
+            IF (p_filters -> 'co_def_acc_num') ? 'min' THEN
+                v_co_def_acc_num_min := (p_filters -> 'co_def_acc_num' ->> 'min')::NUMERIC;
+            END IF;
+            IF (p_filters -> 'co_def_acc_num') ? 'max' THEN
+                v_co_def_acc_num_max := (p_filters -> 'co_def_acc_num' ->> 'max')::NUMERIC;
+            END IF;
+        ELSE
+            v_co_def_acc_num_eq := (p_filters ->> 'co_def_acc_num')::NUMERIC;
+        END IF;
+    END IF;
+
+    IF p_filters ? 'date_of_appeal_court_judgment' THEN
+        IF jsonb_typeof(p_filters -> 'date_of_appeal_court_judgment') = 'object' THEN
+            IF (p_filters -> 'date_of_appeal_court_judgment') ? 'from' THEN
+                v_date_from := (p_filters -> 'date_of_appeal_court_judgment' ->> 'from')::DATE;
+            ELSIF (p_filters -> 'date_of_appeal_court_judgment') ? 'min' THEN
+                v_date_from := (p_filters -> 'date_of_appeal_court_judgment' ->> 'min')::DATE;
+            END IF;
+
+            IF (p_filters -> 'date_of_appeal_court_judgment') ? 'to' THEN
+                v_date_to := (p_filters -> 'date_of_appeal_court_judgment' ->> 'to')::DATE;
+            ELSIF (p_filters -> 'date_of_appeal_court_judgment') ? 'max' THEN
+                v_date_to := (p_filters -> 'date_of_appeal_court_judgment' ->> 'max')::DATE;
+            END IF;
+        ELSE
+            v_date_eq := (p_filters ->> 'date_of_appeal_court_judgment')::DATE;
+        END IF;
+    END IF;
+
+    IF p_filters ? 'case_name' THEN
+        v_case_name_like := NULLIF(TRIM(p_filters ->> 'case_name'), '');
+    END IF;
+    IF p_filters ? 'neutral_citation_number' THEN
+        v_neutral_citation_like := NULLIF(TRIM(p_filters ->> 'neutral_citation_number'), '');
+    END IF;
+    IF p_filters ? 'appeal_court_judges_names' THEN
+        v_judges_like := NULLIF(TRIM(p_filters ->> 'appeal_court_judges_names'), '');
+    END IF;
+    IF p_filters ? 'offender_representative_name' THEN
+        v_offender_rep_like := NULLIF(TRIM(p_filters ->> 'offender_representative_name'), '');
+    END IF;
+
+    RETURN QUERY
+    WITH filtered AS (
+        SELECT
+            j.id,
+            j.case_number,
+            j.title,
+            j.jurisdiction,
+            j.decision_date,
+            COALESCE(j.base_raw_extraction, '{}'::jsonb) AS extracted_data
+        FROM public.judgments j
+        WHERE
+            j.base_extraction_status = 'completed'
+
+            -- existing scalar enum filters
+            AND (v_appellant IS NULL OR j.base_appellant = ANY(v_appellant))
+            AND (v_appeal_against IS NULL OR j.base_appeal_against && v_appeal_against)
+            AND (v_appeal_outcome IS NULL OR j.base_appeal_outcome && v_appeal_outcome)
+            AND (v_plea_point IS NULL OR j.base_plea_point = ANY(v_plea_point))
+            AND (v_remand_decision IS NULL OR j.base_remand_decision = ANY(v_remand_decision))
+            AND (v_sentence_serve IS NULL OR j.base_sentence_serve && v_sentence_serve)
+            AND (v_offender_gender IS NULL OR j.base_offender_gender && v_offender_gender)
+            AND (v_offender_intox_offence IS NULL OR j.base_offender_intox_offence && v_offender_intox_offence)
+            AND (v_victim_gender IS NULL OR j.base_victim_gender && v_victim_gender)
+            AND (v_victim_intox_offence IS NULL OR j.base_victim_intox_offence && v_victim_intox_offence)
+            AND (v_victim_type IS NULL OR j.base_victim_type = ANY(v_victim_type))
+            AND (v_pre_sent_report IS NULL OR j.base_pre_sent_report = ANY(v_pre_sent_report))
+
+            -- new scalar enum filters
+            AND (v_offender_job_offence IS NULL OR j.base_offender_job_offence = ANY(v_offender_job_offence))
+            AND (v_offender_home_offence IS NULL OR j.base_offender_home_offence = ANY(v_offender_home_offence))
+            AND (v_offender_victim_relationship IS NULL OR j.base_offender_victim_relationship = ANY(v_offender_victim_relationship))
+
+            -- booleans
+            AND (v_did_offender_confess IS NULL OR j.base_did_offender_confess = v_did_offender_confess)
+            AND (v_vic_impact_statement IS NULL OR j.base_vic_impact_statement = v_vic_impact_statement)
+
+            -- existing array filters
+            AND (v_keywords IS NULL OR j.base_keywords && v_keywords)
+            AND (v_convict_offences IS NULL OR j.base_convict_offences && v_convict_offences)
+            AND (v_acquit_offences IS NULL OR j.base_acquit_offences && v_acquit_offences)
+            AND (v_appeal_ground IS NULL OR j.base_appeal_ground && v_appeal_ground)
+
+            -- new array filters
+            AND (v_sentences_received IS NULL OR j.base_sentences_received && v_sentences_received)
+            AND (v_what_ancilliary_orders IS NULL OR j.base_what_ancilliary_orders && v_what_ancilliary_orders)
+            AND (v_pros_evid_type_trial IS NULL OR j.base_pros_evid_type_trial && v_pros_evid_type_trial)
+            AND (v_def_evid_type_trial IS NULL OR j.base_def_evid_type_trial && v_def_evid_type_trial)
+            AND (v_agg_fact_sent IS NULL OR j.base_agg_fact_sent && v_agg_fact_sent)
+            AND (v_mit_fact_sent IS NULL OR j.base_mit_fact_sent && v_mit_fact_sent)
+            AND (v_sent_guide_which IS NULL OR j.base_sent_guide_which && v_sent_guide_which)
+            AND (v_reason_quash_conv IS NULL OR j.base_reason_quash_conv && v_reason_quash_conv)
+            AND (v_reason_sent_excessive IS NULL OR j.base_reason_sent_excessive && v_reason_sent_excessive)
+            AND (v_reason_sent_lenient IS NULL OR j.base_reason_sent_lenient && v_reason_sent_lenient)
+            AND (v_reason_dismiss IS NULL OR j.base_reason_dismiss && v_reason_dismiss)
+            AND (v_convict_plea_dates IS NULL OR j.base_convict_plea_dates && v_convict_plea_dates)
+
+            -- existing numerics
+            AND (
+                (v_num_victims_eq IS NULL OR j.base_num_victims = v_num_victims_eq)
+                AND (v_num_victims_min IS NULL OR j.base_num_victims >= v_num_victims_min)
+                AND (v_num_victims_max IS NULL OR j.base_num_victims <= v_num_victims_max)
+            )
+            AND (
+                (v_case_number_eq IS NULL OR j.base_case_number = v_case_number_eq)
+                AND (v_case_number_min IS NULL OR j.base_case_number >= v_case_number_min)
+                AND (v_case_number_max IS NULL OR j.base_case_number <= v_case_number_max)
+            )
+            AND (
+                (v_victim_age_eq IS NULL OR j.base_victim_age_offence = v_victim_age_eq)
+                AND (v_victim_age_min IS NULL OR j.base_victim_age_offence >= v_victim_age_min)
+                AND (v_victim_age_max IS NULL OR j.base_victim_age_offence <= v_victim_age_max)
+            )
+
+            -- new numeric
+            AND (
+                (v_co_def_acc_num_eq IS NULL OR j.base_co_def_acc_num = v_co_def_acc_num_eq)
+                AND (v_co_def_acc_num_min IS NULL OR j.base_co_def_acc_num >= v_co_def_acc_num_min)
+                AND (v_co_def_acc_num_max IS NULL OR j.base_co_def_acc_num <= v_co_def_acc_num_max)
+            )
+
+            -- date
+            AND (
+                (v_date_eq IS NULL OR j.base_date_of_appeal_court_judgment = v_date_eq)
+                AND (v_date_from IS NULL OR j.base_date_of_appeal_court_judgment >= v_date_from)
+                AND (v_date_to IS NULL OR j.base_date_of_appeal_court_judgment <= v_date_to)
+            )
+
+            -- existing substring
+            AND (
+                v_case_name_like IS NULL OR
+                j.base_case_name ILIKE '%' || v_case_name_like || '%'
+            )
+            AND (
+                v_neutral_citation_like IS NULL OR
+                j.base_neutral_citation_number ILIKE '%' || v_neutral_citation_like || '%'
+            )
+
+            -- new substring (Tier 3)
+            AND (
+                v_judges_like IS NULL OR
+                j.base_appeal_court_judges_names ILIKE '%' || v_judges_like || '%'
+            )
+            AND (
+                v_offender_rep_like IS NULL OR
+                j.base_offender_representative_name ILIKE '%' || v_offender_rep_like || '%'
+            )
+
+            -- text query now uses indexed base_search_tsv (Tier 2)
+            AND (
+                p_text_query IS NULL OR TRIM(p_text_query) = '' OR
+                j.base_search_tsv @@ websearch_to_tsquery('simple', p_text_query)
+            )
+    )
+    SELECT
+        f.id,
+        f.case_number,
+        f.title,
+        f.jurisdiction,
+        f.decision_date,
+        f.extracted_data,
+        COUNT(*) OVER()::BIGINT AS total_count
+    FROM filtered f
+    ORDER BY f.decision_date DESC NULLS LAST, f.id
+    LIMIT GREATEST(COALESCE(p_limit, 50), 1)
+    OFFSET GREATEST(COALESCE(p_offset, 0), 0);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.filter_documents_by_extracted_data(JSONB, TEXT, INT, INT)
+    TO anon, authenticated, service_role;
+
+-- -----------------------------------------------------------------------------
+-- Refresh planner statistics so the new indexes are picked immediately.
+-- -----------------------------------------------------------------------------
+ANALYZE public.judgments;


### PR DESCRIPTION
## Summary

Three coordinated pieces so users can filter and search every `base_*` extraction column from natural language without paying full-table-scan costs.

### Migration — `supabase/migrations/20260505000001`

- **Tier 1** — B-tree / GIN / partial-boolean indexes for previously unindexed filter targets: `co_def_acc_num`, `offender_job/home_offence`, `offender_victim_relationship`, `did_offender_confess`, `vic_impact_statement`, `agg_fact_sent`, `mit_fact_sent`, `sentences_received`, `what_ancilliary_orders`, `pros/def_evid_type_trial`, sentencing-guideline + dismissal/quash reason arrays, `convict_plea_dates`.
- **Tier 2** — STORED generated `base_search_tsv` + GIN, weighted A/B/C/D across ~20 source fields. Replaces the inline `to_tsvector(...) @@ ...` block inside `filter_documents_by_extracted_data` — FTS branch becomes an index lookup instead of a seq-scan.
- **Tier 3** — `pg_trgm` GIN indexes on `base_appeal_court_judges_names` and `base_offender_representative_name` for substring ILIKE.
- `filter_documents_by_extracted_data` is replaced (signature unchanged: `JSONB, TEXT, INT, INT`) to read the new filter keys and route `p_text_query` through `base_search_tsv`.

### Backend — `app/extraction_domain/nl_filter_generator.py`

- `BaseSchemaFilter` (Pydantic) mirrors the migration's `CHECK` constraints via `Literal[...]`. LLM-hallucinated enum values trigger `ValidationError` rather than poisoning the SQL.
- `to_rpc_payload()` splits `text_query` from the JSONB `filters` body, matching `POST /api/extractions/base-schema/filter` exactly.
- `generate_base_schema_filter()` wires a structured-output LangChain pipeline on top of `get_default_llm(use_mini_model=True)`.

### Tests — `tests/app/test_nl_filter_generator.py`

17 unit tests covering schema validation, `from`/`to` alias handling, numeric/date range helpers, extra-field rejection, and chain wiring (LLM mocked).

### Docs — `docs/how-to/test-base-schema-filter-queries.md`

10 worked queries spanning all three tiers, each with the JSON body for the API and the equivalent direct SQL for psql / Supabase SQL editor, plus a smoke-test snippet.

## Why no `DROP FUNCTION` first

PR #135 needed `DROP FUNCTION` because `search_judgments_hybrid`'s parameter list changed. Here the signature `(JSONB, TEXT, INT, INT)` and `RETURNS TABLE` shape are identical to `20260226000001`, so `CREATE OR REPLACE` is sufficient.

## Test plan

- [x] `poetry run ruff check` — clean
- [x] `poetry run ruff format` — applied (whitespace only, 2 files)
- [x] `poetry run pytest tests/app/test_nl_filter_generator.py -v` — 17/17 pass
- [ ] Migration applied against a Supabase project — verify the 10 queries in the how-to return rows / use the new indexes (`EXPLAIN ANALYZE` on the FTS query should show `base_search_tsv` GIN index lookup, not `Seq Scan`)
- [ ] `generate_base_schema_filter()` end-to-end smoke test against OpenAI for a handful of natural-language queries