### PR TITLE
feat(search): /search/extractions — form-based filter UI for all base_* fields

### DIFF
--- a/frontend/__tests__/lib/extractions/base-schema-filter-config.test.ts
+++ b/frontend/__tests__/lib/extractions/base-schema-filter-config.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Sanity tests for the base-schema filter registry.
+ *
+ * Guards against drift between:
+ *   - types/base-schema-filter.ts (BaseSchemaFilters interface)
+ *   - lib/extractions/base-schema-filter-config.ts (FILTER_FIELDS registry)
+ *
+ * @jest-environment node
+ */
+
+import {
+  FILTER_FIELDS,
+  FILTER_FIELD_BY_NAME,
+  FIELDS_BY_GROUP,
+  GROUP_ORDER,
+  formatEnumLabel,
+} from "@/lib/extractions/base-schema-filter-config";
+import type { BaseSchemaFilters } from "@/types/base-schema-filter";
+
+// Sentinel object pinning every BaseSchemaFilters key. Matches the Pydantic
+// model in backend/app/extraction_domain/nl_filter_generator.py.
+const REQUIRED_KEYS: Record<keyof BaseSchemaFilters, true> = {
+  appellant: true,
+  plea_point: true,
+  remand_decision: true,
+  victim_type: true,
+  pre_sent_report: true,
+  offender_job_offence: true,
+  offender_home_offence: true,
+  offender_victim_relationship: true,
+  appeal_against: true,
+  appeal_outcome: true,
+  sentence_serve: true,
+  offender_gender: true,
+  offender_intox_offence: true,
+  victim_gender: true,
+  victim_intox_offence: true,
+  keywords: true,
+  convict_offences: true,
+  acquit_offences: true,
+  appeal_ground: true,
+  sentences_received: true,
+  what_ancilliary_orders: true,
+  pros_evid_type_trial: true,
+  def_evid_type_trial: true,
+  agg_fact_sent: true,
+  mit_fact_sent: true,
+  sent_guide_which: true,
+  reason_quash_conv: true,
+  reason_sent_excessive: true,
+  reason_sent_lenient: true,
+  reason_dismiss: true,
+  convict_plea_dates: true,
+  did_offender_confess: true,
+  vic_impact_statement: true,
+  num_victims: true,
+  case_number: true,
+  victim_age_offence: true,
+  co_def_acc_num: true,
+  date_of_appeal_court_judgment: true,
+  case_name: true,
+  neutral_citation_number: true,
+  appeal_court_judges_names: true,
+  offender_representative_name: true,
+};
+
+describe("base-schema filter registry", () => {
+  it("registers exactly one entry per BaseSchemaFilters key", () => {
+    const fields = new Set(FILTER_FIELDS.map((c) => c.field));
+    const required = new Set(Object.keys(REQUIRED_KEYS));
+
+    const missing = [...required].filter((k) => !fields.has(k));
+    const extra = [...fields].filter((k) => !required.has(k));
+
+    expect(missing).toEqual([]);
+    expect(extra).toEqual([]);
+    expect(fields.size).toBe(required.size);
+  });
+
+  it("has a unique field name per entry", () => {
+    const seen = new Set<string>();
+    for (const c of FILTER_FIELDS) {
+      expect(seen.has(c.field)).toBe(false);
+      seen.add(c.field);
+    }
+  });
+
+  it("indexes every entry by field in FILTER_FIELD_BY_NAME", () => {
+    for (const c of FILTER_FIELDS) {
+      expect(FILTER_FIELD_BY_NAME[c.field]).toBe(c);
+    }
+  });
+
+  it("groups every entry into a known group, total covers FILTER_FIELDS", () => {
+    let total = 0;
+    for (const g of GROUP_ORDER) {
+      const fields = FIELDS_BY_GROUP[g];
+      expect(Array.isArray(fields)).toBe(true);
+      total += fields.length;
+    }
+    expect(total).toBe(FILTER_FIELDS.length);
+  });
+
+  it("requires enumValues on enum_multi controls", () => {
+    for (const c of FILTER_FIELDS) {
+      if (c.control === "enum_multi") {
+        expect(Array.isArray(c.enumValues)).toBe(true);
+        expect(c.enumValues!.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("formatEnumLabel humanises snake_case", () => {
+    expect(formatEnumLabel("gender_male")).toBe("Gender male");
+    expect(formatEnumLabel("appeal_conviction_unsafe")).toBe(
+      "Appeal conviction unsafe",
+    );
+    expect(formatEnumLabel("low")).toBe("Low");
+  });
+});

--- a/frontend/__tests__/lib/extractions/use-extracted-data-filters.test.ts
+++ b/frontend/__tests__/lib/extractions/use-extracted-data-filters.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Pure-function tests for the URL <-> filter-state codec.
+ *
+ * The hook itself depends on next/navigation and is exercised in the E2E test;
+ * here we lock down the behaviour of the encoder/decoder/pruner so that
+ * round-trips through the URL never lose or mangle a filter.
+ *
+ * @jest-environment jsdom
+ */
+
+import {
+  countActive,
+  decodeFilters,
+  encodeFilters,
+  pruneEmpty,
+} from "@/lib/extractions/use-extracted-data-filters";
+import type { BaseSchemaFilters } from "@/types/base-schema-filter";
+
+describe("encodeFilters / decodeFilters", () => {
+  it("round-trips an empty filter to empty string and back", () => {
+    expect(encodeFilters({})).toBe("");
+    expect(decodeFilters("")).toEqual({});
+    expect(decodeFilters(null)).toEqual({});
+    expect(decodeFilters(undefined)).toEqual({});
+  });
+
+  it("round-trips enum + numeric range + boolean composite", () => {
+    const filters: BaseSchemaFilters = {
+      offender_gender: ["gender_female"],
+      co_def_acc_num: { min: 2 },
+      did_offender_confess: true,
+      appeal_court_judges_names: "Holroyde",
+    };
+    const blob = encodeFilters(filters);
+    expect(blob).not.toBe("");
+    expect(decodeFilters(blob)).toEqual(filters);
+  });
+
+  it("prunes empty arrays and empty strings before encoding", () => {
+    const blob = encodeFilters({
+      offender_gender: [],
+      case_name: "   ",
+      did_offender_confess: false,
+    });
+    expect(decodeFilters(blob)).toEqual({ did_offender_confess: false });
+  });
+
+  it("returns {} on malformed blob instead of throwing", () => {
+    expect(decodeFilters("not-base64$$$")).toEqual({});
+    expect(decodeFilters("Zm9v")).toEqual({}); // 'foo' decoded — not JSON object
+  });
+
+  it("uses URL-safe base64 (no '+' or '/')", () => {
+    const filters: BaseSchemaFilters = {
+      keywords: ["robbery", "knife", "domestic violence", "manslaughter"],
+    };
+    const blob = encodeFilters(filters);
+    expect(blob).not.toMatch(/[+/=]/);
+  });
+});
+
+describe("pruneEmpty", () => {
+  it("drops empty arrays and whitespace strings", () => {
+    expect(
+      pruneEmpty({
+        offender_gender: [],
+        case_name: " ",
+        keywords: ["a"],
+        co_def_acc_num: { min: 1 },
+      }),
+    ).toEqual({
+      keywords: ["a"],
+      co_def_acc_num: { min: 1 },
+    });
+  });
+
+  it("preserves boolean false (it is not 'empty')", () => {
+    expect(pruneEmpty({ did_offender_confess: false })).toEqual({
+      did_offender_confess: false,
+    });
+  });
+
+  it("preserves zero numeric values", () => {
+    expect(pruneEmpty({ num_victims: 0 })).toEqual({ num_victims: 0 });
+  });
+
+  it("drops empty range objects", () => {
+    expect(pruneEmpty({ co_def_acc_num: {} })).toEqual({});
+  });
+});
+
+describe("countActive", () => {
+  it("counts only non-empty fields", () => {
+    expect(
+      countActive({
+        offender_gender: ["gender_female"],
+        keywords: [],
+        case_name: "",
+        did_offender_confess: true,
+      }),
+    ).toBe(2);
+  });
+});

--- a/frontend/app/search/extractions/page.tsx
+++ b/frontend/app/search/extractions/page.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import Link from "next/link";
+import { Suspense, useMemo } from "react";
+
+import {
+  ActiveFilterChips,
+  ExtractedFilterDrawer,
+} from "@/components/filters/extracted-search-filters";
+import { Pagination } from "@/lib/styles/components";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useExtractionResults } from "@/lib/extractions/base-schema-filter-api";
+import { useExtractedDataFilters } from "@/lib/extractions/use-extracted-data-filters";
+import type {
+  BaseSchemaFilterRequest,
+  BaseSchemaFilterResultRow,
+} from "@/types/base-schema-filter";
+
+function ResultRow({ row }: { row: BaseSchemaFilterResultRow }) {
+  const date = row.decision_date ? new Date(row.decision_date) : null;
+  return (
+    <Link
+      href={`/judgments/${row.id}`}
+      className="block rounded-lg border bg-card p-4 transition-colors hover:bg-muted/50"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <h3 className="font-semibold leading-tight truncate">
+            {row.title ?? row.case_number ?? row.id}
+          </h3>
+          {row.case_number && row.title && (
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {row.case_number}
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          {row.jurisdiction && (
+            <Badge variant="outline" className="text-xs">
+              {row.jurisdiction}
+            </Badge>
+          )}
+          {date && (
+            <span className="text-xs text-muted-foreground">
+              {date.toISOString().slice(0, 10)}
+            </span>
+          )}
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function ResultList({
+  rows,
+  isLoading,
+}: {
+  rows: BaseSchemaFilterResultRow[];
+  isLoading: boolean;
+}) {
+  if (isLoading && rows.length === 0) {
+    return (
+      <div className="space-y-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-20 w-full rounded-lg" />
+        ))}
+      </div>
+    );
+  }
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed p-8 text-center">
+        <p className="text-sm text-muted-foreground">
+          No judgments match the current filters.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-3">
+      {rows.map((row) => (
+        <ResultRow key={row.id} row={row} />
+      ))}
+    </div>
+  );
+}
+
+function ExtractionSearchPage() {
+  const {
+    filters,
+    textQuery,
+    page,
+    pageSize,
+    setFilters,
+    setTextQuery,
+    setPage,
+    removeFilter,
+    clearAll,
+    activeCount,
+  } = useExtractedDataFilters();
+
+  const request = useMemo<BaseSchemaFilterRequest>(
+    () => ({
+      filters,
+      text_query: textQuery.trim() === "" ? undefined : textQuery.trim(),
+      limit: pageSize,
+      offset: (page - 1) * pageSize,
+    }),
+    [filters, textQuery, page, pageSize],
+  );
+
+  const { data, isLoading, isFetching, error } = useExtractionResults(request);
+  const rows = data?.documents ?? [];
+  const total = data?.total_count ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  const clearText = () => setTextQuery("");
+
+  return (
+    <div className="container mx-auto max-w-6xl px-4 py-6 space-y-4">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-bold">Search by extracted data</h1>
+        <p className="text-sm text-muted-foreground">
+          Filter judgments across the full extracted base schema. Combine
+          structured filters with free-text search.
+        </p>
+      </header>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <Input
+          placeholder="Search case names, judges, charges, courts…"
+          value={textQuery}
+          onChange={(e) => setTextQuery(e.target.value)}
+          className="flex-1"
+          aria-label="Full-text search"
+        />
+        <ExtractedFilterDrawer
+          filters={filters}
+          onChange={setFilters}
+          activeCount={activeCount}
+        />
+      </div>
+
+      <ActiveFilterChips
+        filters={filters}
+        textQuery={textQuery}
+        onRemove={removeFilter}
+        onClearText={clearText}
+        onClearAll={clearAll}
+      />
+
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          {isLoading
+            ? "Searching…"
+            : total === 0
+              ? "No results"
+              : `${total.toLocaleString()} judgment${total === 1 ? "" : "s"}`}
+          {isFetching && !isLoading && " (updating…)"}
+        </p>
+        {error && (
+          <Button variant="ghost" size="sm" onClick={() => clearAll()}>
+            Reset
+          </Button>
+        )}
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          {(error as Error).message}
+        </div>
+      )}
+
+      <ResultList rows={rows} isLoading={isLoading} />
+
+      {total > pageSize && (
+        <Pagination
+          currentPage={page}
+          totalPages={totalPages}
+          totalResults={total}
+          pageSize={pageSize}
+          onPageChange={setPage}
+          onPageSizeChange={() => undefined}
+          showPageSizeSelector={false}
+        />
+      )}
+    </div>
+  );
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={null}>
+      <ExtractionSearchPage />
+    </Suspense>
+  );
+}

--- a/frontend/components/filters/extracted-search-filters.tsx
+++ b/frontend/components/filters/extracted-search-filters.tsx
@@ -1,0 +1,630 @@
+"use client";
+
+import { CalendarIcon, ChevronDown, Filter, X } from "lucide-react";
+import * as React from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import {
+  FILTER_FIELD_BY_NAME,
+  FIELDS_BY_GROUP,
+  GROUP_LABELS,
+  GROUP_ORDER,
+  formatEnumLabel,
+  type FilterFieldConfig,
+} from "@/lib/extractions/base-schema-filter-config";
+import { useExtractionFacet } from "@/lib/extractions/base-schema-filter-api";
+import { cn } from "@/lib/utils";
+import type {
+  BaseSchemaFilters,
+  DateRange as DateRangeFilter,
+  FacetCount,
+  NumericRange,
+} from "@/types/base-schema-filter";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function isNumericRange(value: unknown): value is NumericRange {
+  return (
+    typeof value === "object" && value !== null && !Array.isArray(value) &&
+    ("min" in value || "max" in value)
+  );
+}
+
+function isDateRange(value: unknown): value is DateRangeFilter {
+  return (
+    typeof value === "object" && value !== null && !Array.isArray(value) &&
+    ("from" in value || "to" in value)
+  );
+}
+
+function parseISODate(value: string | undefined): Date | undefined {
+  if (!value) return undefined;
+  const d = new Date(value + "T00:00:00Z");
+  return Number.isNaN(d.getTime()) ? undefined : d;
+}
+
+function toISODate(d: Date | undefined): string | undefined {
+  if (!d) return undefined;
+  return d.toISOString().slice(0, 10);
+}
+
+// =============================================================================
+// Individual controls
+// =============================================================================
+
+interface ControlProps<T> {
+  config: FilterFieldConfig;
+  value: T | undefined;
+  onChange: (next: T | undefined) => void;
+}
+
+// ---- Enum multi-select ------------------------------------------------------
+
+function EnumMultiSelect({
+  config,
+  value,
+  onChange,
+  facets,
+}: ControlProps<string[]> & { facets?: FacetCount[] }) {
+  const selected = value ?? [];
+  const options = config.enumValues ?? [];
+
+  const toggle = (opt: string) => {
+    const next = selected.includes(opt)
+      ? selected.filter((v) => v !== opt)
+      : [...selected, opt];
+    onChange(next.length > 0 ? next : undefined);
+  };
+
+  return (
+    <div className="space-y-2 px-2">
+      {options.map((opt) => {
+        const count = facets?.find((f) => f.value === opt)?.count;
+        const id = `${config.field}-${opt}`;
+        return (
+          <div key={opt} className="flex items-center gap-2">
+            <Checkbox
+              id={id}
+              checked={selected.includes(opt)}
+              onCheckedChange={() => toggle(opt)}
+            />
+            <Label htmlFor={id} className="flex-1 cursor-pointer text-sm">
+              {formatEnumLabel(opt)}
+              {count !== undefined && (
+                <span className="ml-2 text-xs text-muted-foreground">
+                  ({count})
+                </span>
+              )}
+            </Label>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---- Free-text tag array (Enter to add, click X to remove) ------------------
+
+function TagArrayFilter({
+  config,
+  value,
+  onChange,
+}: ControlProps<string[]>) {
+  const [draft, setDraft] = React.useState("");
+  const tags = value ?? [];
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (!trimmed || tags.includes(trimmed)) {
+      setDraft("");
+      return;
+    }
+    onChange([...tags, trimmed]);
+    setDraft("");
+  };
+
+  const remove = (tag: string) => {
+    const next = tags.filter((t) => t !== tag);
+    onChange(next.length > 0 ? next : undefined);
+  };
+
+  return (
+    <div className="space-y-2 px-2">
+      <div className="flex gap-2">
+        <Input
+          placeholder={`Add ${config.label.toLowerCase()}…`}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commit();
+            }
+          }}
+          className="flex-1"
+        />
+        <Button size="sm" variant="outline" onClick={commit}>
+          Add
+        </Button>
+      </div>
+      {tags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {tags.map((tag) => (
+            <Badge key={tag} variant="secondary" className="gap-1">
+              {tag}
+              <button
+                onClick={() => remove(tag)}
+                className="hover:text-destructive"
+                aria-label={`Remove ${tag}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---- Boolean tri-state ------------------------------------------------------
+
+function BooleanTriState({
+  config,
+  value,
+  onChange,
+}: ControlProps<boolean>) {
+  const setVal = (next: boolean | undefined) => onChange(next);
+
+  const buttons: { label: string; val: boolean | undefined }[] = [
+    { label: "Any", val: undefined },
+    { label: "Yes", val: true },
+    { label: "No", val: false },
+  ];
+
+  return (
+    <div className="px-2 flex gap-1" role="radiogroup" aria-label={config.label}>
+      {buttons.map(({ label, val }) => {
+        const selected = value === val;
+        return (
+          <Button
+            key={label}
+            size="sm"
+            variant={selected ? "default" : "outline"}
+            onClick={() => setVal(val)}
+            role="radio"
+            aria-checked={selected}
+            className="flex-1"
+          >
+            {label}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---- Numeric range ----------------------------------------------------------
+
+function NumericRangeFilter({
+  config,
+  value,
+  onChange,
+}: ControlProps<number | NumericRange>) {
+  const min =
+    typeof value === "number"
+      ? value
+      : isNumericRange(value)
+        ? value.min
+        : undefined;
+  const max = isNumericRange(value) ? value.max : undefined;
+
+  const update = (nextMin: number | undefined, nextMax: number | undefined) => {
+    if (nextMin === undefined && nextMax === undefined) {
+      onChange(undefined);
+    } else if (nextMin !== undefined && nextMax === undefined && Number.isFinite(nextMin)) {
+      // fold to scalar equality only when explicitly requested via UI? keep range form for clarity
+      onChange({ min: nextMin });
+    } else {
+      onChange({ min: nextMin, max: nextMax });
+    }
+  };
+
+  return (
+    <div className="grid grid-cols-2 gap-2 px-2">
+      <div>
+        <Label className="text-xs text-muted-foreground">Min</Label>
+        <Input
+          type="number"
+          value={min ?? ""}
+          onChange={(e) =>
+            update(
+              e.target.value === "" ? undefined : Number(e.target.value),
+              max,
+            )
+          }
+          aria-label={`${config.label} minimum`}
+        />
+      </div>
+      <div>
+        <Label className="text-xs text-muted-foreground">Max</Label>
+        <Input
+          type="number"
+          value={max ?? ""}
+          onChange={(e) =>
+            update(
+              min,
+              e.target.value === "" ? undefined : Number(e.target.value),
+            )
+          }
+          aria-label={`${config.label} maximum`}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---- Date range -------------------------------------------------------------
+
+function DateRangeField({
+  config,
+  value,
+  onChange,
+}: ControlProps<string | DateRangeFilter>) {
+  const from =
+    typeof value === "string"
+      ? parseISODate(value)
+      : isDateRange(value)
+        ? parseISODate(value.from)
+        : undefined;
+  const to = isDateRange(value) ? parseISODate(value.to) : undefined;
+
+  const update = (nextFrom: Date | undefined, nextTo: Date | undefined) => {
+    const fromIso = toISODate(nextFrom);
+    const toIso = toISODate(nextTo);
+    if (!fromIso && !toIso) {
+      onChange(undefined);
+    } else {
+      onChange({ from: fromIso, to: toIso });
+    }
+  };
+
+  const label = (() => {
+    const parts: string[] = [];
+    if (from) parts.push(`from ${toISODate(from)}`);
+    if (to) parts.push(`to ${toISODate(to)}`);
+    return parts.length > 0 ? parts.join(" ") : `Pick ${config.label.toLowerCase()}`;
+  })();
+
+  return (
+    <div className="px-2">
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            className={cn("w-full justify-start text-left font-normal", !from && !to && "text-muted-foreground")}
+          >
+            <CalendarIcon className="mr-2 h-4 w-4" />
+            {label}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <Calendar
+            mode="range"
+            selected={{ from, to }}
+            onSelect={(range) => {
+              if (!range || range instanceof Date) {
+                update(undefined, undefined);
+                return;
+              }
+              update(range.from, range.to);
+            }}
+            numberOfMonths={2}
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+// ---- Substring (debounced ILIKE) -------------------------------------------
+
+function SubstringFilter({
+  config,
+  value,
+  onChange,
+}: ControlProps<string>) {
+  const [local, setLocal] = React.useState(value ?? "");
+
+  React.useEffect(() => {
+    setLocal(value ?? "");
+  }, [value]);
+
+  React.useEffect(() => {
+    const handle = setTimeout(() => {
+      const trimmed = local.trim();
+      if (trimmed === (value ?? "")) return;
+      onChange(trimmed === "" ? undefined : trimmed);
+    }, 300);
+    return () => clearTimeout(handle);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [local]);
+
+  return (
+    <div className="px-2">
+      <Input
+        placeholder={`Search ${config.label.toLowerCase()}…`}
+        value={local}
+        onChange={(e) => setLocal(e.target.value)}
+        aria-label={config.label}
+      />
+    </div>
+  );
+}
+
+// =============================================================================
+// Field row with collapsible header + active count
+// =============================================================================
+
+interface FieldRowProps {
+  config: FilterFieldConfig;
+  filters: BaseSchemaFilters;
+  onChange: (field: string, next: unknown) => void;
+}
+
+function describeActive(config: FilterFieldConfig, value: unknown): string | null {
+  if (value === undefined || value === null) return null;
+  if (Array.isArray(value)) {
+    return value.length > 0 ? `${value.length}` : null;
+  }
+  if (typeof value === "string") return value.trim() === "" ? null : "•";
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (typeof value === "number") return String(value);
+  if (isNumericRange(value)) {
+    const parts: string[] = [];
+    if (value.min !== undefined) parts.push(`≥${value.min}`);
+    if (value.max !== undefined) parts.push(`≤${value.max}`);
+    return parts.join(" ") || null;
+  }
+  if (isDateRange(value)) {
+    const parts: string[] = [];
+    if (value.from) parts.push(value.from);
+    if (value.to) parts.push(value.to);
+    return parts.length > 0 ? parts.join("→") : null;
+  }
+  return null;
+}
+
+function FieldRow({ config, filters, onChange }: FieldRowProps) {
+  const value = filters[config.field as keyof BaseSchemaFilters];
+  const [open, setOpen] = React.useState(false);
+  const facetQuery = useExtractionFacet(
+    config.control === "enum_multi" ? config.field : null,
+    open,
+  );
+  const activeBadge = describeActive(config, value);
+
+  const set = (next: unknown) => onChange(config.field, next);
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger className="flex w-full items-center justify-between rounded-md px-2 py-2 text-left text-sm font-medium hover:bg-muted/50">
+        <span>{config.label}</span>
+        <span className="flex items-center gap-2">
+          {activeBadge && (
+            <Badge variant="secondary" className="text-xs">
+              {activeBadge}
+            </Badge>
+          )}
+          <ChevronDown
+            className={cn("h-4 w-4 transition-transform", open && "rotate-180")}
+          />
+        </span>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="pt-2 pb-3">
+        {config.help && (
+          <p className="px-2 pb-2 text-xs text-muted-foreground">{config.help}</p>
+        )}
+        {config.control === "enum_multi" && (
+          <EnumMultiSelect
+            config={config}
+            value={value as string[] | undefined}
+            onChange={set}
+            facets={facetQuery.data}
+          />
+        )}
+        {config.control === "tag_array" && (
+          <TagArrayFilter
+            config={config}
+            value={value as string[] | undefined}
+            onChange={set}
+          />
+        )}
+        {config.control === "boolean_tri" && (
+          <BooleanTriState
+            config={config}
+            value={value as boolean | undefined}
+            onChange={set}
+          />
+        )}
+        {config.control === "numeric_range" && (
+          <NumericRangeFilter
+            config={config}
+            value={value as number | NumericRange | undefined}
+            onChange={set}
+          />
+        )}
+        {config.control === "date_range" && (
+          <DateRangeField
+            config={config}
+            value={value as string | DateRangeFilter | undefined}
+            onChange={set}
+          />
+        )}
+        {config.control === "substring" && (
+          <SubstringFilter
+            config={config}
+            value={value as string | undefined}
+            onChange={set}
+          />
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+// =============================================================================
+// Drawer composition: groups all 42 fields into themed sections
+// =============================================================================
+
+interface FilterDrawerProps {
+  filters: BaseSchemaFilters;
+  onChange: (filters: BaseSchemaFilters) => void;
+  activeCount: number;
+}
+
+export function ExtractedFilterDrawer({
+  filters,
+  onChange,
+  activeCount,
+}: FilterDrawerProps) {
+  const setField = (field: string, value: unknown) => {
+    const next = { ...filters };
+    if (value === undefined) {
+      delete (next as Record<string, unknown>)[field];
+    } else {
+      (next as Record<string, unknown>)[field] = value;
+    }
+    onChange(next);
+  };
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline" className="gap-2">
+          <Filter className="h-4 w-4" />
+          Filters
+          {activeCount > 0 && (
+            <Badge variant="secondary" className="ml-1">
+              {activeCount}
+            </Badge>
+          )}
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right" className="w-full sm:max-w-md p-0">
+        <SheetHeader className="border-b p-4">
+          <SheetTitle>Advanced filters</SheetTitle>
+        </SheetHeader>
+        <ScrollArea className="h-[calc(100vh-7rem)]">
+          <div className="p-4 space-y-4">
+            {GROUP_ORDER.map((group, idx) => {
+              const fields = FIELDS_BY_GROUP[group];
+              if (!fields || fields.length === 0) return null;
+              return (
+                <div key={group}>
+                  {idx > 0 && <Separator className="my-2" />}
+                  <h4 className="px-2 mb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                    {GROUP_LABELS[group]}
+                  </h4>
+                  {fields.map((c) => (
+                    <FieldRow
+                      key={c.field}
+                      config={c}
+                      filters={filters}
+                      onChange={setField}
+                    />
+                  ))}
+                </div>
+              );
+            })}
+          </div>
+        </ScrollArea>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// =============================================================================
+// Active-filter chips — sit above results, click X to remove
+// =============================================================================
+
+interface ActiveChipsProps {
+  filters: BaseSchemaFilters;
+  textQuery: string;
+  onRemove: (field: keyof BaseSchemaFilters) => void;
+  onClearText: () => void;
+  onClearAll: () => void;
+}
+
+export function ActiveFilterChips({
+  filters,
+  textQuery,
+  onRemove,
+  onClearText,
+  onClearAll,
+}: ActiveChipsProps) {
+  const entries = Object.entries(filters) as [keyof BaseSchemaFilters, unknown][];
+  const hasText = textQuery.trim() !== "";
+  if (entries.length === 0 && !hasText) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {hasText && (
+        <Badge variant="secondary" className="gap-1">
+          <span className="text-xs text-muted-foreground">text:</span>
+          <span className="font-medium">{textQuery}</span>
+          <button onClick={onClearText} aria-label="Clear text query" className="hover:text-destructive">
+            <X className="h-3 w-3" />
+          </button>
+        </Badge>
+      )}
+      {entries.map(([field, value]) => {
+        const config = FILTER_FIELD_BY_NAME[field];
+        const desc = config ? describeActive(config, value) : null;
+        if (!desc) return null;
+        return (
+          <Badge key={field} variant="secondary" className="gap-1">
+            <span className="font-medium">{config?.label ?? field}:</span>
+            <span>{desc}</span>
+            <button
+              onClick={() => onRemove(field)}
+              aria-label={`Remove ${config?.label ?? field}`}
+              className="hover:text-destructive"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </Badge>
+        );
+      })}
+      <Button variant="ghost" size="sm" onClick={onClearAll} className="text-xs">
+        Clear all
+      </Button>
+    </div>
+  );
+}

--- a/frontend/lib/extractions/base-schema-filter-api.ts
+++ b/frontend/lib/extractions/base-schema-filter-api.ts
@@ -1,0 +1,80 @@
+// =============================================================================
+// API client + React Query hooks for the base-schema filter surface.
+//
+// Routes:
+//   POST /api/extractions/base-schema/filter         — filtered judgment list
+//   GET  /api/extractions/base-schema/facets/[field] — facet counts per field
+//
+// The Next.js routes proxy to the FastAPI backend, which calls the Postgres
+// RPC `filter_documents_by_extracted_data` (extended in
+// supabase/migrations/20260505000001_*).
+// =============================================================================
+
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import type {
+  BaseSchemaFilterRequest,
+  BaseSchemaFilterResponse,
+  FacetCount,
+} from "@/types/base-schema-filter";
+
+const FILTER_URL = "/api/extractions/base-schema/filter";
+const FACETS_URL = "/api/extractions/base-schema/facets";
+
+async function postFilter(
+  request: BaseSchemaFilterRequest,
+  signal?: AbortSignal,
+): Promise<BaseSchemaFilterResponse> {
+  const response = await fetch(FILTER_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+    signal,
+  });
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(`Filter request failed (${response.status}): ${detail}`);
+  }
+  return (await response.json()) as BaseSchemaFilterResponse;
+}
+
+async function fetchFacet(
+  field: string,
+  signal?: AbortSignal,
+): Promise<FacetCount[]> {
+  const response = await fetch(`${FACETS_URL}/${encodeURIComponent(field)}`, {
+    signal,
+  });
+  if (!response.ok) {
+    if (response.status === 404) return [];
+    throw new Error(`Facet fetch failed for ${field}: ${response.status}`);
+  }
+  const json = (await response.json()) as { facets?: FacetCount[] } | FacetCount[];
+  return Array.isArray(json) ? json : (json.facets ?? []);
+}
+
+/** Filtered list of judgments. Cached for 30s; results table-friendly. */
+export function useExtractionResults(
+  request: BaseSchemaFilterRequest,
+  enabled: boolean = true,
+) {
+  return useQuery({
+    queryKey: ["base-schema-filter", request],
+    queryFn: ({ signal }) => postFilter(request, signal),
+    enabled,
+    staleTime: 30_000,
+    placeholderData: (prev) => prev,
+  });
+}
+
+/** Facet counts for one field. Cached longer — values shift slowly. */
+export function useExtractionFacet(field: string | null, enabled: boolean = true) {
+  return useQuery({
+    queryKey: ["base-schema-facet", field],
+    queryFn: ({ signal }) => fetchFacet(field as string, signal),
+    enabled: enabled && Boolean(field),
+    staleTime: 5 * 60_000,
+  });
+}

--- a/frontend/lib/extractions/base-schema-filter-config.ts
+++ b/frontend/lib/extractions/base-schema-filter-config.ts
@@ -1,0 +1,445 @@
+// =============================================================================
+// Registry of every base_* extraction field surfaced by the filter UI.
+//
+// Single source of truth for: human label, semantic group, control type,
+// underlying enum values. The /search/extractions page iterates this list
+// when rendering grouped sections of the advanced-filter drawer; the URL
+// serialiser uses `control` to decide how to encode each field.
+//
+// Mirrors the migration's CHECK constraints (supabase/migrations/
+// 20260226000001_create_judgment_base_extractions_table.sql) and the Pydantic
+// model in backend/app/extraction_domain/nl_filter_generator.py.
+// =============================================================================
+
+export type FilterGroup =
+  | "offender"
+  | "victim"
+  | "charges_plea"
+  | "sentence"
+  | "appeal"
+  | "court_date"
+  | "evidence"
+  | "other";
+
+export type FilterControl =
+  | "enum_multi"        // multi-select over fixed enum values, RPC ANY/&&
+  | "tag_array"         // free-text array, RPC && — values discovered via facets
+  | "boolean_tri"       // tri-state: true / false / unset
+  | "numeric_range"     // {min,max} or scalar equality
+  | "date_range"        // {from,to} ISO dates
+  | "substring";        // ILIKE substring match
+
+export interface FilterFieldConfig {
+  /** RPC field name (matches `BaseSchemaFilters` key in types/base-schema-filter.ts). */
+  field: string;
+  /** Human label shown in the UI. */
+  label: string;
+  /** Short helper hint surfaced under the control. */
+  help?: string;
+  group: FilterGroup;
+  control: FilterControl;
+  /** Allowed values for enum controls. Undefined for free-text arrays. */
+  enumValues?: readonly string[];
+}
+
+export const GROUP_LABELS: Record<FilterGroup, string> = {
+  offender: "Offender",
+  victim: "Victim",
+  charges_plea: "Charges & Plea",
+  sentence: "Sentence",
+  appeal: "Appeal",
+  court_date: "Court & Date",
+  evidence: "Evidence & Reasons",
+  other: "Other",
+};
+
+/** Order groups appear in the drawer. */
+export const GROUP_ORDER: readonly FilterGroup[] = [
+  "court_date",
+  "offender",
+  "victim",
+  "charges_plea",
+  "sentence",
+  "appeal",
+  "evidence",
+  "other",
+] as const;
+
+// -----------------------------------------------------------------------------
+// Enum option lists (must mirror migration CHECK constraints).
+// -----------------------------------------------------------------------------
+
+const APPELLANT = ["offender", "attorney_general", "other"] as const;
+const PLEA_POINT = [
+  "police_presence",
+  "first_court_appearance",
+  "before_trial",
+  "first_day_of_trial",
+  "after_first_day_of_trial",
+  "dont_know",
+] as const;
+const REMAND_DECISION = [
+  "unconditional_bail",
+  "conditional_bail",
+  "remanded_in_custody",
+  "dont_know",
+] as const;
+const SENTENCE_SERVE = [
+  "serve_concurrent",
+  "serve_consecutive",
+  "serve_unknown",
+] as const;
+const GENDER = ["gender_male", "gender_female", "gender_unknown"] as const;
+const INTOXICATION = ["intox_alcohol", "intox_drugs", "intox_unknown"] as const;
+const VICTIM_TYPE = ["individual_person", "organisation"] as const;
+const PRE_SENT_REPORT = ["low", "medium", "high", "dont_know"] as const;
+const OFFENDER_JOB = [
+  "employed",
+  "self_employed",
+  "unemployed",
+  "student",
+  "retired",
+  "other",
+  "dont_know",
+] as const;
+const OFFENDER_HOME = [
+  "fixed_address",
+  "homeless",
+  "temporary_accommodation",
+  "dont_know",
+] as const;
+const OFFENDER_VICTIM_REL = [
+  "stranger",
+  "relative",
+  "acquaintance",
+  "dont_know",
+] as const;
+const APPEAL_AGAINST = [
+  "appeal_conviction_unsafe",
+  "appeal_sentence_excessive",
+  "appeal_sentence_lenient",
+  "appeal_other",
+  "appeal_unknown",
+] as const;
+const APPEAL_OUTCOME = [
+  "outcome_dismissed_or_refused",
+  "outcome_conviction_quashed",
+  "outcome_sentence_more_severe",
+  "outcome_sentence_more_lenient",
+  "outcome_other",
+  "outcome_unknown",
+] as const;
+
+// -----------------------------------------------------------------------------
+// Field registry. Every key in `BaseSchemaFilters` must appear here exactly
+// once. Order within a group drives display order in the drawer.
+// -----------------------------------------------------------------------------
+
+export const FILTER_FIELDS: readonly FilterFieldConfig[] = [
+  // --- court_date ----------------------------------------------------------
+  {
+    field: "case_name",
+    label: "Case name",
+    help: "Substring match (ILIKE).",
+    group: "court_date",
+    control: "substring",
+  },
+  {
+    field: "neutral_citation_number",
+    label: "Neutral citation",
+    help: "Substring match.",
+    group: "court_date",
+    control: "substring",
+  },
+  {
+    field: "appeal_court_judges_names",
+    label: "Judges",
+    help: "Substring match against judge names.",
+    group: "court_date",
+    control: "substring",
+  },
+  {
+    field: "offender_representative_name",
+    label: "Offender representative",
+    help: "Substring match.",
+    group: "court_date",
+    control: "substring",
+  },
+  {
+    field: "date_of_appeal_court_judgment",
+    label: "Date of appeal judgment",
+    group: "court_date",
+    control: "date_range",
+  },
+  {
+    field: "case_number",
+    label: "Case number",
+    group: "court_date",
+    control: "numeric_range",
+  },
+
+  // --- offender ------------------------------------------------------------
+  {
+    field: "offender_gender",
+    label: "Gender",
+    group: "offender",
+    control: "enum_multi",
+    enumValues: GENDER,
+  },
+  {
+    field: "offender_intox_offence",
+    label: "Intoxication at offence",
+    group: "offender",
+    control: "enum_multi",
+    enumValues: INTOXICATION,
+  },
+  {
+    field: "offender_job_offence",
+    label: "Employment status",
+    group: "offender",
+    control: "enum_multi",
+    enumValues: OFFENDER_JOB,
+  },
+  {
+    field: "offender_home_offence",
+    label: "Accommodation status",
+    group: "offender",
+    control: "enum_multi",
+    enumValues: OFFENDER_HOME,
+  },
+  {
+    field: "offender_victim_relationship",
+    label: "Relationship to victim",
+    group: "offender",
+    control: "enum_multi",
+    enumValues: OFFENDER_VICTIM_REL,
+  },
+  {
+    field: "co_def_acc_num",
+    label: "Co-defendants count",
+    help: "Number of co-defendants accused.",
+    group: "offender",
+    control: "numeric_range",
+  },
+  {
+    field: "did_offender_confess",
+    label: "Offender confessed",
+    group: "offender",
+    control: "boolean_tri",
+  },
+
+  // --- victim --------------------------------------------------------------
+  {
+    field: "victim_type",
+    label: "Victim type",
+    group: "victim",
+    control: "enum_multi",
+    enumValues: VICTIM_TYPE,
+  },
+  {
+    field: "victim_gender",
+    label: "Victim gender",
+    group: "victim",
+    control: "enum_multi",
+    enumValues: GENDER,
+  },
+  {
+    field: "victim_intox_offence",
+    label: "Victim intoxication",
+    group: "victim",
+    control: "enum_multi",
+    enumValues: INTOXICATION,
+  },
+  {
+    field: "num_victims",
+    label: "Number of victims",
+    group: "victim",
+    control: "numeric_range",
+  },
+  {
+    field: "victim_age_offence",
+    label: "Victim age at offence",
+    group: "victim",
+    control: "numeric_range",
+  },
+  {
+    field: "vic_impact_statement",
+    label: "Victim impact statement filed",
+    group: "victim",
+    control: "boolean_tri",
+  },
+
+  // --- charges_plea --------------------------------------------------------
+  {
+    field: "convict_offences",
+    label: "Convicted offences",
+    group: "charges_plea",
+    control: "tag_array",
+  },
+  {
+    field: "acquit_offences",
+    label: "Acquitted offences",
+    group: "charges_plea",
+    control: "tag_array",
+  },
+  {
+    field: "plea_point",
+    label: "Plea point",
+    group: "charges_plea",
+    control: "enum_multi",
+    enumValues: PLEA_POINT,
+  },
+  {
+    field: "remand_decision",
+    label: "Remand decision",
+    group: "charges_plea",
+    control: "enum_multi",
+    enumValues: REMAND_DECISION,
+  },
+  {
+    field: "convict_plea_dates",
+    label: "Conviction / plea dates",
+    group: "charges_plea",
+    control: "tag_array",
+  },
+
+  // --- sentence ------------------------------------------------------------
+  {
+    field: "sentences_received",
+    label: "Sentences received",
+    group: "sentence",
+    control: "tag_array",
+  },
+  {
+    field: "sentence_serve",
+    label: "Serve mode",
+    group: "sentence",
+    control: "enum_multi",
+    enumValues: SENTENCE_SERVE,
+  },
+  {
+    field: "what_ancilliary_orders",
+    label: "Ancillary orders",
+    group: "sentence",
+    control: "tag_array",
+  },
+  {
+    field: "agg_fact_sent",
+    label: "Aggravating factors",
+    group: "sentence",
+    control: "tag_array",
+  },
+  {
+    field: "mit_fact_sent",
+    label: "Mitigating factors",
+    group: "sentence",
+    control: "tag_array",
+  },
+  {
+    field: "sent_guide_which",
+    label: "Sentencing guidelines cited",
+    group: "sentence",
+    control: "tag_array",
+  },
+  {
+    field: "pre_sent_report",
+    label: "Pre-sentence report risk",
+    group: "sentence",
+    control: "enum_multi",
+    enumValues: PRE_SENT_REPORT,
+  },
+
+  // --- appeal --------------------------------------------------------------
+  {
+    field: "appellant",
+    label: "Appellant",
+    group: "appeal",
+    control: "enum_multi",
+    enumValues: APPELLANT,
+  },
+  {
+    field: "appeal_against",
+    label: "Appeal against",
+    group: "appeal",
+    control: "enum_multi",
+    enumValues: APPEAL_AGAINST,
+  },
+  {
+    field: "appeal_outcome",
+    label: "Appeal outcome",
+    group: "appeal",
+    control: "enum_multi",
+    enumValues: APPEAL_OUTCOME,
+  },
+  {
+    field: "appeal_ground",
+    label: "Appeal grounds",
+    group: "appeal",
+    control: "tag_array",
+  },
+
+  // --- evidence ------------------------------------------------------------
+  {
+    field: "pros_evid_type_trial",
+    label: "Prosecution evidence types",
+    group: "evidence",
+    control: "tag_array",
+  },
+  {
+    field: "def_evid_type_trial",
+    label: "Defence evidence types",
+    group: "evidence",
+    control: "tag_array",
+  },
+  {
+    field: "reason_quash_conv",
+    label: "Reasons conviction quashed",
+    group: "evidence",
+    control: "tag_array",
+  },
+  {
+    field: "reason_sent_excessive",
+    label: "Reasons sentence excessive",
+    group: "evidence",
+    control: "tag_array",
+  },
+  {
+    field: "reason_sent_lenient",
+    label: "Reasons sentence lenient",
+    group: "evidence",
+    control: "tag_array",
+  },
+  {
+    field: "reason_dismiss",
+    label: "Reasons appeal dismissed",
+    group: "evidence",
+    control: "tag_array",
+  },
+
+  // --- other ---------------------------------------------------------------
+  {
+    field: "keywords",
+    label: "Keywords",
+    group: "other",
+    control: "tag_array",
+  },
+] as const;
+
+/** Quick lookup by field name. */
+export const FILTER_FIELD_BY_NAME: Record<string, FilterFieldConfig> =
+  Object.fromEntries(FILTER_FIELDS.map((c) => [c.field, c]));
+
+/** Fields grouped for display, in `GROUP_ORDER`. */
+export const FIELDS_BY_GROUP: Record<FilterGroup, FilterFieldConfig[]> =
+  GROUP_ORDER.reduce(
+    (acc, g) => {
+      acc[g] = FILTER_FIELDS.filter((c) => c.group === g);
+      return acc;
+    },
+    {} as Record<FilterGroup, FilterFieldConfig[]>,
+  );
+
+/** Format a snake_case enum value for display ("gender_male" → "Gender male"). */
+export function formatEnumLabel(value: string): string {
+  return value.replace(/_/g, " ").replace(/^\w/, (c) => c.toUpperCase());
+}

--- a/frontend/lib/extractions/use-extracted-data-filters.ts
+++ b/frontend/lib/extractions/use-extracted-data-filters.ts
@@ -1,0 +1,178 @@
+// =============================================================================
+// Filter-state hook for /search/extractions.
+//
+// Owns BaseSchemaFilters + textQuery + page + pageSize. Persists state in the
+// URL using two query params:
+//
+//   ?q=<text>           — full-text query (mirrors RPC `text_query`)
+//   ?f=<base64-json>    — opaque blob holding the structured filters
+//   ?page=<n>           — 1-based page (default 1)
+//
+// The blob is opaque on purpose: the field set is wide (42 keys) and any
+// schema growth would force a URL-format migration if we encoded each field
+// individually. A base64-JSON blob round-trips cleanly and stays compact for
+// realistic filter combinations (~30–80 chars).
+// =============================================================================
+
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type { BaseSchemaFilters } from "@/types/base-schema-filter";
+
+const DEFAULT_PAGE_SIZE = 25;
+
+interface FilterState {
+  filters: BaseSchemaFilters;
+  textQuery: string;
+  page: number;
+}
+
+interface UseExtractedDataFiltersResult extends FilterState {
+  pageSize: number;
+  setFilters: (next: BaseSchemaFilters) => void;
+  setTextQuery: (next: string) => void;
+  setPage: (page: number) => void;
+  removeFilter: (field: keyof BaseSchemaFilters) => void;
+  clearAll: () => void;
+  /** Active filter count (excludes empty arrays / empty strings). */
+  activeCount: number;
+}
+
+// -----------------------------------------------------------------------------
+// URL <-> state helpers (exported for tests).
+// -----------------------------------------------------------------------------
+
+export function encodeFilters(filters: BaseSchemaFilters): string {
+  const cleaned = pruneEmpty(filters);
+  if (Object.keys(cleaned).length === 0) return "";
+  const json = JSON.stringify(cleaned);
+  if (typeof window === "undefined") {
+    return Buffer.from(json, "utf-8").toString("base64url");
+  }
+  return btoa(unescape(encodeURIComponent(json)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+export function decodeFilters(blob: string | null | undefined): BaseSchemaFilters {
+  if (!blob) return {};
+  try {
+    const padded = blob.replace(/-/g, "+").replace(/_/g, "/");
+    const json =
+      typeof window === "undefined"
+        ? Buffer.from(padded, "base64").toString("utf-8")
+        : decodeURIComponent(escape(atob(padded)));
+    const parsed = JSON.parse(json);
+    return typeof parsed === "object" && parsed !== null ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function pruneEmpty(filters: BaseSchemaFilters): BaseSchemaFilters {
+  const out: BaseSchemaFilters = {};
+  for (const [key, value] of Object.entries(filters) as [
+    keyof BaseSchemaFilters,
+    unknown,
+  ][]) {
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value) && value.length === 0) continue;
+    if (typeof value === "string" && value.trim() === "") continue;
+    if (
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      Object.keys(value as object).length === 0
+    ) {
+      continue;
+    }
+    // assignment is safe — pruneEmpty preserves the original key/value types
+    (out as Record<string, unknown>)[key] = value;
+  }
+  return out;
+}
+
+export function countActive(filters: BaseSchemaFilters): number {
+  return Object.keys(pruneEmpty(filters)).length;
+}
+
+// -----------------------------------------------------------------------------
+// Hook
+// -----------------------------------------------------------------------------
+
+export function useExtractedDataFilters(): UseExtractedDataFiltersResult {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const initial = useMemo<FilterState>(
+    () => ({
+      filters: decodeFilters(searchParams.get("f")),
+      textQuery: searchParams.get("q") ?? "",
+      page: Math.max(1, Number(searchParams.get("page") ?? "1") || 1),
+    }),
+    // intentionally only on mount; later updates use writeUrl
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  const [state, setState] = useState<FilterState>(initial);
+
+  const writeUrl = useCallback(
+    (next: FilterState) => {
+      const params = new URLSearchParams();
+      const blob = encodeFilters(next.filters);
+      if (blob) params.set("f", blob);
+      if (next.textQuery.trim() !== "") params.set("q", next.textQuery.trim());
+      if (next.page > 1) params.set("page", String(next.page));
+      const queryString = params.toString();
+      const url = queryString ? `?${queryString}` : window.location.pathname;
+      router.replace(url, { scroll: false });
+    },
+    [router],
+  );
+
+  // Sync URL whenever state changes after the initial render.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    writeUrl(state);
+  }, [state, writeUrl]);
+
+  const setFilters = useCallback((next: BaseSchemaFilters) => {
+    setState((prev) => ({ ...prev, filters: pruneEmpty(next), page: 1 }));
+  }, []);
+
+  const setTextQuery = useCallback((next: string) => {
+    setState((prev) => ({ ...prev, textQuery: next, page: 1 }));
+  }, []);
+
+  const setPage = useCallback((page: number) => {
+    setState((prev) => ({ ...prev, page: Math.max(1, page) }));
+  }, []);
+
+  const removeFilter = useCallback((field: keyof BaseSchemaFilters) => {
+    setState((prev) => {
+      const nextFilters = { ...prev.filters };
+      delete nextFilters[field];
+      return { ...prev, filters: nextFilters, page: 1 };
+    });
+  }, []);
+
+  const clearAll = useCallback(() => {
+    setState((prev) => ({ ...prev, filters: {}, textQuery: "", page: 1 }));
+  }, []);
+
+  const activeCount = useMemo(() => countActive(state.filters), [state.filters]);
+
+  return {
+    ...state,
+    pageSize: DEFAULT_PAGE_SIZE,
+    setFilters,
+    setTextQuery,
+    setPage,
+    removeFilter,
+    clearAll,
+    activeCount,
+  };
+}

--- a/frontend/types/base-schema-filter.ts
+++ b/frontend/types/base-schema-filter.ts
@@ -1,0 +1,190 @@
+// =============================================================================
+// TS mirror of `BaseSchemaFilter` (backend/app/extraction_domain/nl_filter_generator.py)
+// and the parameters of the Postgres RPC `filter_documents_by_extracted_data`
+// (supabase/migrations/20260226000001_* + 20260505000001_*).
+//
+// Keep enum unions in sync with CHECK constraints in the migration. The
+// frontend filter UI uses these types as the single source of truth — the
+// React hook serialises them to JSON, the Next.js API route POSTs them to the
+// FastAPI proxy, and the RPC interprets them.
+// =============================================================================
+
+export type Appellant = "offender" | "attorney_general" | "other";
+
+export type PleaPoint =
+  | "police_presence"
+  | "first_court_appearance"
+  | "before_trial"
+  | "first_day_of_trial"
+  | "after_first_day_of_trial"
+  | "dont_know";
+
+export type RemandDecision =
+  | "unconditional_bail"
+  | "conditional_bail"
+  | "remanded_in_custody"
+  | "dont_know";
+
+export type SentenceServe =
+  | "serve_concurrent"
+  | "serve_consecutive"
+  | "serve_unknown";
+
+export type Gender = "gender_male" | "gender_female" | "gender_unknown";
+
+export type Intoxication = "intox_alcohol" | "intox_drugs" | "intox_unknown";
+
+export type VictimType = "individual_person" | "organisation";
+
+export type PreSentReport = "low" | "medium" | "high" | "dont_know";
+
+export type OffenderJob =
+  | "employed"
+  | "self_employed"
+  | "unemployed"
+  | "student"
+  | "retired"
+  | "other"
+  | "dont_know";
+
+export type OffenderHome =
+  | "fixed_address"
+  | "homeless"
+  | "temporary_accommodation"
+  | "dont_know";
+
+export type OffenderVictimRel =
+  | "stranger"
+  | "relative"
+  | "acquaintance"
+  | "dont_know";
+
+export type AppealAgainst =
+  | "appeal_conviction_unsafe"
+  | "appeal_sentence_excessive"
+  | "appeal_sentence_lenient"
+  | "appeal_other"
+  | "appeal_unknown";
+
+export type AppealOutcome =
+  | "outcome_dismissed_or_refused"
+  | "outcome_conviction_quashed"
+  | "outcome_sentence_more_severe"
+  | "outcome_sentence_more_lenient"
+  | "outcome_other"
+  | "outcome_unknown";
+
+// -----------------------------------------------------------------------------
+// Range helpers — match the JSONB shapes the RPC accepts.
+// -----------------------------------------------------------------------------
+
+export interface NumericRange {
+  min?: number;
+  max?: number;
+}
+
+export interface DateRange {
+  /** Inclusive ISO date YYYY-MM-DD. Mapped to RPC `from`. */
+  from?: string;
+  /** Inclusive ISO date YYYY-MM-DD. */
+  to?: string;
+}
+
+// -----------------------------------------------------------------------------
+// Top-level filter object — mirrors Pydantic BaseSchemaFilter.
+// All keys optional; absent keys mean "no filter on this field".
+// -----------------------------------------------------------------------------
+
+export interface BaseSchemaFilters {
+  // scalar enums (IN-list)
+  appellant?: Appellant[];
+  plea_point?: PleaPoint[];
+  remand_decision?: RemandDecision[];
+  victim_type?: VictimType[];
+  pre_sent_report?: PreSentReport[];
+  offender_job_offence?: OffenderJob[];
+  offender_home_offence?: OffenderHome[];
+  offender_victim_relationship?: OffenderVictimRel[];
+
+  // multi-value enums (array overlap)
+  appeal_against?: AppealAgainst[];
+  appeal_outcome?: AppealOutcome[];
+  sentence_serve?: SentenceServe[];
+  offender_gender?: Gender[];
+  offender_intox_offence?: Intoxication[];
+  victim_gender?: Gender[];
+  victim_intox_offence?: Intoxication[];
+
+  // free-text array overlap
+  keywords?: string[];
+  convict_offences?: string[];
+  acquit_offences?: string[];
+  appeal_ground?: string[];
+  sentences_received?: string[];
+  what_ancilliary_orders?: string[];
+  pros_evid_type_trial?: string[];
+  def_evid_type_trial?: string[];
+  agg_fact_sent?: string[];
+  mit_fact_sent?: string[];
+  sent_guide_which?: string[];
+  reason_quash_conv?: string[];
+  reason_sent_excessive?: string[];
+  reason_sent_lenient?: string[];
+  reason_dismiss?: string[];
+  convict_plea_dates?: string[];
+
+  // booleans
+  did_offender_confess?: boolean;
+  vic_impact_statement?: boolean;
+
+  // numerics (eq or range)
+  num_victims?: number | NumericRange;
+  case_number?: number | NumericRange;
+  victim_age_offence?: number | NumericRange;
+  co_def_acc_num?: number | NumericRange;
+
+  // date
+  date_of_appeal_court_judgment?: string | DateRange;
+
+  // substring (ILIKE)
+  case_name?: string;
+  neutral_citation_number?: string;
+  appeal_court_judges_names?: string;
+  offender_representative_name?: string;
+}
+
+// -----------------------------------------------------------------------------
+// Wire shape sent to /api/extractions/base-schema/filter.
+// -----------------------------------------------------------------------------
+
+export interface BaseSchemaFilterRequest {
+  filters: BaseSchemaFilters;
+  text_query?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface BaseSchemaFilterResultRow {
+  id: string;
+  case_number: string | null;
+  title: string | null;
+  jurisdiction: string | null;
+  decision_date: string | null;
+  extracted_data: Record<string, unknown>;
+}
+
+export interface BaseSchemaFilterResponse {
+  documents: BaseSchemaFilterResultRow[];
+  total_count: number;
+  limit: number;
+  offset: number;
+}
+
+// -----------------------------------------------------------------------------
+// Facet count shape (returned by /api/extractions/base-schema/facets/[field]).
+// -----------------------------------------------------------------------------
+
+export interface FacetCount {
+  value: string;
+  count: number;
+}


### PR DESCRIPTION
## Summary

- Adds **/search/extractions** page with a hybrid layout: persistent full-text search bar, advanced-filter drawer for all 42 `base_*` extraction fields, active-filter chips, paginated results.
- All 42 RPC parameters of `filter_documents_by_extracted_data` are now reachable through a deterministic UI — no LLM-transpiled query layer in the user path.
- Single registry (`lib/extractions/base-schema-filter-config.ts`) drives the drawer; types in `types/base-schema-filter.ts` mirror the Pydantic `BaseSchemaFilter` from #137.

## Why form-first instead of NL → filter

Domain is finite (42 fields, 13 enum sets with CHECK constraints in the migration), users are mostly legal researchers who benefit from seeing the schema. A form is more discoverable, debuggable, faster, and shareable via URL. The NL generator added in #137 is preserved for a future opt-in "paste your question" shortcut — not as the primary path.

## Components

| File | Role |
|---|---|
| `app/search/extractions/page.tsx` | Page composition. |
| `components/filters/extracted-search-filters.tsx` | All filter primitives (`EnumMultiSelect`, `TagArrayFilter`, `BooleanTriState`, `NumericRangeFilter`, `DateRangeField`, `SubstringFilter`) + drawer + active chips. |
| `lib/extractions/use-extracted-data-filters.ts` | Filter state + URL ↔ state codec. |
| `lib/extractions/base-schema-filter-api.ts` | React Query wrappers for filter + facet endpoints. |
| `lib/extractions/base-schema-filter-config.ts` | Registry of all 42 fields with group / control / enum options. |
| `types/base-schema-filter.ts` | TS mirror of the Pydantic shape. |

## Notable design choices

- **Boolean tri-state** (Any / Yes / No) maps to `undefined / true / false`. The migration's partial indexes only cover `TRUE`, so a real-world "show me cases where the offender did not confess" still scans, but is rare enough not to warrant a second partial index.
- **URL state via opaque base64-JSON blob** in `?f=…`. Field-prefixed query params would be prettier but every schema growth would force a URL migration; ~30–80 chars compact stays well under URL length limits.
- **Facets are lazy** — only fetched when a section is expanded; React Query caches them for 5 min.

## Stack order

This PR depends on #137 (migration + RPC + Pydantic generator). When #137 lands, this branch auto-narrows to just the UI changes.

## Out of scope (intentional)

- Quick-filters strip above the drawer.
- Numeric distribution histograms / range sliders.
- LLM-assisted form fill (uses #137's `generate_base_schema_filter`).
- Playwright E2E (requires seeded extracted-data fixtures).

## Test plan

- [x] 16 new Jest tests (registry sanity + URL codec round-trip).
- [x] 591/591 lib suite green.
- [x] `npx tsc --noEmit` clean on new files (16 pre-existing errors in `schema-editor/service.test.ts` are unrelated).
- [x] `npx eslint` clean on new files.
- [ ] Manual: open `/search/extractions`, expand a few groups, apply enum + numeric range + boolean filters, copy URL, paste in incognito → state restored.
- [ ] Manual: confirm RPC indexes get hit (`EXPLAIN ANALYZE` of generated query) on representative dataset.