### PR TITLE
fix(ci): unblock dependency audit + frontend e2e on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: frontend-build
-          path: frontend/
+          # The artifact preserves full paths (frontend/.next/, frontend/public/, …)
+          # so we must download to the repo root. Downloading to `frontend/` would
+          # produce `frontend/frontend/.next/` and `next start` wouldn't find the build.
+          path: .
 
       - name: Install Playwright browsers
         working-directory: frontend
@@ -378,7 +381,13 @@ jobs:
 
       - name: Export requirements
         working-directory: backend
-        run: poetry export -f requirements.txt --without-hashes -o /tmp/requirements.txt
+        run: |
+          # Strip editable local-path packages (`-e file:///...`) — pip-audit
+          # tries to install them and the absolute paths from `poetry export`
+          # don't exist on the runner. Their deps are already covered by the
+          # exported pinned third-party packages.
+          poetry export -f requirements.txt --without-hashes -o /tmp/requirements.raw.txt
+          grep -v '^-e ' /tmp/requirements.raw.txt > /tmp/requirements.txt
 
       - name: Audit Python dependencies (blocking on HIGH/CRITICAL)
         id: backend_audit


### PR DESCRIPTION
## Summary

Follow-up to #152 — fixes the two non-required jobs that still failed on the post-merge `main` CI run (https://github.com/pwr-ai/juddges-app/actions/runs/25368708674).

## Fixes

**Backend Dependency Audit**
\`pip-audit\` exited \`ResolutionImpossible\` because \`poetry export\` emits editable local-path packages (\`-e file:///home/laugustyniak/...\`) and pip tried to install them. Those absolute paths don't exist on the runner. Filter \`^-e\` lines out of the exported requirements before audit; their pinned dependencies are still in the file via the third-party section.

**Frontend E2E Tests**
\`actions/upload-artifact@v4\` preserves full paths, so the artifact entries are \`frontend/.next/\`, \`frontend/public/\`, etc. Downloading into \`path: frontend/\` produced \`frontend/frontend/.next/\` and \`next start\` failed with "Could not find a production build". Switched the download target to \`.\` (repo root) so paths line up. The E2E job runs only on \`main\`/\`develop\`, which is why this surfaced after merge, not in PR-level CI.

## Test plan
- [ ] CI on this PR passes (or at minimum: Backend Dependency Audit and Frontend E2E Tests succeed)
- [x] Required checks (Backend Lint, Backend Unit Tests, Frontend Lint, Frontend Unit Tests) already verified green on parent commit