### PR TITLE
fix(ci): include hidden files in frontend-build artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,10 @@ jobs:
             frontend/package.json
             frontend/package-lock.json
             frontend/next.config.*
+          # `actions/upload-artifact@v4` defaults `include-hidden-files: false`,
+          # which silently skips the dot-prefixed `.next/` directory — leaving
+          # ~22 files instead of the full Next.js build output. Enable it.
+          include-hidden-files: true
           retention-days: 1
 
   # ============================================================================


### PR DESCRIPTION
## Summary

Final follow-up for #155. The Frontend E2E job kept failing with "Could not find a production build in the '.next' directory" even after correcting the download path.

Root cause is upstream: \`actions/upload-artifact@v4\` defaults \`include-hidden-files: false\`, which silently skips the dot-prefixed \`.next/\` directory. The uploaded artifact ended up with **~22 files / 290 KB** (just \`public/\` + 4 root files); the real build output (\`.next/server/\`, \`.next/static/\`, build manifests) never made it across.

So the path fix in #155 was correct but insufficient — files weren't there to begin with. This sets \`include-hidden-files: true\` on the upload step.

## Test plan
- [ ] Frontend E2E completes (or at minimum, gets past "Wait for frontend to be ready")
- [ ] All other jobs remain green (no required check changes)