### PR TITLE
fix(ci): correct e2e download path + de-flake typing-animation test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,10 +290,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: frontend-build
-          # The artifact preserves full paths (frontend/.next/, frontend/public/, …)
-          # so we must download to the repo root. Downloading to `frontend/` would
-          # produce `frontend/frontend/.next/` and `next start` wouldn't find the build.
-          path: .
+          # actions/upload-artifact@v4 strips the lowest common ancestor from
+          # paths, so the artifact entries are `.next/…`, `public/…`,
+          # `package.json`, `next.config.*` (no `frontend/` prefix). Download
+          # into `frontend/` so `next start` (run from `working-directory: frontend`)
+          # finds them at the expected locations.
+          path: frontend/
 
       - name: Install Playwright browsers
         working-directory: frontend

--- a/frontend/__tests__/integration/search-flow.test.tsx
+++ b/frontend/__tests__/integration/search-flow.test.tsx
@@ -243,9 +243,15 @@ describe('Complete Search Flow Integration', () => {
     it('should show typing animation header', async () => {
       renderWithProviders(<SearchPage />);
 
-      await waitFor(() => {
-        expect(screen.getByRole('heading')).toHaveTextContent(/search legal docume/i);
-      });
+      // Typing animation renders char-by-char; default waitFor timeout (1s)
+      // is too short on slower CI runners and the assertion races the
+      // animation. Bump to 5s — still fast enough to catch a regression.
+      await waitFor(
+        () => {
+          expect(screen.getByRole('heading')).toHaveTextContent(/search legal docume/i);
+        },
+        { timeout: 5000 }
+      );
     });
 
     it('should load persisted search state', async () => {


### PR DESCRIPTION
## Summary

Final follow-up after #155, #156. Two issues from the post-#156 main CI run (https://github.com/pwr-ai/juddges-app/actions/runs/25369841892):

**Frontend E2E** — \`actions/upload-artifact@v4\` strips the lowest common ancestor from paths, so the artifact entries are \`.next/…\`, \`public/…\`, \`package.json\`, \`next.config.*\` — no \`frontend/\` prefix. My #155 fix (\`path: .\`) was wrong: it dropped the build into repo root as \`.next/\`, but \`next start\` runs with \`working-directory: frontend\` and looks for \`frontend/.next/\`. Restored \`path: frontend/\`.

**Frontend Unit Tests** — \`should show typing animation header\` is flaky on slow CI runners. The header is rendered char-by-char by a typing animation; default \`waitFor\` timeout (1s) is too short and the assertion races the animation, getting "Search legal docu" instead of expected "search legal docume". Bumped to 5s.

## Test plan
- [ ] Frontend Unit Tests passes (the typing animation test no longer races)
- [ ] Frontend E2E gets past "Wait for frontend to be ready" — running the actual playwright tests is a stretch goal here
- [ ] All other jobs remain green