### PR TITLE
fix(ci): skip playwright webServer in CI

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -79,23 +79,35 @@ export default defineConfig({
     }
   ],
 
-  /* Run your local dev server before starting the tests */
-  webServer: [
-    {
-      command: 'npm run dev',
-      url: 'http://localhost:3006',
-      reuseExistingServer: !process.env.CI,
-      timeout: 120 * 1000,
-      stdout: 'ignore',
-      stderr: 'pipe',
-    },
-    {
-      command: 'cd ../backend && poetry run uvicorn app.server:app --port 8004',
-      url: 'http://localhost:8004',
-      reuseExistingServer: !process.env.CI,
-      timeout: 120 * 1000,
-      stdout: 'ignore',
-      stderr: 'pipe',
-    }
-  ],
+  /*
+   * Run your local dev server before starting the tests.
+   *
+   * In CI, the workflow itself starts a production frontend (`npm start` on
+   * 3006) and intentionally does NOT start the backend — the E2E suite is
+   * scoped to UI-only flows that tolerate a missing backend (see ci.yml,
+   * "Frontend E2E - Issue #98"). Letting Playwright also try to spawn a dev
+   * server would race the existing one ("port 3006 already used"), and
+   * spawning the backend uvicorn would fail because the E2E runner has no
+   * Python/Poetry. Skip webServer entirely in CI.
+   */
+  webServer: process.env.CI
+    ? undefined
+    : [
+        {
+          command: 'npm run dev',
+          url: 'http://localhost:3006',
+          reuseExistingServer: true,
+          timeout: 120 * 1000,
+          stdout: 'ignore',
+          stderr: 'pipe',
+        },
+        {
+          command: 'cd ../backend && poetry run uvicorn app.server:app --port 8004',
+          url: 'http://localhost:8004',
+          reuseExistingServer: true,
+          timeout: 120 * 1000,
+          stdout: 'ignore',
+          stderr: 'pipe',
+        },
+      ],
 });


### PR DESCRIPTION
## Summary

Final fix for the remaining failing job (Frontend E2E). After #157 the artifact handoff worked and the workflow successfully started the production frontend on :3006. Playwright then failed at "Run E2E tests" with:

> Error: http://localhost:3006 is already used, make sure that nothing is running on the port/url or set reuseExistingServer:true in config.webServer.

## Cause

\`playwright.config.ts\` had two \`webServer\` entries — one for \`npm run dev\` on 3006 and one for \`poetry run uvicorn\` on 8004 — both with \`reuseExistingServer: !process.env.CI\`, i.e. **never reuse in CI**. So in CI:
- Frontend webServer raced the workflow's already-running production server → port conflict.
- Backend webServer would have failed anyway: the E2E runner has no Python / Poetry, and the workflow intentionally doesn't start the backend (E2E suite is UI-only, see \`ci.yml\` "Frontend E2E - Issue #98" comment).

## Fix

Skip Playwright's \`webServer\` entirely when \`CI=true\` — the workflow already owns the server lifecycle. Local behaviour is unchanged (still spawns dev server + backend uvicorn), but with \`reuseExistingServer: true\` so re-running tests against already-up servers no longer errors.

## Test plan
- [ ] Frontend E2E job passes (or at minimum: no port-conflict error)
- [ ] All other jobs remain green