### PR TITLE
fix(db): make 20260505 base_search_tsv GENERATED expression IMMUTABLE

### DIFF
--- a/supabase/migrations/20260505000001_extend_base_schema_filterable_searchable.sql
+++ b/supabase/migrations/20260505000001_extend_base_schema_filterable_searchable.sql
@@ -77,32 +77,66 @@ CREATE INDEX IF NOT EXISTS idx_judgments_base_reason_sent_lenient_gin
 --   D — sentences received, ancillary orders, mental/job/home narrative fields
 -- All source columns are wrapped in coalesce() so a NULL source never poisons
 -- the generated value to NULL.
+--
+-- Note on f_immutable_tsvector: PostgreSQL requires STORED GENERATED expressions
+-- to be IMMUTABLE end-to-end. Two functions in the original expression are
+-- not IMMUTABLE in Postgres and need wrapping:
+--
+--   1. to_tsvector(regconfig, text) is IMMUTABLE in Postgres ≥ 14 (verified on
+--      the Supabase Postgres 17 target), so calling it directly with an
+--      explicit 'simple'::regconfig literal would actually be safe. We still
+--      route it through the wrapper for symmetry with the array variant below
+--      and to centralise the regconfig choice.
+--   2. array_to_string(anyarray, text) is STABLE — this is the *actual* blocker
+--      that fails the original migration with SQLSTATE 42P17 ("generation
+--      expression is not immutable"), regardless of whether the surrounding
+--      to_tsvector is IMMUTABLE or not.
+--
+-- Fix: wrap both flavors in plpgsql IMMUTABLE wrappers. plpgsql is opaque to
+-- the planner's deep-immutability check (which walks into inlinable LANGUAGE
+-- sql function bodies and re-derives volatility from their dependencies);
+-- LANGUAGE sql wrappers would still be rejected. We overload by argument
+-- type — the text variant handles text columns; the text[] variant embeds
+-- the array_to_string conversion internally so the GENERATED expression
+-- never references array_to_string at all.
 -- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.f_immutable_tsvector(text)
+RETURNS tsvector
+LANGUAGE plpgsql
+IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RETURN to_tsvector('simple'::regconfig, coalesce($1, '')); END; $$;
+
+CREATE OR REPLACE FUNCTION public.f_immutable_tsvector(text[])
+RETURNS tsvector
+LANGUAGE plpgsql
+IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RETURN to_tsvector('simple'::regconfig, array_to_string(coalesce($1, ARRAY[]::TEXT[]), ' ')); END; $$;
 
 ALTER TABLE public.judgments
     ADD COLUMN IF NOT EXISTS base_search_tsv tsvector
         GENERATED ALWAYS AS (
-            setweight(to_tsvector('simple'::regconfig, coalesce(base_case_name, '')), 'A') ||
-            setweight(to_tsvector('simple'::regconfig, coalesce(base_neutral_citation_number, '')), 'A') ||
-            setweight(to_tsvector('simple'::regconfig, array_to_string(coalesce(base_keywords, ARRAY[]::TEXT[]), ' ')), 'A') ||
-            setweight(to_tsvector('simple'::regconfig, coalesce(base_appeal_court_judges_names, '')), 'B') ||
-            setweight(to_tsvector('simple'::regconfig, coalesce(base_offender_representative_name, '')), 'B') ||
-            setweight(to_tsvector('simple'::regconfig, coalesce(base_crown_attorney_general_representative_name, '')), 'B') ||
-            setweight(to_tsvector('simple'::regconfig, array_to_string(coalesce(base_convict_offences, ARRAY[]::TEXT[]), ' ')), 'B') ||
-            setweight(to_tsvector('simple'::regconfig, array_to_string(coalesce(base_acquit_offences, ARRAY[]::TEXT[]), ' ')), 'B') ||
-            setweight(to_tsvector('simple'::regconfig, array_to_string(coalesce(base_appeal_ground, ARRAY[]::TEXT[]), ' ')), 'B') ||
-            setweight(to_tsvector('simple'::regconfig, coalesce(base_conv_court_names, '')), 'C') ||
-            setweight(to_tsvector('simple'::regconfig, coalesce(base_sent_court_name, '')), 'C') ||
-            setweight(to_tsvector('simple'::regconfig, array_to_string(coalesce(base_agg_fact_sent, ARRAY[]::TEXT[]), ' ')), 'C') ||
-            setweight(to_tsvector('simple'::regconfig, array_to_string(coalesce(base_mit_fact_sent, ARRAY[]::TEXT[]), ' ')), 'C') ||
-            setweight(to_tsvector('simple'::regconfig, array_to_string(coalesce(base_sentences_received, ARRAY[]::TEXT[]), ' ')), 'D') ||
-            setweight(to_tsvector('simple'::regconfig, array_to_string(coalesce(base_what_ancilliary_orders, ARRAY[]::TEXT[]), ' ')), 'D') ||
-            setweight(to_tsvector('simple'::regconfig, coalesce(base_offender_mental_offence, '')), 'D') ||
-            setweight(to_tsvector('simple'::regconfig, coalesce(base_victim_mental_offence, '')), 'D') ||
-            setweight(to_tsvector('simple'::regconfig, coalesce(base_offender_job_offence, '')), 'D') ||
-            setweight(to_tsvector('simple'::regconfig, coalesce(base_offender_home_offence, '')), 'D') ||
-            setweight(to_tsvector('simple'::regconfig, coalesce(base_victim_job_offence, '')), 'D') ||
-            setweight(to_tsvector('simple'::regconfig, coalesce(base_victim_home_offence, '')), 'D')
+            setweight(public.f_immutable_tsvector(base_case_name), 'A') ||
+            setweight(public.f_immutable_tsvector(base_neutral_citation_number), 'A') ||
+            setweight(public.f_immutable_tsvector(base_keywords), 'A') ||
+            setweight(public.f_immutable_tsvector(base_appeal_court_judges_names), 'B') ||
+            setweight(public.f_immutable_tsvector(base_offender_representative_name), 'B') ||
+            setweight(public.f_immutable_tsvector(base_crown_attorney_general_representative_name), 'B') ||
+            setweight(public.f_immutable_tsvector(base_convict_offences), 'B') ||
+            setweight(public.f_immutable_tsvector(base_acquit_offences), 'B') ||
+            setweight(public.f_immutable_tsvector(base_appeal_ground), 'B') ||
+            setweight(public.f_immutable_tsvector(base_conv_court_names), 'C') ||
+            setweight(public.f_immutable_tsvector(base_sent_court_name), 'C') ||
+            setweight(public.f_immutable_tsvector(base_agg_fact_sent), 'C') ||
+            setweight(public.f_immutable_tsvector(base_mit_fact_sent), 'C') ||
+            setweight(public.f_immutable_tsvector(base_sentences_received), 'D') ||
+            setweight(public.f_immutable_tsvector(base_what_ancilliary_orders), 'D') ||
+            setweight(public.f_immutable_tsvector(base_offender_mental_offence), 'D') ||
+            setweight(public.f_immutable_tsvector(base_victim_mental_offence), 'D') ||
+            setweight(public.f_immutable_tsvector(base_offender_job_offence), 'D') ||
+            setweight(public.f_immutable_tsvector(base_offender_home_offence), 'D') ||
+            setweight(public.f_immutable_tsvector(base_victim_job_offence), 'D') ||
+            setweight(public.f_immutable_tsvector(base_victim_home_offence), 'D')
         ) STORED;
 
 CREATE INDEX IF NOT EXISTS idx_judgments_base_search_tsv


### PR DESCRIPTION
## Summary

Fixes a real SQL bug in `supabase/migrations/20260505000001_extend_base_schema_filterable_searchable.sql` that prevents the migration from applying to any Postgres target. The migration was already merged but never landed on prod.

## The bug

The migration adds `public.judgments.base_search_tsv` as a `STORED GENERATED` column whose expression calls `array_to_string(anyarray, text)` — which is `STABLE` in Postgres. That makes the whole expression `STABLE`, and Postgres rejects it with:

```
ERROR:  generation expression is not immutable (SQLSTATE 42P17)
```

(Subtle: `to_tsvector(regconfig, text)` is **IMMUTABLE** in Postgres ≥ 14 — verified on the Supabase Postgres 17 target — so it isn't the blocker. The `array_to_string` call is.)

## The fix

Two overloaded `plpgsql` IMMUTABLE wrappers, both named `public.f_immutable_tsvector`:
- `(text)` — wraps `to_tsvector('simple', coalesce($1, ''))`.
- `(text[])` — wraps `to_tsvector('simple', array_to_string(coalesce($1, ARRAY[]::TEXT[]), ' '))`. This embeds the `array_to_string` call internally so the GENERATED expression never references it.

The GENERATED expression simplifies from `setweight(to_tsvector('simple'::regconfig, coalesce(col, '')), 'A')` to `setweight(public.f_immutable_tsvector(col), 'A')` — overload resolution picks the right variant by argument type.

### Why `LANGUAGE plpgsql` and not `LANGUAGE sql`

PostgreSQL ≥ 14 walks into inlinable `LANGUAGE sql` function bodies and re-derives volatility from their dependencies, defeating an IMMUTABLE marker on an SQL wrapper. `plpgsql` bodies are opaque to that check, so the IMMUTABLE marker is taken at face value. The `'simple'` regconfig is a Postgres built-in that never changes in practice, so the marker is safe.

## Verification

End-to-end on `postgres:16` Docker container with all `base_*` columns stubbed:

| Test | Result |
|---|---|
| Both wrappers create | ✅ `CREATE FUNCTION` × 2 |
| `ALTER TABLE … ADD COLUMN … GENERATED ALWAYS AS (…) STORED` | ✅ `ALTER TABLE` succeeds |
| Insert row with text + text[] sources | ✅ `tsvector` populates correctly |
| `WHERE base_search_tsv @@ websearch_to_tsquery('simple', 'fraud')` | ✅ matches row whose `base_keywords` array contains 'fraud' |
| `WHERE base_search_tsv @@ websearch_to_tsquery('simple', 'unemployed')` | ✅ matches row whose `base_offender_job_offence` text equals 'unemployed' |

Reproduced the original error first by running the unfixed migration against the same stub schema → `ERROR: generation expression is not immutable (SQLSTATE 42P17)` at the `ADD COLUMN` step.

## Test plan

- [ ] CI green on this branch
- [ ] Run `npx supabase db push --linked --dry-run` against the linked project — expect to see this migration as the only pending one
- [ ] Apply via `npx supabase db push --linked` to non-prod Supabase first if available
- [ ] After merge, apply to prod via the standard release flow
- [ ] Smoke-check: `SELECT base_case_name FROM public.judgments WHERE base_search_tsv @@ websearch_to_tsquery('simple', '<known-keyword>') LIMIT 5;` returns rows
- [ ] Confirm `idx_judgments_base_search_tsv` GIN index is in `pg_indexes`

## Files changed

- `supabase/migrations/20260505000001_extend_base_schema_filterable_searchable.sql` (+55 / −21)

No other code changes; the rest of the migration (Tier 1 B-tree/GIN indexes, Tier 3 trigram indexes, the `filter_documents_by_extracted_data` rewrite) is untouched.

## Notes for reviewer

- The `f_immutable_tsvector` name lives in `public` and is reusable elsewhere if other generated columns need it — it's not migration-private.
- The `'simple'` regconfig is hardcoded inside the wrappers. If we ever want per-column configs, the wrappers would need a regconfig parameter (and we'd lose IMMUTABLE classification, since regconfig is text-based — would need a non-generated column updated by trigger instead).
- Migration is still **not** applied to prod after this PR merges; a follow-up `supabase db push` is needed (out of scope here; this PR just makes the migration applyable).