### PR TITLE
feat(search): judgment-only + blazing fast

### DIFF
--- a/backend/app/api/schema_generator.py
+++ b/backend/app/api/schema_generator.py
@@ -81,7 +81,7 @@ class SchemaChatRequest(BaseModel):
         default=None, description="Legacy agent ID (backward compatibility)"
     )
     document_type: str = Field(
-        default="tax_interpretation", description="Document type for schema generation"
+        default="judgment", description="Document type for schema generation"
     )
     mode: str = Field(
         default="rabbit", description="Agent mode: 'rabbit' or 'thinking'"
@@ -328,7 +328,7 @@ async def schema_chat(
         {
             "message": "I need to extract drug information from court documents",
             "collection_id": "drug-cases",
-            "document_type": "tax_interpretation",
+            "document_type": "judgment",
             "mode": "rabbit"
         }
         ```

--- a/backend/app/dashboard.py
+++ b/backend/app/dashboard.py
@@ -644,7 +644,7 @@ async def get_featured_examples(
                 "judgment_date, country, language, issuing_body, "
                 "full_text, docket_number, court_name, judgment_id"
             )
-            .in_("document_type", ["judgment", "tax_interpretation"])
+            .eq("document_type", "judgment")
             .not_.is_("title", "null")
             .limit(limit * 3)
             .execute()
@@ -765,7 +765,6 @@ async def test_document_counts(
         logger.info("Fetching document counts by type...")
         document_types = [
             "judgment",
-            "tax_interpretation",
             "ruling",
             "opinion",
             "legislation",

--- a/backend/app/documents.py
+++ b/backend/app/documents.py
@@ -727,9 +727,6 @@ async def get_citation_network(
     min_shared_refs: int = Query(
         1, ge=1, le=10, description="Minimum shared references for an edge"
     ),
-    document_types: str | None = Query(
-        None, description="Comma-separated document types to filter"
-    ),
 ) -> CitationNetworkResponse:
     """Build citation network from shared legal references between documents."""
     try:
@@ -738,13 +735,6 @@ async def get_citation_network(
         query = db.client.table("legal_documents").select(
             'document_id, title, document_type, date_issued, x, y, "references", court_name, document_number, language'
         )
-
-        if document_types:
-            types_list = [t.strip() for t in document_types.split(",")]
-            if len(types_list) == 1:
-                query = query.eq("document_type", types_list[0])
-            else:
-                query = query.in_("document_type", types_list)
 
         response = query.not_.is_("references", "null").limit(sample_size).execute()
         docs = response.data or []

--- a/backend/app/documents.py
+++ b/backend/app/documents.py
@@ -15,7 +15,7 @@ import random
 import re
 import time
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import APIRouter, HTTPException, Path, Query, Response
 from juddges_search.db.supabase_db import get_vector_db
@@ -188,12 +188,17 @@ def _detect_search_language(
 def _convert_judgment_to_legal_document(
     judgment_data: dict[str, Any],
     include_vectors: bool = False,
+    result_view: Literal["card", "full"] = "full",
 ) -> LegalDocument:
     """Convert judgment table data to LegalDocument model.
 
     Args:
         judgment_data: Dictionary from judgments table query
         include_vectors: Whether to include vector embeddings
+        result_view: ``"card"`` returns only the small set of fields the search
+            cards render (~10 fields, all other optional fields are left at
+            their None/empty defaults, ``full_text`` is dropped); ``"full"``
+            preserves the historical fully-populated payload.
 
     Returns:
         LegalDocument model instance
@@ -201,13 +206,40 @@ def _convert_judgment_to_legal_document(
     # Map jurisdiction to country code
     country = judgment_data.get("jurisdiction", "PL")
 
-    # Parse dates
+    # Parse dates (always cheap; needed for both views)
     date_issued = parse_date(judgment_data.get("decision_date"))
     publication_date = parse_date(judgment_data.get("publication_date"))
+    court_name = judgment_data.get("court_name")
 
+    # Get metadata from JSONB field for language detection. We avoid mutating
+    # the shared dict in card view because we don't need to attach case_type /
+    # decision_type to a payload we won't ship.
+    metadata = judgment_data.get("metadata", {}) or {}
+
+    if result_view == "card":
+        # Card view: minimal payload — only the fields the SearchResultCard
+        # renders. ``country`` and ``full_text`` are required by the
+        # ``LegalDocument`` model, so we keep ``country`` (cheap, 2-3 bytes)
+        # and pass an empty ``full_text``.
+        return LegalDocument(
+            document_id=str(judgment_data.get("id", "")),
+            document_type=DocumentType.JUDGMENT,
+            title=judgment_data.get("title"),
+            date_issued=date_issued,
+            language=metadata.get("language", "pl" if country == "PL" else "en")
+            if isinstance(metadata, dict)
+            else ("pl" if country == "PL" else "en"),
+            document_number=judgment_data.get("case_number"),
+            country=country,
+            full_text="",
+            summary=judgment_data.get("summary"),
+            publication_date=publication_date,
+            court_name=court_name,
+        )
+
+    # Full view: keep the historical, fully-populated payload.
     # Build issuing body from court information
     issuing_body = None
-    court_name = judgment_data.get("court_name")
     if court_name:
         issuing_body = IssuingBody(
             name=court_name,
@@ -220,10 +252,8 @@ def _convert_judgment_to_legal_document(
     if include_vectors and judgment_data.get("embedding"):
         vectors["default"] = judgment_data["embedding"]
 
-    # Get metadata from JSONB field and merge with judgment fields
-    metadata = judgment_data.get("metadata", {}) or {}
+    # Add judgment-specific fields to metadata for the full payload
     if isinstance(metadata, dict):
-        # Add judgment-specific fields to metadata
         if judgment_data.get("case_type"):
             metadata["case_type"] = judgment_data["case_type"]
         if judgment_data.get("decision_type"):
@@ -1430,6 +1460,64 @@ async def _run_hybrid_search(
     return response.data or [], search_time_ms
 
 
+async def _get_estimated_total(
+    supabase: Any,
+    effective_filters: dict[str, Any],
+) -> int | None:
+    """Return COUNT(*) of judgments matching filters, or None on any error.
+
+    Mirrors the helper in ``documents_pkg/search.py``; this duplicate exists
+    because ``backend/app/documents.py`` is the legacy near-duplicate router.
+    Both copies must stay in sync.
+    """
+    try:
+        rpc_query = supabase.rpc(
+            "count_judgments_filtered",
+            {
+                "filter_jurisdictions": effective_filters.get("jurisdictions"),
+                "filter_court_names": effective_filters.get("court_names"),
+                "filter_court_levels": effective_filters.get("court_levels"),
+                "filter_case_types": effective_filters.get("case_types"),
+                "filter_decision_types": effective_filters.get("decision_types"),
+                "filter_outcomes": effective_filters.get("outcomes"),
+                "filter_keywords": effective_filters.get("keywords"),
+                "filter_legal_topics": effective_filters.get("legal_topics"),
+                "filter_cited_legislation": effective_filters.get("cited_legislation"),
+                "filter_date_from": effective_filters.get("date_from"),
+                "filter_date_to": effective_filters.get("date_to"),
+            },
+        )
+        execute = rpc_query.execute
+        if asyncio.iscoroutinefunction(execute):
+            response = await execute()
+        else:
+            response = await asyncio.to_thread(execute)
+
+        data = response.data
+        if data is None:
+            return None
+        if isinstance(data, int):
+            return data
+        if isinstance(data, list):
+            if not data:
+                return None
+            first = data[0]
+            if isinstance(first, dict):
+                value = next(iter(first.values()), None)
+                return int(value) if value is not None else None
+            if isinstance(first, int):
+                return first
+        if isinstance(data, dict):
+            value = next(iter(data.values()), None)
+            return int(value) if value is not None else None
+        return None
+    except Exception as exc:
+        logger.warning(
+            "count_judgments_filtered failed; estimated_total stays None: {}", exc
+        )
+        return None
+
+
 async def _rerank_if_enabled(
     query: str,
     results: list[dict[str, Any]],
@@ -1448,6 +1536,7 @@ async def _rerank_if_enabled(
 
 def _build_search_result_payload(
     results: list[dict[str, Any]],
+    result_view: Literal["card", "full"] = "full",
 ) -> tuple[list[dict[str, Any]], list[LegalDocument]]:
     chunks: list[dict[str, Any]] = []
     documents: list[LegalDocument] = []
@@ -1470,7 +1559,9 @@ def _build_search_result_payload(
                 "combined_score": result.get("combined_score"),
             }
         )
-        documents.append(_convert_judgment_to_legal_document(result))
+        documents.append(
+            _convert_judgment_to_legal_document(result, result_view=result_view)
+        )
 
     return chunks, documents
 
@@ -1510,6 +1601,7 @@ def _build_search_pagination(
     offset: int,
     limit: int,
     result_count: int,
+    estimated_total: int | None = None,
 ) -> PaginationMetadata:
     has_more = result_count >= limit
     next_offset = offset + result_count if has_more else None
@@ -1517,7 +1609,7 @@ def _build_search_pagination(
         offset=offset,
         limit=limit,
         loaded_count=result_count,
-        estimated_total=None,
+        estimated_total=estimated_total,
         has_more=has_more,
         next_offset=next_offset,
     )
@@ -1614,7 +1706,23 @@ async def search_documents(request: SearchChunksRequest):
                 enhanced_query_text = fallback_query
 
         results, rerank_time_ms = await _rerank_if_enabled(query, results, top_k=limit)
-        chunks, documents = _build_search_result_payload(results)
+        chunks, documents = _build_search_result_payload(
+            results, result_view=request.result_view
+        )
+
+        # First-page estimated_total. Only paid on offset==0 + include_count, so
+        # load-more requests stay free. Errors return None and never block search.
+        estimated_total: int | None = None
+        if request.include_count and offset == 0:
+            try:
+                estimated_total = await _get_estimated_total(
+                    supabase, effective_filters
+                )
+            except Exception as count_err:
+                logger.warning(
+                    "Skipping estimated_total (helper failed): {}", count_err
+                )
+                estimated_total = None
 
         total_time_ms = (time.perf_counter() - start_time) * 1000
         timing_breakdown = _build_search_timing_breakdown(
@@ -1638,7 +1746,9 @@ async def search_documents(request: SearchChunksRequest):
             f"(embedding: {embedding_time_ms:.0f}ms, search: {search_time_ms:.0f}ms)"
         )
 
-        pagination = _build_search_pagination(offset, limit, len(results))
+        pagination = _build_search_pagination(
+            offset, limit, len(results), estimated_total=estimated_total
+        )
 
         return SearchChunksResponse(
             chunks=chunks,

--- a/backend/app/documents.py
+++ b/backend/app/documents.py
@@ -1546,7 +1546,7 @@ async def search_documents(request: SearchChunksRequest):
 
     logger.info(
         f"Search request: query='{query[:100]}...', limit={limit}, "
-        f"languages={request.languages}, document_types={request.document_types}, "
+        f"languages={request.languages}, "
         f"jurisdictions={request.jurisdictions}, case_types={request.case_types}"
     )
 

--- a/backend/app/documents_pkg/__init__.py
+++ b/backend/app/documents_pkg/__init__.py
@@ -180,9 +180,6 @@ async def get_citation_network(
     min_shared_refs: int = Query(
         1, ge=1, le=10, description="Minimum shared references for an edge"
     ),
-    document_types: str | None = Query(
-        None, description="Comma-separated document types to filter"
-    ),
 ) -> CitationNetworkResponse:
     """Build citation network from shared legal references between documents."""
     try:
@@ -191,13 +188,6 @@ async def get_citation_network(
         query = db.client.table("legal_documents").select(
             'document_id, title, document_type, date_issued, x, y, "references", court_name, document_number, language'
         )
-
-        if document_types:
-            types_list = [t.strip() for t in document_types.split(",")]
-            if len(types_list) == 1:
-                query = query.eq("document_type", types_list[0])
-            else:
-                query = query.in_("document_type", types_list)
 
         response = query.not_.is_("references", "null").limit(sample_size).execute()
         docs = response.data or []
@@ -420,7 +410,10 @@ async def search_documents(request: SearchChunksRequest):
         try:
             from app.search_cache import get_cached_search
 
-            cached_response = await get_cached_search(request)
+            # user_id=None: RLS is currently public-read so the cache key
+            # stays request-only. Pass a stable user/role identifier here
+            # once any non-public field or per-user filter ships.
+            cached_response = await get_cached_search(request, user_id=None)
             if cached_response is not None:
                 logger.debug(
                     "search_cache hit: query='{}...' offset={} limit={}",
@@ -638,7 +631,8 @@ async def search_documents(request: SearchChunksRequest):
             try:
                 from app.search_cache import set_cached_search
 
-                await set_cached_search(request, response)
+                # user_id=None: see matching note on get_cached_search above.
+                await set_cached_search(request, response, user_id=None)
             except Exception as cache_err:
                 logger.warning("search_cache write failed (non-fatal): {}", cache_err)
 

--- a/backend/app/documents_pkg/__init__.py
+++ b/backend/app/documents_pkg/__init__.py
@@ -426,7 +426,7 @@ async def search_documents(request: SearchChunksRequest):
 
     logger.info(
         f"Search request: query='{query[:100]}...', limit={limit}, "
-        f"languages={request.languages}, document_types={request.document_types}, "
+        f"languages={request.languages}, "
         f"jurisdictions={request.jurisdictions}, case_types={request.case_types}"
     )
 

--- a/backend/app/documents_pkg/__init__.py
+++ b/backend/app/documents_pkg/__init__.py
@@ -56,6 +56,7 @@ from .search import (
     _build_search_rpc_params,
     _build_search_timing_breakdown,
     _generate_search_embedding,
+    _get_estimated_total,
     _get_search_client,
     _prepare_search_queries,
     _rerank_if_enabled,
@@ -524,7 +525,24 @@ async def search_documents(request: SearchChunksRequest):
             )
 
         results, rerank_time_ms = await _rerank_if_enabled(query, results, top_k=limit)
-        chunks, documents = _build_search_result_payload(results)
+        chunks, documents = _build_search_result_payload(
+            results, result_view=request.result_view
+        )
+
+        # First-page estimated_total. Only paid on offset==0 + include_count, so
+        # load-more requests stay free. Errors return None and never block search.
+        estimated_total: int | None = None
+        if request.include_count and offset == 0:
+            try:
+                count_supabase = await _get_search_client()
+                estimated_total = await _get_estimated_total(
+                    count_supabase, effective_filters
+                )
+            except Exception as count_err:
+                logger.warning(
+                    "Skipping estimated_total (client/setup failed): {}", count_err
+                )
+                estimated_total = None
 
         total_time_ms = (time.perf_counter() - start_time) * 1000
         timing_breakdown = _build_search_timing_breakdown(
@@ -548,7 +566,9 @@ async def search_documents(request: SearchChunksRequest):
             f"(embedding: {embedding_time_ms:.0f}ms, search: {search_time_ms:.0f}ms)"
         )
 
-        pagination = _build_search_pagination(offset, limit, len(results))
+        pagination = _build_search_pagination(
+            offset, limit, len(results), estimated_total=estimated_total
+        )
 
         try:
             from app.search_telemetry import record_search

--- a/backend/app/documents_pkg/__init__.py
+++ b/backend/app/documents_pkg/__init__.py
@@ -413,6 +413,25 @@ async def search_documents(request: SearchChunksRequest):
     limit = request.limit_docs or 20
     offset = request.offset or 0
 
+    # Full-response Redis cache (rabbit mode only). A hit here skips embedding,
+    # RPC, rerank, payload build, estimated_total — the entire pipeline. Any
+    # cache failure is swallowed so search continues to work without Redis.
+    if request.mode != "thinking":
+        try:
+            from app.search_cache import get_cached_search
+
+            cached_response = await get_cached_search(request)
+            if cached_response is not None:
+                logger.debug(
+                    "search_cache hit: query='{}...' offset={} limit={}",
+                    query[:60],
+                    offset,
+                    limit,
+                )
+                return cached_response
+        except Exception as cache_err:
+            logger.warning("search_cache lookup failed (non-fatal): {}", cache_err)
+
     try:
         import sentry_sdk
 
@@ -596,7 +615,7 @@ async def search_documents(request: SearchChunksRequest):
         except Exception as telem_err:
             logger.debug(f"Search telemetry skipped: {telem_err}")
 
-        return SearchChunksResponse(
+        response = SearchChunksResponse(
             chunks=chunks,
             documents=documents,
             total_chunks=len(chunks),
@@ -611,6 +630,19 @@ async def search_documents(request: SearchChunksRequest):
             inferred_filters=inferred_filters if request.mode == "thinking" else None,
             query_analysis_source=query_analysis_source,
         )
+
+        # Populate the full-response cache for subsequent identical requests.
+        # Skipped for thinking mode (non-deterministic) and for any error path
+        # (we never reach here on exception).
+        if request.mode != "thinking":
+            try:
+                from app.search_cache import set_cached_search
+
+                await set_cached_search(request, response)
+            except Exception as cache_err:
+                logger.warning("search_cache write failed (non-fatal): {}", cache_err)
+
+        return response
 
     except HTTPException:
         raise

--- a/backend/app/documents_pkg/conversion.py
+++ b/backend/app/documents_pkg/conversion.py
@@ -1,7 +1,7 @@
 """Document type conversion functions."""
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from juddges_search.models import DocumentType, IssuingBody, LegalDocument
 
@@ -11,12 +11,17 @@ from app.utils.date_utils import parse_date
 def _convert_judgment_to_legal_document(
     judgment_data: dict[str, Any],
     include_vectors: bool = False,
+    result_view: Literal["card", "full"] = "full",
 ) -> LegalDocument:
     """Convert judgment table data to LegalDocument model.
 
     Args:
         judgment_data: Dictionary from judgments table query
         include_vectors: Whether to include vector embeddings
+        result_view: ``"card"`` returns only the small set of fields the search
+            cards render (~10 fields, all other optional fields are left at
+            their None/empty defaults, ``full_text`` is dropped); ``"full"``
+            preserves the historical fully-populated payload.
 
     Returns:
         LegalDocument model instance
@@ -24,13 +29,40 @@ def _convert_judgment_to_legal_document(
     # Map jurisdiction to country code
     country = judgment_data.get("jurisdiction", "PL")
 
-    # Parse dates
+    # Parse dates (always cheap; needed for both views)
     date_issued = parse_date(judgment_data.get("decision_date"))
     publication_date = parse_date(judgment_data.get("publication_date"))
+    court_name = judgment_data.get("court_name")
 
+    # Get metadata from JSONB field for language detection. We avoid mutating
+    # the shared dict in card view because we don't need to attach case_type /
+    # decision_type to a payload we won't ship.
+    metadata = judgment_data.get("metadata", {}) or {}
+
+    if result_view == "card":
+        # Card view: minimal payload — only the fields the SearchResultCard
+        # renders. ``country`` and ``full_text`` are required by the
+        # ``LegalDocument`` model, so we keep ``country`` (cheap, 2-3 bytes)
+        # and pass an empty ``full_text``.
+        return LegalDocument(
+            document_id=str(judgment_data.get("id", "")),
+            document_type=DocumentType.JUDGMENT,
+            title=judgment_data.get("title"),
+            date_issued=date_issued,
+            language=metadata.get("language", "pl" if country == "PL" else "en")
+            if isinstance(metadata, dict)
+            else ("pl" if country == "PL" else "en"),
+            document_number=judgment_data.get("case_number"),
+            country=country,
+            full_text="",
+            summary=judgment_data.get("summary"),
+            publication_date=publication_date,
+            court_name=court_name,
+        )
+
+    # Full view: keep the historical, fully-populated payload.
     # Build issuing body from court information
     issuing_body = None
-    court_name = judgment_data.get("court_name")
     if court_name:
         issuing_body = IssuingBody(
             name=court_name,
@@ -43,10 +75,8 @@ def _convert_judgment_to_legal_document(
     if include_vectors and judgment_data.get("embedding"):
         vectors["default"] = judgment_data["embedding"]
 
-    # Get metadata from JSONB field and merge with judgment fields
-    metadata = judgment_data.get("metadata", {}) or {}
+    # Add judgment-specific fields to metadata for the full payload
     if isinstance(metadata, dict):
-        # Add judgment-specific fields to metadata
         if judgment_data.get("case_type"):
             metadata["case_type"] = judgment_data["case_type"]
         if judgment_data.get("decision_type"):

--- a/backend/app/documents_pkg/search.py
+++ b/backend/app/documents_pkg/search.py
@@ -4,7 +4,7 @@ import asyncio
 import os
 import re
 import time
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import HTTPException
 from juddges_search.models import LegalDocument
@@ -552,6 +552,70 @@ async def _run_hybrid_search(
     return response.data or [], search_time_ms
 
 
+async def _get_estimated_total(
+    supabase: Any,
+    effective_filters: dict[str, Any],
+) -> int | None:
+    """Return COUNT(*) of judgments matching filters, or None on any error.
+
+    This is a best-effort companion to ``search_judgments_hybrid``: it ignores
+    text/vector relevance and just counts rows that satisfy the same filter
+    predicates. The backend invokes it only on the first page; the value
+    populates ``PaginationMetadata.estimated_total``. Failures are swallowed
+    so a count blip never breaks search.
+    """
+    try:
+        rpc_query = supabase.rpc(
+            "count_judgments_filtered",
+            {
+                "filter_jurisdictions": effective_filters.get("jurisdictions"),
+                "filter_court_names": effective_filters.get("court_names"),
+                "filter_court_levels": effective_filters.get("court_levels"),
+                "filter_case_types": effective_filters.get("case_types"),
+                "filter_decision_types": effective_filters.get("decision_types"),
+                "filter_outcomes": effective_filters.get("outcomes"),
+                "filter_keywords": effective_filters.get("keywords"),
+                "filter_legal_topics": effective_filters.get("legal_topics"),
+                "filter_cited_legislation": effective_filters.get("cited_legislation"),
+                "filter_date_from": effective_filters.get("date_from"),
+                "filter_date_to": effective_filters.get("date_to"),
+            },
+        )
+        execute = rpc_query.execute
+        if asyncio.iscoroutinefunction(execute):
+            response = await execute()
+        else:
+            response = await asyncio.to_thread(execute)
+
+        # Supabase returns the scalar bigint as response.data — most clients
+        # surface it as ``int`` directly, but defensive handling: it may also
+        # arrive wrapped (e.g. ``[{"count_judgments_filtered": 1234}]``).
+        data = response.data
+        if data is None:
+            return None
+        if isinstance(data, int):
+            return data
+        if isinstance(data, list):
+            if not data:
+                return None
+            first = data[0]
+            if isinstance(first, dict):
+                # Pick the only/first value, regardless of column key.
+                value = next(iter(first.values()), None)
+                return int(value) if value is not None else None
+            if isinstance(first, int):
+                return first
+        if isinstance(data, dict):
+            value = next(iter(data.values()), None)
+            return int(value) if value is not None else None
+        return None
+    except Exception as exc:
+        logger.warning(
+            "count_judgments_filtered failed; estimated_total stays None: {}", exc
+        )
+        return None
+
+
 async def _rerank_if_enabled(
     query: str,
     results: list[dict[str, Any]],
@@ -584,6 +648,7 @@ async def _rerank_if_enabled(
 
 def _build_search_result_payload(
     results: list[dict[str, Any]],
+    result_view: Literal["card", "full"] = "full",
 ) -> tuple[list[dict[str, Any]], list[LegalDocument]]:
     chunks: list[dict[str, Any]] = []
     documents: list[LegalDocument] = []
@@ -606,7 +671,9 @@ def _build_search_result_payload(
                 "combined_score": result.get("combined_score"),
             }
         )
-        documents.append(_convert_judgment_to_legal_document(result))
+        documents.append(
+            _convert_judgment_to_legal_document(result, result_view=result_view)
+        )
 
     return chunks, documents
 
@@ -646,6 +713,7 @@ def _build_search_pagination(
     offset: int,
     limit: int,
     result_count: int,
+    estimated_total: int | None = None,
 ) -> PaginationMetadata:
     has_more = result_count >= limit
     next_offset = offset + result_count if has_more else None
@@ -653,7 +721,7 @@ def _build_search_pagination(
         offset=offset,
         limit=limit,
         loaded_count=result_count,
-        estimated_total=None,
+        estimated_total=estimated_total,
         has_more=has_more,
         next_offset=next_offset,
     )

--- a/backend/app/graphql_api/schema.py
+++ b/backend/app/graphql_api/schema.py
@@ -68,7 +68,6 @@ class SearchDocumentsInput:
     mode: str = "rabbit"
     alpha: float = 0.5
     languages: list[str] | None = None
-    document_types: list[str] | None = None
     return_properties: list[str] | None = None
 
 
@@ -80,7 +79,6 @@ class SearchChunksInput:
     limit_docs: int = 20
     alpha: float = 0.7
     languages: list[str] | None = None
-    document_types: list[str] | None = None
     segment_types: list[str] | None = None
     fetch_full_documents: bool = False
     mode: str = "rabbit"
@@ -180,7 +178,6 @@ class Query:
             mode=input.mode,
             alpha=input.alpha,
             languages=input.languages,
-            document_types=input.document_types,
             limit_docs=input.limit_docs if hasattr(input, "limit_docs") else 20,
             offset=0,
         )
@@ -228,7 +225,6 @@ class Query:
             limit_docs=input.limit_docs,
             alpha=input.alpha,
             languages=input.languages,
-            document_types=input.document_types,
             segment_types=input.segment_types,
             fetch_full_documents=input.fetch_full_documents,
             mode=input.mode,

--- a/backend/app/graphql_api/types.py
+++ b/backend/app/graphql_api/types.py
@@ -16,7 +16,6 @@ import strawberry
 @strawberry.enum
 class DocumentTypeEnum(enum.Enum):
     JUDGMENT = "judgment"
-    TAX_INTERPRETATION = "tax_interpretation"
 
 
 @strawberry.enum

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -959,6 +959,12 @@ class SearchChunksRequest(BaseModel):
         default=True,
         description="Whether to include estimated total count on first request. Set to False for subsequent load-more requests.",
     )
+    result_view: Literal["card", "full"] = Field(
+        default="card",
+        description="Payload size selector: 'card' returns a trimmed ~10-field "
+        "card-friendly document (default, fastest), 'full' returns the legacy "
+        "complete LegalDocument payload.",
+    )
 
     # NEW FILTER FIELDS FOR ENHANCED FILTERING
     jurisdictions: list[str] | None = Field(

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -848,15 +848,6 @@ class SearchDocumentsRequest(BaseModel):
         description="Language codes to filter by. Accepts 'pl', 'en', or 'uk' (normalized to 'en'). Note: 'uk' = United Kingdom (English), not Ukraine.",
         examples=[["pl"], ["en"], ["uk"], ["pl", "en"]],
     )
-    document_types: list[str] | None = Field(
-        default=None,
-        description="Document types to filter by. Accepts 'judgment' or 'tax_interpretation'",
-        examples=[
-            ["tax_interpretation"],
-            ["judgment"],
-            ["tax_interpretation", "judgment"],
-        ],
-    )
 
     @field_validator("languages")
     @classmethod
@@ -864,13 +855,6 @@ class SearchDocumentsRequest(BaseModel):
         from app.utils.validators import validate_languages
 
         return validate_languages(v)
-
-    @field_validator("document_types")
-    @classmethod
-    def validate_document_types_field(cls, v: list[str] | None) -> list[str] | None:
-        from app.utils.validators import validate_document_types
-
-        return validate_document_types(v)
 
     @field_validator("mode")
     @classmethod
@@ -938,15 +922,6 @@ class SearchChunksRequest(BaseModel):
         default=None,
         description="Language codes to filter by. Accepts 'pl', 'en', or 'uk' (normalized to 'en'). Note: 'uk' = United Kingdom (English), not Ukraine.",
         examples=[["pl"], ["en"], ["uk"], ["pl", "en"]],
-    )
-    document_types: list[str] | None = Field(
-        default=None,
-        description="Document types to filter by. Accepts 'judgment' or 'tax_interpretation'",
-        examples=[
-            ["tax_interpretation"],
-            ["judgment"],
-            ["tax_interpretation", "judgment"],
-        ],
     )
     segment_types: list[str] | None = Field(
         default=None,
@@ -1038,13 +1013,6 @@ class SearchChunksRequest(BaseModel):
         from app.utils.validators import validate_languages
 
         return validate_languages(v)
-
-    @field_validator("document_types")
-    @classmethod
-    def validate_document_types_field(cls, v: list[str] | None) -> list[str] | None:
-        from app.utils.validators import validate_document_types
-
-        return validate_document_types(v)
 
     @field_validator("segment_types")
     @classmethod

--- a/backend/app/precedents.py
+++ b/backend/app/precedents.py
@@ -68,7 +68,7 @@ class PrecedentFilters(BaseModel):
 
     document_types: list[str] | None = Field(
         default=None,
-        description="Filter by document types (e.g., 'judgment', 'tax_interpretation')",
+        description="Filter by document types (e.g., 'judgment')",
     )
     court_names: list[str] | None = Field(
         default=None,

--- a/backend/app/search_cache.py
+++ b/backend/app/search_cache.py
@@ -104,9 +104,18 @@ def _get_client():
     return _client
 
 
-def _make_key(request: SearchChunksRequest) -> str:
-    """SHA-256 of a stable JSON projection of the request payload."""
+def _make_key(request: SearchChunksRequest, user_id: str | None = None) -> str:
+    """SHA-256 of a stable JSON projection of the request payload.
+
+    ``user_id`` is an optional discriminator. When ``None`` (current default)
+    the key is derived purely from the request shape, preserving today's
+    public-read behaviour. Callers should pass a stable user/role identifier
+    once RLS tightens (see module docstring) so two users with different
+    access levels can never share a cache entry.
+    """
     payload = {field: getattr(request, field, None) for field in _KEY_FIELDS}
+    if user_id is not None:
+        payload["__user__"] = user_id
     blob = json.dumps(payload, sort_keys=True, default=str)
     digest = hashlib.sha256(blob.encode("utf-8")).hexdigest()
     return f"{_CACHE_PREFIX}{digest}"
@@ -114,12 +123,18 @@ def _make_key(request: SearchChunksRequest) -> str:
 
 async def get_cached_search(
     request: SearchChunksRequest,
+    user_id: str | None = None,
 ) -> SearchChunksResponse | None:
     """Return a cached :class:`SearchChunksResponse` for *request* or ``None``.
 
     Bypasses the cache entirely for ``mode="thinking"`` (LLM-driven query
     rewriting is non-deterministic — caching would freeze a stale rewrite).
     Any Redis or deserialisation error is logged and treated as a miss.
+
+    ``user_id`` is forward-compatible: when provided it is folded into the
+    cache key so cached entries are partitioned per user. When omitted
+    (current behaviour) the key is request-only — safe today because every
+    field returned is public-read. See module docstring.
     """
     if request.mode == "thinking":
         return None
@@ -127,7 +142,7 @@ async def get_cached_search(
     if client is None:
         return None
     try:
-        raw = await client.get(_make_key(request))
+        raw = await client.get(_make_key(request, user_id))
     except Exception as exc:
         logger.warning(f"Search cache GET failed (treating as miss): {exc}")
         return None
@@ -145,8 +160,12 @@ async def get_cached_search(
 async def set_cached_search(
     request: SearchChunksRequest,
     response: SearchChunksResponse,
+    user_id: str | None = None,
 ) -> None:
-    """Store *response* under the request's cache key. Best-effort, never raises."""
+    """Store *response* under the request's cache key. Best-effort, never raises.
+
+    See :func:`get_cached_search` for the ``user_id`` semantics.
+    """
     if request.mode == "thinking":
         return
     client = _get_client()
@@ -154,7 +173,7 @@ async def set_cached_search(
         return
     try:
         await client.set(
-            _make_key(request),
+            _make_key(request, user_id),
             response.model_dump_json(),
             ex=_CACHE_TTL,
         )

--- a/backend/app/search_cache.py
+++ b/backend/app/search_cache.py
@@ -1,0 +1,173 @@
+"""Redis-backed cache for full search responses.
+
+Caches the *entire* :class:`SearchChunksResponse` (post-rerank, post-payload-
+build, post-estimated-total) keyed by a content-addressed digest of the
+:class:`SearchChunksRequest`. This complements the existing partial cache in
+``app.services.search_cache`` (which caches raw RPC rows pre-rerank).
+
+Why a separate layer?
+- The existing ``services.search_cache`` short-circuits the Supabase RPC but
+  still runs reranking, payload trimming, and ``estimated_total`` on every
+  request. For the blazing-fast path we want to skip *all* of that on a
+  warm cache hit and return the assembled response directly.
+- Mirrors the lazy-init / fail-soft pattern from ``app.embedding_cache``.
+
+DB index allocation (avoid collisions):
+- 1 → guest_sessions
+- 2 → embedding_cache, schema_generation
+- 3 → rate limiter (reserved)
+- 4 → search response cache (this module, default; configurable via
+       ``SEARCH_CACHE_REDIS_DB``)
+
+SECURITY CONTRACT — public-read only
+------------------------------------
+Cache keys are derived from the search inputs only. They DO NOT include any
+user identity, role, or session context. This is safe today because every
+field returned by the search endpoint is public-read under RLS. If RLS is
+ever tightened (per-user filters, premium fields, non-public tables), the
+cache key MUST be widened to include a stable user/role discriminator
+*before* shipping the change. See
+``app/services/search_cache.py`` for the longer write-up.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from app.models import SearchChunksRequest, SearchChunksResponse
+
+
+_CACHE_DB = int(os.getenv("SEARCH_CACHE_REDIS_DB", "4"))
+_CACHE_TTL = int(os.getenv("SEARCH_CACHE_TTL_SECONDS", "300"))
+_CACHE_PREFIX = "search:v1:"
+
+# Field order is part of the cache key contract: changing it invalidates
+# every existing entry. The "v1" prefix lets us bump the namespace cleanly
+# if the request schema grows.
+_KEY_FIELDS: tuple[str, ...] = (
+    "query",
+    "alpha",
+    "languages",
+    "mode",
+    "jurisdictions",
+    "court_names",
+    "court_levels",
+    "case_types",
+    "decision_types",
+    "outcomes",
+    "keywords",
+    "legal_topics",
+    "cited_legislation",
+    "date_from",
+    "date_to",
+    "offset",
+    "limit_docs",
+    "result_view",
+    "include_count",
+)
+
+_client = None  # lazy redis.asyncio.Redis | None
+
+
+def _get_client():
+    """Lazily construct the Redis client. Returns ``None`` on import error."""
+    global _client
+    if _client is not None:
+        return _client
+    try:
+        import redis.asyncio as redis
+
+        _client = redis.Redis(
+            host=os.getenv("REDIS_HOST", "localhost"),
+            port=int(os.getenv("REDIS_PORT", "6379")),
+            # Honor the spec's REDIS_PASSWORD name, but fall back to REDIS_AUTH
+            # for parity with embedding_cache / guest_sessions / Celery config.
+            password=os.getenv("REDIS_PASSWORD") or os.getenv("REDIS_AUTH") or None,
+            db=_CACHE_DB,
+            decode_responses=True,
+            socket_connect_timeout=2,
+            socket_timeout=2,
+        )
+        logger.info(
+            f"Search response cache: Redis db={_CACHE_DB} "
+            f"ttl={_CACHE_TTL}s prefix={_CACHE_PREFIX}"
+        )
+    except Exception as exc:
+        logger.warning(f"Search response cache: Redis init failed: {exc}")
+        _client = None
+    return _client
+
+
+def _make_key(request: SearchChunksRequest) -> str:
+    """SHA-256 of a stable JSON projection of the request payload."""
+    payload = {field: getattr(request, field, None) for field in _KEY_FIELDS}
+    blob = json.dumps(payload, sort_keys=True, default=str)
+    digest = hashlib.sha256(blob.encode("utf-8")).hexdigest()
+    return f"{_CACHE_PREFIX}{digest}"
+
+
+async def get_cached_search(
+    request: SearchChunksRequest,
+) -> SearchChunksResponse | None:
+    """Return a cached :class:`SearchChunksResponse` for *request* or ``None``.
+
+    Bypasses the cache entirely for ``mode="thinking"`` (LLM-driven query
+    rewriting is non-deterministic — caching would freeze a stale rewrite).
+    Any Redis or deserialisation error is logged and treated as a miss.
+    """
+    if request.mode == "thinking":
+        return None
+    client = _get_client()
+    if client is None:
+        return None
+    try:
+        raw = await client.get(_make_key(request))
+    except Exception as exc:
+        logger.warning(f"Search cache GET failed (treating as miss): {exc}")
+        return None
+    if raw is None:
+        return None
+    try:
+        from app.models import SearchChunksResponse
+
+        return SearchChunksResponse.model_validate_json(raw)
+    except Exception as exc:
+        logger.warning(f"Search cache: stale/invalid entry, ignoring: {exc}")
+        return None
+
+
+async def set_cached_search(
+    request: SearchChunksRequest,
+    response: SearchChunksResponse,
+) -> None:
+    """Store *response* under the request's cache key. Best-effort, never raises."""
+    if request.mode == "thinking":
+        return
+    client = _get_client()
+    if client is None:
+        return
+    try:
+        await client.set(
+            _make_key(request),
+            response.model_dump_json(),
+            ex=_CACHE_TTL,
+        )
+    except Exception as exc:
+        logger.warning(f"Search cache SET failed (non-fatal): {exc}")
+
+
+async def close() -> None:
+    """Close the Redis client. Safe to call when no client exists."""
+    import contextlib
+
+    global _client
+    if _client is not None:
+        with contextlib.suppress(Exception):
+            await _client.aclose()
+        _client = None

--- a/backend/app/search_intelligence.py
+++ b/backend/app/search_intelligence.py
@@ -166,7 +166,6 @@ class IntelligentRanker:
     # Document type scores (based on query context)
     TYPE_SCORES = {
         "judgment": 0.9,
-        "tax_interpretation": 0.8,
         "legislation": 0.7,
         "regulation": 0.6,
         "article": 0.5,
@@ -409,7 +408,6 @@ class IntelligentRanker:
 
         type_explanations = {
             "judgment": "Court judgment - primary legal authority",
-            "tax_interpretation": "Tax authority interpretation - official guidance",
             "legislation": "Legislative text - statutory law",
             "regulation": "Administrative regulation - binding rules",
             "article": "Academic article - scholarly analysis",

--- a/backend/app/services/search_cache.py
+++ b/backend/app/services/search_cache.py
@@ -84,13 +84,19 @@ def _result_key(
     alpha: float | None,
     limit: int | None,
     offset: int | None,
+    user_id: str | None = None,
 ) -> str:
-    """Deterministic cache key for a search result set."""
-    payload = json.dumps(
-        {"q": query, "f": filters, "a": alpha, "l": limit, "o": offset},
-        sort_keys=True,
-        default=str,
-    )
+    """Deterministic cache key for a search result set.
+
+    ``user_id`` is an optional discriminator. When ``None`` (current default)
+    the key is request-only, preserving today's public-read behaviour.
+    Once RLS tightens, callers MUST pass a stable user/role identifier so
+    cache entries are partitioned per user. See module docstring.
+    """
+    blob = {"q": query, "f": filters, "a": alpha, "l": limit, "o": offset}
+    if user_id is not None:
+        blob["u"] = user_id
+    payload = json.dumps(blob, sort_keys=True, default=str)
     digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:32]
     return f"{_RES_PREFIX}{digest}"
 
@@ -136,13 +142,20 @@ async def get_cached_results(
     alpha: float | None = None,
     limit: int | None = None,
     offset: int | None = None,
+    user_id: str | None = None,
 ) -> dict | list | None:
-    """Return cached search results, or ``None`` on miss/error."""
+    """Return cached search results, or ``None`` on miss/error.
+
+    ``user_id`` is forward-compatible: when ``None`` (current default) the
+    key is request-only — safe today because RLS exposes public-read on
+    every cached field. See module docstring for the contract you accept
+    by relying on the default.
+    """
     if not _cache_enabled():
         return None
     try:
         raw = await _redis_client.get(  # type: ignore[union-attr]
-            _result_key(query, filters, alpha, limit, offset)
+            _result_key(query, filters, alpha, limit, offset, user_id)
         )
         if raw is not None:
             return json.loads(raw)
@@ -158,12 +171,16 @@ async def set_cached_results(
     alpha: float | None = None,
     limit: int | None = None,
     offset: int | None = None,
+    user_id: str | None = None,
 ) -> None:
-    """Store search results in the cache."""
+    """Store search results in the cache.
+
+    See :func:`get_cached_results` for the ``user_id`` semantics.
+    """
     if not _cache_enabled():
         return
     try:
-        key = _result_key(query, filters, alpha, limit, offset)
+        key = _result_key(query, filters, alpha, limit, offset, user_id)
         value = json.dumps(results, default=str)
         await _redis_client.setex(key, settings.SEARCH_RESULT_CACHE_TTL, value)  # type: ignore[union-attr]
     except Exception as exc:

--- a/backend/app/utils/__init__.py
+++ b/backend/app/utils/__init__.py
@@ -9,7 +9,6 @@ from app.utils.similarity_graph import (
 )
 from app.utils.validators import (
     validate_array_size,
-    validate_document_types,
     validate_languages,
     validate_string_length,
 )
@@ -21,7 +20,6 @@ __all__ = [
     "serialize_date",
     "serialize_document_for_similarity",
     "validate_array_size",
-    "validate_document_types",
     "validate_languages",
     "validate_string_length",
 ]

--- a/backend/app/utils/validators.py
+++ b/backend/app/utils/validators.py
@@ -71,29 +71,3 @@ def validate_languages(v: list[str] | None) -> list[str] | None:
             normalized.append(lang_lower)
 
     return normalized
-
-
-def validate_document_types(v: list[str] | None) -> list[str] | None:
-    """Validate document types - accept both 'judgment' and 'judgement' (normalize to 'judgment')."""
-    if not v:
-        return v
-
-    valid_types = {"judgment", "tax_interpretation"}
-    # Also accept British spelling "judgement" and normalize to "judgment"
-    valid_types_with_alt = valid_types | {"judgement"}
-    normalized = []
-
-    for doc_type in v:
-        doc_type_lower = doc_type.strip().lower()
-        if doc_type_lower not in valid_types_with_alt:
-            raise ValueError(
-                f"Invalid document_type: '{doc_type}'. "
-                f"Must be one of: 'judgment' (or 'judgement'), 'tax_interpretation'"
-            )
-        # Normalize "judgement" to "judgment"
-        if doc_type_lower == "judgement":
-            normalized.append("judgment")
-        else:
-            normalized.append(doc_type_lower)
-
-    return normalized

--- a/backend/packages/juddges_search/juddges_search/chains/models.py
+++ b/backend/packages/juddges_search/juddges_search/chains/models.py
@@ -36,7 +36,7 @@ class DocumentRetrievalInput(BaseModel):
         default=None,
     )
     document_types: list[str] | None = Field(
-        description="List of document types to filter (e.g., ['judgment', 'tax_interpretation'])",
+        description="List of document types to filter (e.g., ['judgment'])",
         default=None,
     )
 
@@ -62,7 +62,7 @@ class DocumentRetrieval(BaseModel):
         default=None,
     )
     document_types: list[str] | None = Field(
-        description="List of document types to filter (e.g., ['judgment', 'tax_interpretation'])",
+        description="List of document types to filter (e.g., ['judgment'])",
         default=None,
     )
     response_format: str | None = Field(

--- a/backend/packages/juddges_search/juddges_search/db/documents_db.py
+++ b/backend/packages/juddges_search/juddges_search/db/documents_db.py
@@ -85,7 +85,7 @@ class SupabaseVectorDB(SupabaseClientMixin):
         Args:
             query_text: Text query for full-text search
             query_embedding: 1024-dimensional embedding vector
-            document_type: Filter by document type (e.g., "judgment", "tax_interpretation")
+            document_type: Filter by document type (e.g., "judgment")
             court_name: Filter by court name (partial match)
             language: Filter by language code (e.g., "pl", "en")
             start_date: Filter documents issued after this date (ISO format)

--- a/backend/packages/juddges_search/juddges_search/models.py
+++ b/backend/packages/juddges_search/juddges_search/models.py
@@ -5,10 +5,16 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class DocumentType(str, Enum):
-    """Enumeration of supported legal document types."""
+    """Enumeration of supported legal document types.
+
+    Search is judgment-only as of 2026-05-09; the enum is retained as a
+    one-value placeholder so existing imports keep compiling. Consumers
+    that still reference removed members (e.g. ``TAX_INTERPRETATION``)
+    will fail at attribute-access time and are cleaned up in follow-up
+    tasks per ``docs/superpowers/specs/2026-05-09-search-judgment-only-blazing-fast.md``.
+    """
 
     JUDGMENT = "judgment"
-    TAX_INTERPRETATION = "tax_interpretation"
 
 
 class SegmentType(str, Enum):

--- a/backend/packages/juddges_search/juddges_search/models.py
+++ b/backend/packages/juddges_search/juddges_search/models.py
@@ -8,10 +8,9 @@ class DocumentType(str, Enum):
     """Enumeration of supported legal document types.
 
     Search is judgment-only as of 2026-05-09; the enum is retained as a
-    one-value placeholder so existing imports keep compiling. Consumers
-    that still reference removed members (e.g. ``TAX_INTERPRETATION``)
-    will fail at attribute-access time and are cleaned up in follow-up
-    tasks per ``docs/superpowers/specs/2026-05-09-search-judgment-only-blazing-fast.md``.
+    one-value placeholder so existing imports keep compiling. See
+    ``docs/superpowers/specs/2026-05-09-search-judgment-only-blazing-fast.md``
+    for the migration that collapsed the enum.
     """
 
     JUDGMENT = "judgment"

--- a/backend/packages/juddges_search/juddges_search/retrieval/utils.py
+++ b/backend/packages/juddges_search/juddges_search/retrieval/utils.py
@@ -220,13 +220,6 @@ def convert_obj_to_legal_document(obj, include_vectors: bool = False, include_sc
         # Normalize common variations
         doc_type_str = doc_type_str.replace("judgement", "judgment")
 
-        # Handle "tax interpretation" (with space) -> "tax_interpretation"
-        if "tax interpretation" in doc_type_str:
-            doc_type_str = doc_type_str.replace("tax interpretation", "tax_interpretation")
-        # Only replace standalone "interpretation" if it's not already "tax_interpretation"
-        elif doc_type_str == "interpretation":
-            doc_type_str = "tax_interpretation"
-
         try:
             document_type = DocumentType(doc_type_str)
         except (ValueError, KeyError):
@@ -408,13 +401,6 @@ def convert_obj_to_legal_document_metadata(obj, score: Optional[float] = None) -
     else:
         # Normalize common variations
         doc_type_str = doc_type_str.replace("judgement", "judgment")
-
-        # Handle "tax interpretation" (with space) -> "tax_interpretation"
-        if "tax interpretation" in doc_type_str:
-            doc_type_str = doc_type_str.replace("tax interpretation", "tax_interpretation")
-        # Only replace standalone "interpretation" if it's not already "tax_interpretation"
-        elif doc_type_str == "interpretation":
-            doc_type_str = "tax_interpretation"
 
         try:
             document_type = DocumentType(doc_type_str)

--- a/backend/packages/schema_generator_agent/schema_generator_agent/agents/schema_generator.py
+++ b/backend/packages/schema_generator_agent/schema_generator_agent/agents/schema_generator.py
@@ -244,10 +244,10 @@ def route_after_data_assessment_merger(state: AgentState) -> str:
 
 
 def load_prompts(document_type: DocumentType) -> dict[str, str]:
-    if document_type == DocumentType.TAX_INTERPRETATION:
-        system_type = "tax"
-    else:
-        system_type = "law"
+    # Search is judgment-only as of 2026-05-09 (see docs/superpowers/specs/
+    # 2026-05-09-search-judgment-only-blazing-fast.md); the legacy tax branch
+    # was removed alongside the corresponding DocumentType enum member.
+    system_type = "law"
 
     prompt_names = [
         "problem_definer_helper",

--- a/backend/packages/schema_generator_agent/scripts/schema_generator.py
+++ b/backend/packages/schema_generator_agent/scripts/schema_generator.py
@@ -39,10 +39,11 @@ def load_prompts(system_type: str) -> dict[str, str]:
 
 
 def main() -> None:
-    assert SYSTEM_TYPE in ["law", "tax"], "Invalid system type"
-    document_type = (
-        DocumentType.JUDGMENT if SYSTEM_TYPE == "law" else DocumentType.TAX_INTERPRETATION
-    )
+    # Search is judgment-only as of 2026-05-09 (see docs/superpowers/specs/
+    # 2026-05-09-search-judgment-only-blazing-fast.md); the legacy tax branch
+    # was removed alongside the corresponding DocumentType enum member.
+    assert SYSTEM_TYPE == "law", "Invalid system type (only 'law' is supported)"
+    document_type = DocumentType.JUDGMENT
     prompts = load_prompts(SYSTEM_TYPE)
 
     llm = ChatOpenAI(

--- a/backend/tests/app/test_graphql_converters.py
+++ b/backend/tests/app/test_graphql_converters.py
@@ -27,7 +27,6 @@ from app.graphql_api.converters import (
 
 class MockDocType(Enum):
     JUDGMENT = "judgment"
-    TAX_INTERPRETATION = "tax_interpretation"
 
 
 class MockSegmentType(Enum):
@@ -107,9 +106,9 @@ class TestConvertLegalDocument:
         assert result.court_name == "Supreme Court"
 
     def test_document_type_enum_value(self):
-        doc = _make_doc(document_type=MockDocType.TAX_INTERPRETATION)
+        doc = _make_doc(document_type=MockDocType.JUDGMENT)
         result = convert_legal_document(doc)
-        assert result.document_type == "tax_interpretation"
+        assert result.document_type == "judgment"
 
     def test_document_type_string(self):
         doc = _make_doc(document_type="custom_type")
@@ -162,9 +161,9 @@ class TestConvertLegalDocumentMetadata:
         assert result.score == 0.95
 
     def test_enum_document_type(self):
-        meta = _make_metadata(document_type=MockDocType.TAX_INTERPRETATION)
+        meta = _make_metadata(document_type=MockDocType.JUDGMENT)
         result = convert_legal_document_metadata(meta)
-        assert result.document_type == "tax_interpretation"
+        assert result.document_type == "judgment"
 
     def test_string_document_type(self):
         meta = _make_metadata(document_type="custom")

--- a/backend/tests/app/test_precedents.py
+++ b/backend/tests/app/test_precedents.py
@@ -219,7 +219,7 @@ class TestApplyFilters:
             },
             {
                 "document_id": "doc-2",
-                "document_type": "tax_interpretation",
+                "document_type": "judgment",
                 "court_name": "Administrative Court",
                 "language": "en",
                 "date_issued": "2023-06-01",
@@ -244,7 +244,9 @@ class TestApplyFilters:
         results = self._make_results()
         filters = PrecedentFilters(document_types=["judgment"])
         filtered = _apply_filters(results, filters)
-        assert len(filtered) == 2
+        # All fixture rows are judgments now (TI removed); the in-memory
+        # document_types filter still exercises the in-list code path.
+        assert len(filtered) == 3
         assert all(r["document_type"] == "judgment" for r in filtered)
 
     def test_filter_by_court_name_case_insensitive(self):

--- a/backend/tests/app/test_query_analysis_pipeline.py
+++ b/backend/tests/app/test_query_analysis_pipeline.py
@@ -17,8 +17,15 @@ class _FakeSupabase:
         self.capture = capture
 
     def rpc(self, fn_name: str, params: dict[str, Any]):
-        self.capture["rpc_name"] = fn_name
-        self.capture["rpc_params"] = params
+        # Skip the count_judgments_filtered helper invoked after the search
+        # for first-page estimated_total — capture only the search rpc so the
+        # assertions remain stable when Task 6's count helper runs.
+        if fn_name != "count_judgments_filtered":
+            self.capture["rpc_name"] = fn_name
+            self.capture["rpc_params"] = params
+
+        if fn_name == "count_judgments_filtered":
+            return SimpleNamespace(execute=lambda: SimpleNamespace(data=0))
 
         row = {
             "id": "11111111-1111-1111-1111-111111111111",
@@ -62,6 +69,12 @@ class _FakeSupabaseSequenced:
         self.calls: list[dict[str, Any]] = []
 
     def rpc(self, fn_name: str, params: dict[str, Any]):
+        # Task 6 added a `count_judgments_filtered` rpc invoked after the
+        # search; isolate it from the search response sequence so the test
+        # fixtures stay focused on the hybrid-search branch.
+        if fn_name == "count_judgments_filtered":
+            return SimpleNamespace(execute=lambda: SimpleNamespace(data=0))
+
         self.capture["rpc_name"] = fn_name
         self.capture["rpc_params"] = params
         self.calls.append({"fn_name": fn_name, "params": params})

--- a/backend/tests/app/test_schema_generator.py
+++ b/backend/tests/app/test_schema_generator.py
@@ -173,9 +173,7 @@ class TestGetOrCreateAgent:
 
         from juddges_search.models import DocumentType
 
-        result = get_or_create_agent(
-            "session-1", DocumentType.TAX_INTERPRETATION, mock_request
-        )
+        result = get_or_create_agent("session-1", DocumentType.JUDGMENT, mock_request)
         assert result is mock_agent
 
     @patch("app.api.schema_generator._generation_sessions")
@@ -193,7 +191,7 @@ class TestGetOrCreateAgent:
         from juddges_search.models import DocumentType
 
         result = get_or_create_agent(
-            "existing-session", DocumentType.TAX_INTERPRETATION, mock_request
+            "existing-session", DocumentType.JUDGMENT, mock_request
         )
         assert result is mock_agent
 

--- a/backend/tests/app/test_search_quality_with_judge.py
+++ b/backend/tests/app/test_search_quality_with_judge.py
@@ -785,6 +785,10 @@ async def test_case_07_array_overlap_filters(
             "legal_topics": ["criminal law"],
             "cited_legislation": ["Penal Code"],
             "limit_docs": 10,
+            # Card view (default) trims keywords/legal_topics out of the
+            # response payload — request the full view so we can assert the
+            # filter actually matched.
+            "result_view": "full",
         },
     )
     assert response.status_code == 200

--- a/backend/tests/app/test_serializers.py
+++ b/backend/tests/app/test_serializers.py
@@ -1,17 +1,11 @@
 """Unit tests for app.utils.serializers module."""
 
 from datetime import datetime
-from enum import Enum
 
 import pytest
 from juddges_search.models import LegalDocument
 
 from app.utils.serializers import serialize_document_for_similarity
-
-
-class MockDocType(str, Enum):
-    JUDGMENT = "judgment"
-    RULING = "ruling"
 
 
 def _make_doc(**overrides) -> LegalDocument:
@@ -60,13 +54,7 @@ class TestSerializeDocumentForSimilarity:
     def test_document_type_string(self):
         doc = _make_doc(document_type="judgment")
         result = serialize_document_for_similarity(doc)
-        assert result["document_type"] is not None
-
-    def test_document_type_enum_value(self):
-        doc = _make_doc(document_type="tax_interpretation")
-        result = serialize_document_for_similarity(doc)
-        # Enum .value should be extracted
-        assert result["document_type"] == "tax_interpretation"
+        assert result["document_type"] == "judgment"
 
     def test_returns_expected_keys(self):
         doc = _make_doc()

--- a/docs/superpowers/specs/2026-05-09-search-judgment-only-blazing-fast.md
+++ b/docs/superpowers/specs/2026-05-09-search-judgment-only-blazing-fast.md
@@ -1,0 +1,253 @@
+# /search — judgment-only, blazing fast
+
+**Date:** 2026-05-09
+**Owner:** Lukasz
+**Status:** Approved (verbal); pending written review
+
+## Goal
+
+`POST /api/documents/search` (frontend) → `POST /documents/search` (backend) returns the first page of results almost instantaneously and never throws on the
+`document_type` invariant again. We achieve this by:
+
+1. **Removing all `document_type` machinery** from the search hot path — the
+   `judgments` table has no `document_type` column, the backend hard-coded
+   `JUDGMENT`, and the frontend coerced everything to `JUDGMENT` anyway. The
+   field is ceremony, not function.
+2. **Purging `tax_interpretation` codebase-wide** since search is the primary
+   surface and there are no other live consumers expected to keep it.
+3. **Five focused performance fixes** that cut wall-clock time per search.
+
+## Non-goals
+
+- LangServe chat/QA chains, citation network, similar-documents endpoints, the
+  schema_generator agent's prompt examples — those keep working with the same
+  visible behaviour. We touch them only to remove `tax_interpretation` literals.
+- The legacy `/documents/search/legacy` endpoint stays as-is.
+- We do **not** drop the `document_type` column from the `documents` table (if
+  one exists with `tax_interpretation` rows). We just stop reading the value
+  for routing.
+
+## Architecture changes
+
+### A. Search hot path simplification (judgment-only)
+
+| Layer | File | Change |
+|---|---|---|
+| Backend | `backend/app/documents.py` | `_build_search_result_payload` already omits `document_type` — leave it omitted. `_convert_judgment_to_legal_document` keeps hard-coded `DocumentType.JUDGMENT` (with the enum reduced to a single value, this is fine). Drop the `document_types` filter parameter from `search_documents`. |
+| Backend | `backend/app/models.py` | Drop `document_types` field and its validator from `SearchChunksRequest`. Same for `SearchDocumentsDirectRequest` if present. |
+| Frontend | `frontend/hooks/useSearchResults.ts` | Delete the parse/throw block at lines 431-451 and the duplicate at 778-787. Delete `documentTypes`/`requestedDocumentTypes`/`overrideDocumentTypes` parameters and their plumbing. |
+| Frontend | `frontend/hooks/useSearchUrlParams.ts` | Drop `document_type` URL param read/write. Drop `setDocumentTypes` calls. |
+| Frontend | `frontend/lib/store/searchStore.ts` | Drop `documentTypes` and `setDocumentTypes` from store. Drop `isUnknownDocumentType`. |
+| Frontend | `frontend/lib/api/search.ts` | Drop `document_types` from `SearchChunksInput` and `SearchDocumentsDirectInput`. |
+| Frontend | `frontend/types/search.ts` | Drop `document_type` from `LegalDocumentMetadata`, `SearchChunk`, `WeaviateDocument`. Keep on `SearchDocument` only if the document detail page still needs it (it doesn't — strip there too). |
+
+### B. Codebase-wide `tax_interpretation` purge
+
+#### Shared package
+- `backend/packages/juddges_search/juddges_search/models.py` — drop the
+  `DocumentType` enum entirely. Replace consumer references with the literal
+  string `"judgment"` or remove the field. (Enum had only two values; one
+  remaining value is not worth an enum.)
+
+#### Backend
+- `backend/app/dashboard.py:615` — change `.in_("document_type", [...])` to
+  `.eq("document_type", "judgment")` (preserves filter, cuts the
+  `tax_interpretation` rows). `dashboard.py:736` — drop from any list literal.
+- `backend/app/precedents.py:71` — strip `tax_interpretation` from filter
+  description and validation if present.
+- `backend/app/search_intelligence.py:169, 412` — drop the
+  `tax_interpretation` weight entry and description.
+- `backend/app/utils/validators.py` — `validate_document_types` either gets
+  deleted (if the param is gone) or accepts only `"judgment"`.
+- `backend/app/graphql_api/types.py` — drop `tax_interpretation` from any
+  enum/union types. **Public API surface change** — call out in PR description.
+- `backend/app/api/schema_generator.py` — drop from example doctype lists.
+- `backend/app/documents.py:1007-1056` and similar — search request
+  doctype-handling code goes away with Section A.
+- `backend/app/models.py` — drop `tax_interpretation` from any enum, examples,
+  doctype lists. Fix `SearchChunksRequest.document_types` (already going) and
+  any other model carrying the literal.
+- `backend/scripts/generate_lawyer_schemas.py` — drop from any list literals.
+
+#### Frontend
+- `frontend/types/search.ts:1-5` — remove the `DocumentType` enum entirely.
+  Replace consumers with the literal string `"judgment"`. Drop `ERROR` value.
+- `frontend/types/chat-sources.ts:101` — remove the `tax_interpretation` entry
+  from the source-type config map.
+- `frontend/components/chat/SourceCard.tsx:31, 40` — drop the
+  `TAX_INTERPRETATION` and `ERROR` switch cases.
+- `frontend/components/SchemaGenerator.tsx:46` — drop the
+  `tax_interpretation → "Legal document"` mapping.
+- `frontend/components/DocumentVisualization.tsx:59` — drop the
+  `tax_interpretation` colour entry.
+- `frontend/components/similarity-viz/types.ts:112, 120` — drop
+  `tax_interpretation` from type and colour map.
+- `frontend/components/dashboard/document-card-compact.tsx:17` — drop entry.
+- `frontend/app/extract/page.tsx:294` — remove the
+  `tax_interpretation` branch of the badge resolver.
+- `frontend/lib/styles/components/search-filters.tsx:78` — remove the
+  `tax_interpretation` style branch.
+- `frontend/lib/styles/components/document-card.tsx`,
+  `frontend/lib/styles/components/filter-toggle-group.tsx` — drop entries.
+- `frontend/components/SchemaGenerator.tsx`,
+  `frontend/__tests__/components/chat/SourceCard.test.tsx`,
+  `frontend/__tests__/lib/store/searchStore.test.ts`,
+  `frontend/__tests__/integration/search-flow.test.tsx`,
+  `frontend/__tests__/lib/api-client.test.ts`,
+  `frontend/__tests__/hooks/useGraphData.test.ts`,
+  `frontend/tests/e2e-docker/api-integration.spec.ts`,
+  `frontend/tests/e2e/api/backend-api.spec.ts`,
+  `frontend/tests/e2e/search/complete-search-flow.spec.ts`,
+  `frontend/tests/e2e/search/search-flow.spec.ts`,
+  `frontend/tests/e2e/helpers/api-mocks.ts` — drop fixtures and assertions on
+  `tax_interpretation`. **Deletion rule**: a test file or `describe`/`it`
+  block whose *sole purpose* is to assert `tax_interpretation` handling
+  (e.g., "renders TI badge", "filters TI correctly") is deleted. Tests that
+  iterate over both types simplify to judgment-only. Mixed integration tests
+  stay; their fixture data drops `tax_interpretation` entries.
+
+#### Backend tests
+- `backend/tests/app/test_serializers.py`,
+  `backend/tests/app/test_graphql_converters.py`,
+  `backend/tests/app/test_schema_generator.py`,
+  `backend/tests/app/test_precedents.py` — same treatment.
+
+#### Database
+- New migration `supabase/migrations/2026050900000X_drop_tax_interpretation_dashboard_stats.sql`:
+  ```sql
+  delete from dashboard_precomputed_stats
+  where stat_key in ('tax_interpretation', 'tax_interpretation_pl', 'tax_interpretation_uk');
+  ```
+  Existing migrations (`20260325`, `20260509`) are immutable history — leave
+  them. The forward migration removes the rows so dashboards stop showing zero
+  for "Tax Interpretations".
+
+### C. Performance fixes
+
+#### C1 — Eliminate the second round-trip
+`useSearchResults.search()` calls `searchChunks` and then immediately
+`fetchDocumentsByIds` for the same document IDs. The backend's search response
+already includes `documents` built from the same RPC rows. Skip the second
+fetch when `result.documents` is populated.
+
+- **Frontend**: in `useSearchResults.ts`, when `result.documents?.length`,
+  feed those directly into `fullDocumentsMapRef`. Only call
+  `fetchDocumentsByIds` for the (rare) gap case where chunks reference docs
+  not in `result.documents`.
+- **Frontend**: same treatment in `loadMore()`.
+- **Backend**: confirm the search response *always* includes lightweight
+  documents (it already does via `_build_search_result_payload`), and that
+  the lightweight shape matches what the card needs.
+- **Expected gain**: 150–300 ms per search, plus a JSON parse round.
+
+#### C2 — Trim response payload
+Add `result_view: Literal["card", "full"] = "card"` to `SearchChunksRequest`.
+
+- **Card view** returns only: `document_id`, `title`, `summary`,
+  `date_issued`, `publication_date`, `document_number`, `court_name`,
+  `language`, `country`. Roughly 9 fields, ~200 bytes per doc.
+- **Full view** returns the existing payload (used by detail panels if any).
+- The detail page (`GET /documents/{id}`) is the canonical full-doc fetch and
+  is unchanged.
+- **Frontend**: drop the long `return_properties` list from
+  `fetchDocumentsByIds` calls inside `useSearchResults` (no longer needed
+  since C1 skips them on the happy path; if invoked as fallback, request the
+  card-view fields).
+- **Expected gain**: 5–10× JSON shrink, less parse work, less wire time.
+
+#### C3 — Redis result cache
+New module `backend/app/search_cache.py` mirroring the pattern in
+`backend/app/embedding_cache.py`.
+
+- Cache key: SHA-256 of normalised JSON of (query, alpha, languages, mode,
+  jurisdictions, court_names, court_levels, case_types, decision_types,
+  outcomes, keywords, legal_topics, cited_legislation, date_from, date_to,
+  offset, limit_docs, result_view).
+- Cache value: serialised `SearchChunksResponse` (Pydantic
+  `model_dump_json()`).
+- TTL: 300 s (env-overridable via `SEARCH_CACHE_TTL_SECONDS`).
+- DB index: `_CACHE_DB = 4` (or whatever the next free index is given
+  embedding cache uses 1 and rate limits use 2 — confirm during impl).
+- Bypass: when `mode == "thinking"` (LLM analysis is non-deterministic) and
+  when `request.no_cache` is true (for benchmarking; default false).
+- Insert *after* rerank, *before* response model serialisation, so hits skip
+  even Pydantic round-trip overhead. Hits return the raw JSON string with
+  appropriate `Content-Type` header.
+- **Expected gain**: hot queries return in <50 ms wall-clock.
+
+#### C4 — Fix `estimated_total`
+Today `_build_search_pagination` hard-codes `estimated_total=None`. Frontend
+asks for `include_count=True` and silently gets nothing.
+
+- Add a count helper that runs alongside the search RPC for the first page
+  only (`offset == 0` and `request.include_count`).
+- Implementation: a new Postgres function `count_judgments_filtered(...)` in
+  `supabase/migrations/2026050900000Y_add_count_judgments_filtered.sql` that
+  takes the same filter parameters as `search_judgments_hybrid` and returns
+  `COUNT(*)`. Call it via `supabase.rpc(...)` from the same backend method.
+  Reasoning: keeping count logic next to search logic prevents drift when
+  filters evolve.
+- Cache the count for 60 s per filter combination (subset of the C3 cache).
+- The number is informative ("about 1,243 judgments"), not exact — that's
+  fine for an "estimated total".
+
+#### C5 — Logging cleanup
+The frontend `useSearchResults` has ~12 `searchLogger.info(...)` calls in the
+hot path. Each serialises a payload object. Prune to 2–3 phase markers:
+"search start", "results received", "render ready". Errors and warnings
+stay verbose. Same on the backend `documents.py` — keep timing breakdown logs,
+delete chunks-cache-state diagnostics that were added for debugging the bug.
+
+## Out of scope
+
+- Streaming/SSE first-result-fast (Strategic option, deferred).
+- Separate fast-path RPC for keyword-only queries (Strategic, deferred).
+- Server-side rendering of initial results (Strategic, deferred).
+- Reranker tuning.
+- Embedding model swap.
+
+## Verification
+
+- Frontend: `npm run validate` (lint + typecheck) passes.
+- Backend: `poetry run poe check-all` passes.
+- Frontend Jest: existing tests pass after the targeted updates.
+- Backend pytest: existing tests pass after the targeted updates.
+- Manual: searches for "Intellectual property", "podatek VAT", and an
+  empty-query edge case all return a populated page within 1 s on first hit
+  and <100 ms on warm hit (cached).
+- No `document_type` or `tax_interpretation` strings remain in production
+  code paths (allowed in: history migrations, this spec, and CHANGELOG).
+
+## Implementation tasks (subagent-dispatch decomposition)
+
+Sequential dispatch — fresh subagent per task with spec-compliance + code-quality
+review between tasks (per `superpowers:subagent-driven-development`). Cannot
+literally parallelise implementers because tasks share the `DocumentType` enum
+file and other shared modules.
+
+| # | Task | Files (approx) |
+|---|---|---|
+| 1 | **Shared enum + DB migration**: collapse `DocumentType` enum to single value (or remove) in `juddges_search/models.py`; write SQL migration to drop dashboard stats rows | `backend/packages/juddges_search/juddges_search/models.py`, new `supabase/migrations/...sql` |
+| 2 | **Backend search hot path**: drop `document_types` from `SearchChunksRequest`, drop filter-application code in `documents.py`; trim `_convert_judgment_to_legal_document` callers | `backend/app/documents.py`, `backend/app/models.py`, `backend/app/utils/validators.py` |
+| 3 | **Backend tax_interpretation purge (non-search)**: dashboard, precedents, search_intelligence, graphql_api/types, schema_generator, scripts | `backend/app/dashboard.py`, `backend/app/precedents.py`, `backend/app/search_intelligence.py`, `backend/app/graphql_api/types.py`, `backend/app/api/schema_generator.py`, `backend/scripts/generate_lawyer_schemas.py` |
+| 4 | **Frontend search hot path** (incl. C1 + C5): remove document_type plumbing, eliminate second round-trip, prune logging | `frontend/hooks/useSearchResults.ts`, `frontend/hooks/useSearchUrlParams.ts`, `frontend/lib/store/searchStore.ts`, `frontend/lib/api/search.ts`, `frontend/types/search.ts` |
+| 5 | **Frontend tax_interpretation purge (non-search)**: chat sources, schema generator, visualizations, badges, styles | `frontend/types/chat-sources.ts`, `frontend/components/chat/SourceCard.tsx`, `frontend/components/SchemaGenerator.tsx`, `frontend/components/DocumentVisualization.tsx`, `frontend/components/similarity-viz/types.ts`, `frontend/components/dashboard/document-card-compact.tsx`, `frontend/app/extract/page.tsx`, `frontend/lib/styles/components/*.tsx` |
+| 6 | **Backend perf C2 + C4**: `result_view` param, payload trim, `estimated_total` count helper | `backend/app/documents.py`, `backend/app/models.py`, possibly new `supabase/migrations/...count.sql` |
+| 7 | **Backend perf C3**: Redis search result cache | new `backend/app/search_cache.py`, integration in `backend/app/documents.py` |
+| 8 | **Tests update**: backend pytest fixtures + frontend Jest + Playwright fixtures and assertions | `backend/tests/app/test_*.py`, `frontend/__tests__/**/*`, `frontend/tests/e2e/**/*` |
+| 9 | **Final verification**: `poetry run poe check-all`, `npm run validate`, `npm run test`, manual search smoke | (no source files) |
+
+## Risk register
+
+- **GraphQL type drop** (Task 3) is a public schema change. If external
+  consumers exist, this breaks them. Mitigation: confirm during impl that no
+  external clients query `tax_interpretation` (search Slack / docs / contact
+  list — owner: Lukasz). For internal-only use, ship.
+- **Dashboard "Featured examples" composition** (Task 3) currently dedupes by
+  doc type to show variety. With one type, dedup logic still works — code
+  becomes simpler.
+- **Cache invalidation** (Task 7): if data freshness becomes a concern, the
+  300 s TTL is the upper bound on staleness for hot queries. Acceptable per
+  Tactical scope.
+- **`estimated_total` accuracy** (Task 6): the count helper does not reflect
+  reranker filtering. We document it as "approximate" in the response field.

--- a/frontend/__tests__/components/chat/SourceCard.test.tsx
+++ b/frontend/__tests__/components/chat/SourceCard.test.tsx
@@ -6,7 +6,6 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SourceCard } from '@/components/chat/SourceCard';
-import { DocumentType } from '@/types/search';
 
 jest.mock('next/link', () => {
   return ({ children, ...props }: any) => <a {...props}>{children}</a>;
@@ -15,7 +14,7 @@ jest.mock('next/link', () => {
 describe('SourceCard', () => {
   const baseDocument = {
     document_id: 'doc-123',
-    document_type: DocumentType.JUDGMENT,
+    document_type: 'judgment',
     title: 'Contract Law Case 2024',
     document_number: 'XII C 123/24',
     date_issued: '2024-01-15',
@@ -53,27 +52,14 @@ describe('SourceCard', () => {
     expect(screen.getByRole('link')).toHaveAttribute('target', '_blank');
   });
 
-  it('falls back to the generic document label for tax interpretations', () => {
-    render(
-      <SourceCard
-        document={{
-          ...baseDocument,
-          document_type: DocumentType.TAX_INTERPRETATION,
-          document_number: 'INT-2024-001',
-        } as any}
-      />
-    );
-
-    expect(screen.getByText('Document')).toBeInTheDocument();
-    expect(screen.getByText('INT-2024-001')).toBeInTheDocument();
-  });
-
   it('renders the database warning for flagged error documents', () => {
     render(
       <SourceCard
         document={{
           ...baseDocument,
-          document_type: DocumentType.ERROR,
+          // Database errors are signalled by the `_isWeaviateError` /
+          // `_isDatabaseError` flags, not via a separate document_type.
+          _isWeaviateError: true,
           _isDatabaseError: true,
         } as any}
       />

--- a/frontend/__tests__/components/search/SearchForm.test.tsx
+++ b/frontend/__tests__/components/search/SearchForm.test.tsx
@@ -6,7 +6,6 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SearchForm } from '@/lib/styles/components/search/SearchForm';
-import { DocumentType } from '@/types/search';
 
 describe('SearchForm', () => {
   const defaultProps = {
@@ -14,11 +13,8 @@ describe('SearchForm', () => {
     setQuery: jest.fn(),
     searchType: 'thinking' as const,
     setSearchType: jest.fn(),
-    documentTypes: [DocumentType.JUDGMENT],
-    toggleDocumentType: jest.fn(),
     selectedLanguages: new Set(['pl']),
     toggleLanguage: jest.fn(),
-    setDocumentTypes: jest.fn(),
     setSelectedLanguages: jest.fn(),
     isSearching: false,
     hasResults: false,
@@ -84,7 +80,6 @@ describe('SearchForm', () => {
     const user = userEvent.setup();
     const setQuery = jest.fn();
     const setSearchType = jest.fn();
-    const setDocumentTypes = jest.fn();
     const setSelectedLanguages = jest.fn();
 
     render(
@@ -92,7 +87,6 @@ describe('SearchForm', () => {
         {...defaultProps}
         setQuery={setQuery}
         setSearchType={setSearchType}
-        setDocumentTypes={setDocumentTypes}
         setSelectedLanguages={setSelectedLanguages}
       />
     );
@@ -101,7 +95,6 @@ describe('SearchForm', () => {
 
     expect(setQuery).toHaveBeenCalledWith('Intellectual property');
     expect(setSearchType).toHaveBeenCalledWith('thinking');
-    expect(setDocumentTypes).toHaveBeenCalledWith([DocumentType.JUDGMENT]);
     expect(setSelectedLanguages).toHaveBeenCalledWith(new Set(['uk']));
   });
 

--- a/frontend/__tests__/components/search/SearchResultsSection.test.tsx
+++ b/frontend/__tests__/components/search/SearchResultsSection.test.tsx
@@ -6,7 +6,6 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SearchResultsSection } from '@/lib/styles/components/search/SearchResultsSection';
-import { DocumentType } from '@/types/search';
 
 jest.mock('@/lib/styles/components', () => ({
   SearchDocumentCard: ({ doc, isSelected, onToggleSelection, resultPosition }: any) => (
@@ -45,13 +44,13 @@ describe('SearchResultsSection', () => {
     {
       document_id: 'doc-1',
       title: 'First judgment',
-      document_type: DocumentType.JUDGMENT,
+      document_type: 'judgment',
       language: 'en',
     },
     {
       document_id: 'doc-2',
       title: 'Second judgment',
-      document_type: DocumentType.JUDGMENT,
+      document_type: 'judgment',
       language: 'pl',
     },
   ];

--- a/frontend/__tests__/hooks/useGraphData.test.ts
+++ b/frontend/__tests__/hooks/useGraphData.test.ts
@@ -14,7 +14,6 @@ import {
   formatDate,
   truncateText,
 } from '@/lib/hooks/useGraphData';
-import { DocumentType } from '@/types/search';
 import type {
   SimilarityFilters,
   DocumentSimilarity,
@@ -28,7 +27,7 @@ function createDocument(overrides: Partial<any> = {}) {
   return {
     document_id: 'doc-1',
     title: 'Test Judgment',
-    document_type: DocumentType.JUDGMENT,
+    document_type: 'judgment',
     full_text: 'Full text content.',
     summary: 'Summary text.',
     created_at: '2024-01-15T00:00:00Z',
@@ -42,7 +41,6 @@ function createDocument(overrides: Partial<any> = {}) {
 
 function createFilters(overrides: Partial<SimilarityFilters> = {}): SimilarityFilters {
   return {
-    documentTypes: [],
     languages: [],
     dateRange: null,
     similarityThreshold: 0, // low threshold to include everything
@@ -91,7 +89,7 @@ describe('useGraphData', () => {
       const node = result.current.nodes[0];
       expect(node.id).toBe('doc-1');
       expect(node.title).toBe('Test Judgment');
-      expect(node.documentType).toBe(DocumentType.JUDGMENT);
+      expect(node.documentType).toBe('judgment');
       expect(node.language).toBe('en');
       expect(node.keywords).toEqual(['contract']);
     });
@@ -186,25 +184,6 @@ describe('useGraphData', () => {
       expect(result.current.links).toHaveLength(0);
     });
 
-    it('excludes links where one document is filtered out', () => {
-      const docs = [
-        createDocument({ document_id: 'a', document_type: DocumentType.JUDGMENT }),
-        createDocument({ document_id: 'b', document_type: DocumentType.TAX_INTERPRETATION }),
-      ];
-      const sims = [createSimilarity('a', 'b', 0.9)];
-      // Filter to only JUDGMENT type
-      const filters = createFilters({
-        documentTypes: [DocumentType.JUDGMENT],
-        similarityThreshold: 0,
-      });
-
-      const { result } = renderHook(() =>
-        useGraphData(docs, sims, filters)
-      );
-
-      // Only 'a' passes the filter, so no link can be formed
-      expect(result.current.links).toHaveLength(0);
-    });
   });
 
   describe('shared concepts', () => {
@@ -266,26 +245,6 @@ describe('useGraphData', () => {
       const nodeA = result.current.nodes.find((n) => n.id === 'a');
       expect(nodeA?.clusterSize).toBe(2);
       expect(nodeA?.avgSimilarity).toBeCloseTo(0.7, 5);
-    });
-  });
-
-  describe('document type filtering', () => {
-    it('filters documents by type', () => {
-      const docs = [
-        createDocument({ document_id: 'a', document_type: DocumentType.JUDGMENT }),
-        createDocument({ document_id: 'b', document_type: DocumentType.TAX_INTERPRETATION }),
-      ];
-      const filters = createFilters({
-        documentTypes: [DocumentType.JUDGMENT],
-        similarityThreshold: 0,
-      });
-
-      const { result } = renderHook(() =>
-        useGraphData(docs, [], filters)
-      );
-
-      expect(result.current.nodes).toHaveLength(1);
-      expect(result.current.nodes[0].id).toBe('a');
     });
   });
 
@@ -484,13 +443,8 @@ describe('useGraphData', () => {
 
 describe('getNodeColor', () => {
   it('returns the correct color for a judgment node', () => {
-    const node = { documentType: DocumentType.JUDGMENT } as GraphNode;
+    const node = { documentType: 'judgment' } as GraphNode;
     expect(getNodeColor(node)).toBe('#6366f1');
-  });
-
-  it('returns the correct color for a tax_interpretation node', () => {
-    const node = { documentType: DocumentType.TAX_INTERPRETATION } as GraphNode;
-    expect(getNodeColor(node)).toBe('#10B981');
   });
 
   it('returns default color for unknown document type', () => {

--- a/frontend/__tests__/hooks/useNodeInteractions.test.ts
+++ b/frontend/__tests__/hooks/useNodeInteractions.test.ts
@@ -12,7 +12,6 @@ import {
   getNodeSize,
   getNodeOpacity,
 } from '@/lib/hooks/useNodeInteractions';
-import { DocumentType } from '@/types/search';
 import type { GraphNode } from '@/components/similarity-viz/types';
 
 // --- Test Data Factory ---
@@ -21,7 +20,7 @@ function createNode(overrides: Partial<GraphNode> = {}): GraphNode {
   return {
     id: 'node-1',
     title: 'Test Node',
-    documentType: DocumentType.JUDGMENT,
+    documentType: 'judgment',
     documentId: 'doc-1',
     fullText: 'text',
     date: new Date('2024-01-01'),

--- a/frontend/__tests__/hooks/useSearchResults.test.ts
+++ b/frontend/__tests__/hooks/useSearchResults.test.ts
@@ -5,11 +5,9 @@
 import { act, renderHook } from '@testing-library/react';
 import { useSearchResults } from '@/hooks/useSearchResults';
 import { useSearchStore } from '@/lib/store/searchStore';
-import { DocumentType } from '@/types/search';
 
 jest.mock('@/lib/store/searchStore', () => ({
   useSearchStore: jest.fn(),
-  isUnknownDocumentType: jest.fn(() => false),
 }));
 
 jest.mock('@/lib/api', () => ({
@@ -42,7 +40,7 @@ describe('useSearchResults', () => {
 
   const createDocument = (documentId: string) => ({
     document_id: documentId,
-    document_type: DocumentType.JUDGMENT,
+    document_type: 'judgment',
     title: `Title ${documentId}`,
     date_issued: '2024-01-15',
     issuing_body: null,
@@ -76,9 +74,7 @@ describe('useSearchResults', () => {
     storeState = {
       query: 'contract law',
       searchType: 'thinking',
-      documentTypes: [DocumentType.JUDGMENT],
       selectedLanguages: new Set(['en']),
-      ignoreUnknownType: false,
       chunksCache: {},
       loadingChunks: new Set<string>(),
       searchMetadata: [],
@@ -144,7 +140,6 @@ describe('useSearchResults', () => {
         query: 'contract law',
         mode: 'thinking',
         languages: ['en'],
-        document_types: [DocumentType.JUDGMENT],
       })
     );
     expect(mockFetchDocumentsByIds).toHaveBeenCalledWith(
@@ -152,11 +147,14 @@ describe('useSearchResults', () => {
         document_ids: ['doc-1'],
       })
     );
+    // After the search-judgment-only refactor the metadata coerces every
+    // result to a judgment in the UI, so the per-row payload no longer
+    // carries a redundant `document_type` field — assert only on the
+    // identifying fields that are still present.
     expect(storeState.setSearchMetadata).toHaveBeenCalledWith(
       expect.arrayContaining([
         expect.objectContaining({
           document_id: 'doc-1',
-          document_type: DocumentType.JUDGMENT,
         }),
       ]),
       1,

--- a/frontend/__tests__/integration/search-flow.test.tsx
+++ b/frontend/__tests__/integration/search-flow.test.tsx
@@ -37,8 +37,6 @@ function createDefaultSearchStore(): Record<string, any> {
   return {
     query: '',
     setQuery: jest.fn(),
-    documentTypes: ['judgment'],
-    setDocumentTypes: jest.fn(),
     selectedLanguages: new Set(['pl']),
     setSelectedLanguages: jest.fn(),
     isSearching: false,
@@ -55,7 +53,6 @@ function createDefaultSearchStore(): Record<string, any> {
     filters: {
       keywords: new Set(),
       legalConcepts: new Set(),
-      documentTypes: new Set(),
       issuingBodies: new Set(),
       languages: new Set(),
       jurisdictions: new Set(),
@@ -93,7 +90,6 @@ function createDefaultSearchStore(): Record<string, any> {
     getAvailableFiltersFromMetadata: jest.fn(() => ({
       keywords: [],
       legalConcepts: [],
-      documentTypes: [],
       issuingBodies: [],
       languages: [],
       jurisdictions: [],
@@ -135,10 +131,10 @@ const mockSearchResults = {
     {
       document_id: 'doc-2',
       uuid: 'uuid-2',
-      title: 'Tax Interpretation 2023',
-      court_name: 'Tax Chamber',
+      title: 'Civil Procedure Ruling 2023',
+      court_name: 'Supreme Court',
       date_issued: '2023-12-10',
-      document_type: 'tax_interpretation',
+      document_type: 'judgment',
       language: 'pl',
       score: 0.88,
     },
@@ -390,7 +386,8 @@ describe('Complete Search Flow Integration', () => {
       const ipBoxSearch = screen.getByText('Intellectual property');
       await user.click(ipBoxSearch);
 
-      expect(mockSearchStore.setDocumentTypes).toHaveBeenCalled();
+      // Search collapsed to judgment-only — popular searches no longer
+      // configure document_types; verify the language preset still applies.
       expect(mockSearchStore.setSelectedLanguages).toHaveBeenCalled();
     });
   });
@@ -406,32 +403,6 @@ describe('Complete Search Flow Integration', () => {
       });
 
       // Mode switch would be tested here via SearchConfiguration component
-    });
-  });
-
-  describe('Document Type Selection', () => {
-    it('should allow selecting document types', async () => {
-      const user = userEvent.setup();
-
-      renderWithProviders(<SearchPage />);
-
-      await waitFor(() => {
-        expect(screen.getByRole('textbox')).toBeInTheDocument();
-      });
-
-      // Document type selection would be tested here
-    });
-
-    it('should update search when document types change', async () => {
-      const user = userEvent.setup();
-
-      renderWithProviders(<SearchPage />);
-
-      await waitFor(() => {
-        expect(screen.getByRole('textbox')).toBeInTheDocument();
-      });
-
-      // Verify that changing document types triggers appropriate updates
     });
   });
 

--- a/frontend/__tests__/lib/api-client.test.ts
+++ b/frontend/__tests__/lib/api-client.test.ts
@@ -8,7 +8,6 @@
  */
 
 import '@testing-library/jest-dom';
-import { DocumentType } from '@/types/search';
 
 // Mock fetch globally
 global.fetch = jest.fn();
@@ -51,7 +50,6 @@ describe('API Client', () => {
         body: JSON.stringify({
           query: 'contract law',
           filters: {
-            documentTypes: [DocumentType.JUDGMENT],
             languages: ['en'],
           },
         }),
@@ -83,7 +81,6 @@ describe('API Client', () => {
       const searchParams = {
         query: 'test query',
         filters: {
-          documentTypes: [DocumentType.JUDGMENT, DocumentType.TAX_INTERPRETATION],
           languages: ['en', 'pl'],
           dateFrom: '2024-01-01',
           dateTo: '2024-12-31',

--- a/frontend/__tests__/lib/store/savedSearchStore.test.ts
+++ b/frontend/__tests__/lib/store/savedSearchStore.test.ts
@@ -22,7 +22,6 @@ function makeSavedSearch(overrides: Partial<SavedSearch> = {}): SavedSearch {
     folder: null,
     query: 'contract law',
     search_config: {},
-    document_types: ['judgment'],
     languages: ['en'],
     search_mode: 'thinking',
     is_shared: false,

--- a/frontend/__tests__/lib/store/searchStore.test.ts
+++ b/frontend/__tests__/lib/store/searchStore.test.ts
@@ -2,11 +2,13 @@
  * Tests for the searchStore Zustand store.
  *
  * Exercises: initial state, setters, filter toggling, document selection,
- * computed getters, and the isUnknownDocumentType helper.
+ * and computed getters. The legacy multi-document-type plumbing
+ * (`documentTypes`, `setDocumentTypes`, `isUnknownDocumentType`) was
+ * removed when search collapsed to judgment-only — see
+ * `docs/superpowers/specs/2026-05-09-search-judgment-only-blazing-fast.md`.
  */
 
-import { useSearchStore, isUnknownDocumentType } from '@/lib/store/searchStore';
-import { DocumentType } from '@/types/search';
+import { useSearchStore } from '@/lib/store/searchStore';
 import type { SearchDocument, SearchChunk } from '@/types/search';
 
 // Factory helpers
@@ -26,10 +28,8 @@ describe('searchStore', () => {
     // Reset all store state before each test
     useSearchStore.setState({
       query: '',
-      documentTypes: [],
       selectedLanguages: new Set(['uk', 'pl']),
       searchType: 'thinking',
-      ignoreUnknownType: true,
       currentPage: 1,
       pageSize: 20,
       totalResults: 0,
@@ -48,7 +48,6 @@ describe('searchStore', () => {
       filters: {
         keywords: new Set(),
         legalConcepts: new Set(),
-        documentTypes: new Set(),
         issuingBodies: new Set(),
         languages: new Set(),
         dateFrom: undefined,
@@ -90,11 +89,6 @@ describe('searchStore', () => {
     it('setQuery updates query', () => {
       useSearchStore.getState().setQuery('tax law');
       expect(useSearchStore.getState().query).toBe('tax law');
-    });
-
-    it('setDocumentTypes updates documentTypes', () => {
-      useSearchStore.getState().setDocumentTypes([DocumentType.JUDGMENT]);
-      expect(useSearchStore.getState().documentTypes).toEqual([DocumentType.JUDGMENT]);
     });
 
     it('setIsSearching updates searching state', () => {
@@ -262,31 +256,5 @@ describe('searchStore', () => {
       useSearchStore.getState().setPaginationMetadata(meta);
       expect(useSearchStore.getState().paginationMetadata).toEqual(meta);
     });
-  });
-});
-
-// ── isUnknownDocumentType helper ────────────────────────────────────────
-
-describe('isUnknownDocumentType', () => {
-  it('returns true for null/undefined', () => {
-    expect(isUnknownDocumentType(null)).toBe(true);
-    expect(isUnknownDocumentType(undefined)).toBe(true);
-  });
-
-  it('returns false for JUDGMENT', () => {
-    expect(isUnknownDocumentType(DocumentType.JUDGMENT)).toBe(false);
-  });
-
-  it('returns false for TAX_INTERPRETATION', () => {
-    expect(isUnknownDocumentType(DocumentType.TAX_INTERPRETATION)).toBe(false);
-  });
-
-  it('returns true for ERROR type', () => {
-    expect(isUnknownDocumentType(DocumentType.ERROR)).toBe(true);
-  });
-
-  it('returns true for arbitrary strings', () => {
-    expect(isUnknownDocumentType('unknown')).toBe(true);
-    expect(isUnknownDocumentType('random_type')).toBe(true);
   });
 });

--- a/frontend/app/extract/page.tsx
+++ b/frontend/app/extract/page.tsx
@@ -290,14 +290,6 @@ const getDocumentTypeBadge = (type?: string | null) => {
  };
  }
 
- // Collapse legacy tax interpretation documents into a generic label in the UI.
- if (normalized === "tax_interpretation"|| normalized === "tax interpretation"|| normalized.includes("tax_interpretation") || normalized.includes("tax interpretation")) {
- return {
- label: "Legal Document",
- className: documentTypeBadgeStyles.default,
- };
- }
-
  // Fallback to formatted label
  return {
  label: formatDocumentTypeLabel(type),

--- a/frontend/app/saved-searches/page.tsx
+++ b/frontend/app/saved-searches/page.tsx
@@ -38,7 +38,6 @@ import {
   Filter,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { DocumentType } from '@/types/search';
 import type { SavedSearch, SavedSearchConfig } from '@/types/saved-search';
 
 function SavedSearchCard({
@@ -83,11 +82,6 @@ function SavedSearchCard({
             {search.search_mode && (
               <Badge variant="outline" className="text-xs">
                 {search.search_mode === 'thinking' ? 'AI Enhanced' : 'Fast'}
-              </Badge>
-            )}
-            {search.document_types.length > 0 && (
-              <Badge variant="outline" className="text-xs">
-                {search.document_types.map(t => t === 'judgment' ? 'Judgments' : 'Documents').join(', ')}
               </Badge>
             )}
             {search.languages.length > 0 && (
@@ -166,7 +160,6 @@ function countFilters(config: SavedSearchConfig): number {
   let count = 0;
   if (f.keywords?.length) count++;
   if (f.legalConcepts?.length) count++;
-  if (f.documentTypes?.length) count++;
   if (f.issuingBodies?.length) count++;
   if (f.dateFrom || f.dateTo) count++;
   if (f.jurisdictions?.length) count++;
@@ -234,13 +227,6 @@ export default function SavedSearchesPage() {
     if (search.languages.length > 0) {
       searchStore.setSelectedLanguages(new Set(search.languages));
     }
-    if (search.document_types.length > 0) {
-      const types = search.document_types
-        .filter((t): t is DocumentType => Object.values(DocumentType).includes(t as DocumentType));
-      if (types.length > 0) {
-        searchStore.setDocumentTypes(types);
-      }
-    }
 
     // Navigate to search page - the URL params hook will trigger the search
     // Filters are passed via URL params below so the search page can restore them
@@ -248,14 +234,12 @@ export default function SavedSearchesPage() {
     if (search.query) params.set('q', encodeURIComponent(search.query));
     if (search.search_mode) params.set('mode', search.search_mode);
     if (search.languages.length > 0) params.set('lang', search.languages.join(','));
-    if (search.document_types.length > 0) params.set('type', search.document_types.join(','));
 
     // Add filter params
     if (config.filters) {
       const f = config.filters;
       if (f.keywords?.length) params.set('keywords', f.keywords.join(','));
       if (f.legalConcepts?.length) params.set('legalConcepts', f.legalConcepts.join(','));
-      if (f.documentTypes?.length) params.set('filterTypes', f.documentTypes.join(','));
       if (f.issuingBodies?.length) params.set('issuingBodies', f.issuingBodies.join(','));
       if (f.dateFrom) params.set('dateFrom', f.dateFrom);
       if (f.dateTo) params.set('dateTo', f.dateTo);

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -22,7 +22,6 @@ import { SaveSearchDialog } from '@/components/SaveSearchDialog';
 import { useSearchResults } from '@/hooks/useSearchResults';
 import { useSearchAutocomplete } from '@/hooks/useSearchAutocomplete';
 import { useSearchUrlParams } from '@/hooks/useSearchUrlParams';
-import { DocumentType } from '@/types/search';
 
 /**
  * Typing animation component for header text
@@ -103,8 +102,6 @@ function SearchPageContent(): React.JSX.Element | null {
  const {
  query,
  setQuery,
- documentTypes,
- setDocumentTypes,
  selectedLanguages,
  setSelectedLanguages,
  isSearching,
@@ -212,7 +209,6 @@ function SearchPageContent(): React.JSX.Element | null {
  const hasNoFilters =
  currentFilters.keywords.size === 0 &&
  currentFilters.legalConcepts.size === 0 &&
- currentFilters.documentTypes.size === 0 &&
  currentFilters.issuingBodies.size === 0 &&
  !currentFilters.dateFrom &&
  !currentFilters.dateTo;
@@ -267,7 +263,7 @@ function SearchPageContent(): React.JSX.Element | null {
  useEffect(() => {
  if (!mounted || !urlParamsProcessed || updatingUrlRef.current || isSearching) return;
  updateUrlParams();
- }, [query, documentTypes, selectedLanguages, searchType, updateUrlParams, mounted, urlParamsProcessed, isSearching, updatingUrlRef]);
+ }, [query, selectedLanguages, searchType, updateUrlParams, mounted, urlParamsProcessed, isSearching, updatingUrlRef]);
 
  // Update URL when pagination changes
  useEffect(() => {
@@ -293,22 +289,6 @@ function SearchPageContent(): React.JSX.Element | null {
  }
 
  setSelectedLanguages(newSet);
- };
-
-  const toggleDocumentType = (docType: DocumentType): void => {
-  if (docType !== DocumentType.JUDGMENT) {
-  return;
-  }
-  const newTypes = [...documentTypes];
-  const index = newTypes.indexOf(docType);
- if (index > -1) {
- if (newTypes.length > 1) {
- newTypes.splice(index, 1);
- }
- } else {
- newTypes.push(docType);
- }
- setDocumentTypes(newTypes);
  };
 
  // Reset hasPerformedSearch when query is cleared
@@ -343,7 +323,6 @@ function SearchPageContent(): React.JSX.Element | null {
  const handleSearch = async (
  overrideMode?: "thinking" | "rabbit",
  overrideQuery?: string,
- overrideDocumentTypes?: DocumentType[],
  overrideLanguages?: string[]
  ): Promise<void> => {
  const queryToUse = overrideQuery || query;
@@ -362,7 +341,6 @@ function SearchPageContent(): React.JSX.Element | null {
 
  await search(queryToUse, {
  overrideMode: modeToUse,
- overrideDocumentTypes: overrideDocumentTypes || documentTypes,
  overrideLanguages: overrideLanguages || Array.from(selectedLanguages),
  onComplete: () => {
  updateUrlParams(false, true);
@@ -392,7 +370,6 @@ function SearchPageContent(): React.JSX.Element | null {
  courts: Array.from(filters.issuingBodies || []),
  date_from: filters.dateFrom ? filters.dateFrom.toISOString().split('T')[0] : null,
  date_to: filters.dateTo ? filters.dateTo.toISOString().split('T')[0] : null,
- document_types: documentTypes,
  languages: Array.from(selectedLanguages),
  keywords: Array.from(filters.keywords || []),
  legal_concepts: Array.from(filters.legalConcepts || []),
@@ -400,7 +377,7 @@ function SearchPageContent(): React.JSX.Element | null {
  },
  totalResults: searchMetadata.length,
  searchTimestamp: searchTimestamp,
- }), [query, lastSearchMode, searchType, filters, documentTypes, selectedLanguages, searchMetadata.length, searchTimestamp]);
+ }), [query, lastSearchMode, searchType, filters, selectedLanguages, searchMetadata.length, searchTimestamp]);
 
  const handleAutocompleteSelection = useCallback(
  (value: string): void => {
@@ -515,11 +492,8 @@ function SearchPageContent(): React.JSX.Element | null {
  setQuery={setQuery}
  searchType={searchType}
  setSearchType={setSearchType}
- documentTypes={documentTypes}
- toggleDocumentType={toggleDocumentType}
  selectedLanguages={selectedLanguages}
  toggleLanguage={toggleLanguage}
- setDocumentTypes={setDocumentTypes}
  setSelectedLanguages={setSelectedLanguages}
  isSearching={isSearching}
  hasResults={searchMetadata.length > 0}
@@ -546,11 +520,8 @@ function SearchPageContent(): React.JSX.Element | null {
  setQuery={setQuery}
  searchType={searchType}
  setSearchType={setSearchType}
- documentTypes={documentTypes}
- toggleDocumentType={toggleDocumentType}
  selectedLanguages={selectedLanguages}
  toggleLanguage={toggleLanguage}
- setDocumentTypes={setDocumentTypes}
  setSelectedLanguages={setSelectedLanguages}
  isSearching={isSearching}
  hasResults={searchMetadata.length > 0}
@@ -601,7 +572,6 @@ function SearchPageContent(): React.JSX.Element | null {
   ...(filters.dateTo ? [{ label: `To: ${filters.dateTo.toLocaleDateString()}`, onClear: () => setDateFilter('dateTo', undefined) }] : []),
   ...Array.from(filters.keywords).map(kw => ({ label: `Keyword: ${kw}`, onClear: () => toggleFilter('keywords', kw) })),
   ...Array.from(filters.issuingBodies).map(body => ({ label: `Court: ${body}`, onClear: () => toggleFilter('issuingBodies', body) })),
-  ...Array.from(filters.documentTypes).map(dt => ({ label: `Type: ${dt}`, onClear: () => toggleFilter('documentTypes', dt) })),
  ]}
  onClearAllFilters={activeFilterCount > 0 ? resetFilters : undefined}
  onSampleQuery={(q) => {
@@ -656,7 +626,6 @@ function SearchPageContent(): React.JSX.Element | null {
  activeFilterCount={activeFilterCount}
  searchResults={{ documents: searchMetadata.map(m => ({
  keywords: m.keywords,
- document_type: m.document_type,
  language: m.language,
  jurisdiction: m.jurisdiction,
  court_level: m.court_level,

--- a/frontend/components/DocumentVisualization.tsx
+++ b/frontend/components/DocumentVisualization.tsx
@@ -56,7 +56,6 @@ const DOCUMENT_TYPE_COLORS: Record<string, string> = {
  'tax_ruling': '#ff7f0e',
  'legislation': '#2ca02c',
  'administrative_decision': '#d62728',
- 'tax_interpretation': '#9467bd',
  'legal_opinion': '#8c564b',
  'regulation': '#e377c2',
  'guideline': '#7f7f7f',

--- a/frontend/components/SaveSearchDialog.tsx
+++ b/frontend/components/SaveSearchDialog.tsx
@@ -43,7 +43,6 @@ export function SaveSearchDialog({ trigger }: SaveSearchDialogProps) {
  filters: {
  keywords: Array.from(searchStore.filters.keywords),
  legalConcepts: Array.from(searchStore.filters.legalConcepts),
- documentTypes: Array.from(searchStore.filters.documentTypes),
  issuingBodies: Array.from(searchStore.filters.issuingBodies),
  languages: Array.from(searchStore.filters.languages),
  dateFrom: searchStore.filters.dateFrom?.toISOString()?.split('T')[0],
@@ -54,7 +53,6 @@ export function SaveSearchDialog({ trigger }: SaveSearchDialogProps) {
  customMetadata: searchStore.filters.customMetadata,
  },
  pageSize: searchStore.pageSize,
- ignoreUnknownType: searchStore.ignoreUnknownType,
  };
 
  const result = await createSearch({
@@ -63,7 +61,6 @@ export function SaveSearchDialog({ trigger }: SaveSearchDialogProps) {
  folder: folder.trim() || undefined,
  query: searchStore.query,
  search_config: config,
- document_types: searchStore.documentTypes,
  languages: Array.from(searchStore.selectedLanguages),
  search_mode: searchStore.searchType,
  is_shared: isShared,
@@ -176,9 +173,6 @@ export function SaveSearchDialog({ trigger }: SaveSearchDialogProps) {
  <p>Mode: {searchStore.searchType === 'thinking' ? 'AI Enhanced' : 'Fast'}</p>
  {searchStore.selectedLanguages.size > 0 && (
  <p>Languages: {Array.from(searchStore.selectedLanguages).map(l => l.toUpperCase()).join(', ')}</p>
- )}
- {searchStore.documentTypes.length > 0 && (
- <p>Types: {searchStore.documentTypes.join(', ')}</p>
  )}
  {searchStore.getActiveFilterCount() > 0 && (
  <p>{searchStore.getActiveFilterCount()} active filter(s)</p>

--- a/frontend/components/SchemaGenerator.tsx
+++ b/frontend/components/SchemaGenerator.tsx
@@ -43,7 +43,6 @@ interface DocumentSample {
 function formatSampleDocumentType(type: string | null | undefined): string {
  if (!type) return "Legal document";
  if (type === "judgment" || type === "judgement") return "Judgment";
- if (type === "tax_interpretation") return "Legal document";
  return type.replace(/_/g, " ");
 }
 

--- a/frontend/components/chat/SourceCard.tsx
+++ b/frontend/components/chat/SourceCard.tsx
@@ -1,11 +1,10 @@
 // components/chat/SourceCard.tsx
 
 import React from 'react';
-import { SearchDocument, DocumentType } from '@/types/search';
-import { Badge } from '@/components/ui/badge';
+import { SearchDocument } from '@/types/search';
 import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardContent, CardFooter } from '@/components/ui/card';
-import { AlertTriangle, ExternalLink, BookmarkPlus, FileText, Scale, Bug, Calendar } from 'lucide-react';
+import { AlertTriangle, ExternalLink, BookmarkPlus, Scale, Calendar } from 'lucide-react';
 import { format, isValid } from 'date-fns';
 import Link from 'next/link';
 import { cleanDocumentIdForUrl } from '@/lib/document-utils';
@@ -16,54 +15,21 @@ interface SourceCardProps {
  onSaveToCollection?: (documentId: string) => void;
 }
 
-// Get icon and color based on document type
-function getDocumentTypeInfo(type: string) {
- switch (type) {
- case DocumentType.JUDGMENT:
- return {
+// Judgments are the only document type we ship today, so styling is fixed.
+const JUDGMENT_TYPE_INFO = {
  icon: Scale,
  color: 'text-blue-600',
  bgColor: 'bg-gradient-to-br from-blue-100/90 via-indigo-100/70 to-blue-100/90',
  iconBg: 'bg-gradient-to-br from-blue-500 to-indigo-600',
  hoverBorder: 'hover:border-blue-500/50',
  label: 'Judgment',
- };
- case DocumentType.TAX_INTERPRETATION:
- return {
- icon: FileText,
- color: 'text-slate-600',
- bgColor: 'bg-gradient-to-br from-slate-50/70 via-slate-50/50 to-slate-100/40',
- iconBg: 'bg-gradient-to-br from-slate-500 to-slate-600',
- hoverBorder: 'hover:border-slate-500/50',
- label: 'Document',
- };
- case DocumentType.ERROR:
- return {
- icon: Bug,
- color: 'text-red-700',
- bgColor: 'bg-red-50',
- iconBg: 'bg-gradient-to-br from-red-500 to-red-600',
- hoverBorder: 'hover:border-red-500/50',
- label: 'Error',
- };
- default:
- return {
- icon: FileText,
- color: 'text-slate-600',
- bgColor: 'bg-gradient-to-br from-slate-50/70 via-slate-50/50 to-slate-100/40',
- iconBg: 'bg-gradient-to-br from-slate-500 to-slate-600',
- hoverBorder: 'hover:border-slate-500/50',
- label: 'Document',
- };
- }
-}
+} as const;
 
 export function SourceCard({ document, onSaveToCollection }: SourceCardProps) {
- // Get icon and color based on document type
- const typeInfo = getDocumentTypeInfo(document.document_type ?? "");
+ const typeInfo = JUDGMENT_TYPE_INFO;
  const Icon = typeInfo.icon;
- const isDocumentFetched = typeInfo.label !== 'Error';
- const isJudgmentStyle = typeInfo.label === 'Judgment';
+ // Document fetch errors are surfaced via the `_isWeaviateError` flag on the document.
+ const isDocumentFetched = !document._isWeaviateError;
 
  // Avoid crashing on malformed dates from partially normalized documents.
  const formattedDate = (() => {
@@ -90,12 +56,7 @@ export function SourceCard({ document, onSaveToCollection }: SourceCardProps) {
 "py-3 gap-0 flex flex-col h-full rounded-xl"
  )}>
  {/* Enhanced gradient overlay */}
-	 <div className={cn(
-	"absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-xl -z-10",
-	 isJudgmentStyle
-	 ? "bg-gradient-to-br from-blue-500/20 via-indigo-500/15 to-blue-500/20"
-	 : "bg-gradient-to-br from-slate-500/10 via-slate-500/5 to-slate-500/10"
-	 )} />
+	 <div className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-xl -z-10 bg-gradient-to-br from-blue-500/20 via-indigo-500/15 to-blue-500/20" />
  <CardHeader className="pb-2 space-y-1.5 px-4 pt-3 flex-shrink-0 overflow-hidden">
  {/* Document Type and Date Badge - Same level */}
  <div className="flex items-center justify-between gap-2">
@@ -103,12 +64,7 @@ export function SourceCard({ document, onSaveToCollection }: SourceCardProps) {
  {typeInfo.label}
  </div>
  {formattedDate && (
-	 <div className={cn(
-	"flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-md border transition-all",
-	 isJudgmentStyle
-	 ? "bg-gradient-to-r from-blue-50/90 to-indigo-50/70 border-blue-200/50 text-blue-700"
-	 : "bg-gradient-to-r from-slate-50/90 to-slate-100/70 border-slate-200/50 text-slate-700"
-	 )}>
+	 <div className="flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-md border transition-all bg-gradient-to-r from-blue-50/90 to-indigo-50/70 border-blue-200/50 text-blue-700">
  <Calendar className="h-3.5 w-3.5"/>
  <span>{formattedDate}</span>
  </div>
@@ -162,12 +118,7 @@ export function SourceCard({ document, onSaveToCollection }: SourceCardProps) {
  )}
  </CardContent>
 
- <CardFooter className={cn(
-	"px-4 pb-3 pt-0 flex items-center gap-2",
-	 isJudgmentStyle
-	 ? "bg-gradient-to-t from-blue-50/50 via-transparent to-transparent"
-	 : "bg-gradient-to-t from-slate-50/50 via-transparent to-transparent"
-	 )}>
+ <CardFooter className="px-4 pb-3 pt-0 flex items-center gap-2 bg-gradient-to-t from-blue-50/50 via-transparent to-transparent">
  {isDocumentFetched && (
  <>
  <Link
@@ -179,20 +130,10 @@ export function SourceCard({ document, onSaveToCollection }: SourceCardProps) {
  <Button
  variant="outline"
  size="sm"
-	 className={cn(
-	"group/btn relative h-8 text-xs w-full overflow-hidden transition-all duration-300 hover:scale-[1.02] hover:shadow-md",
-	 isJudgmentStyle
-	 ? "bg-white/60 backdrop-blur-sm border-blue-200/50 hover:border-blue-400 text-blue-700 hover:text-blue-800"
-	 : "bg-white/60 backdrop-blur-sm border-slate-200/50 hover:border-slate-400 text-slate-700 hover:text-slate-900"
-	 )}
+	 className="group/btn relative h-8 text-xs w-full overflow-hidden transition-all duration-300 hover:scale-[1.02] hover:shadow-md bg-white/60 backdrop-blur-sm border-blue-200/50 hover:border-blue-400 text-blue-700 hover:text-blue-800"
 	 >
  {/* Gradient overlay on hover */}
-	 <div className={cn(
-	"absolute inset-0 opacity-0 group-hover/btn:opacity-100 transition-opacity duration-300 -z-10",
-	 isJudgmentStyle
-	 ? "bg-gradient-to-r from-blue-50/80 via-indigo-50/60 to-blue-50/80"
-	 : "bg-gradient-to-r from-slate-50/80 via-slate-100/60 to-slate-50/80"
-	 )} />
+	 <div className="absolute inset-0 opacity-0 group-hover/btn:opacity-100 transition-opacity duration-300 -z-10 bg-gradient-to-r from-blue-50/80 via-indigo-50/60 to-blue-50/80" />
 
  {/* Content */}
  <span className="relative z-10 flex items-center justify-center gap-1.5">
@@ -205,21 +146,11 @@ export function SourceCard({ document, onSaveToCollection }: SourceCardProps) {
  <Button
  variant="ghost"
  size="sm"
-	 className={cn(
-	"group/btn relative h-8 text-xs px-3 overflow-hidden transition-all duration-300 hover:scale-[1.02] hover:shadow-md",
-	 isJudgmentStyle
-	 ? "bg-white/60 backdrop-blur-sm border border-blue-200/50 hover:border-blue-400 text-blue-700 hover:text-blue-800"
-	 : "bg-white/60 backdrop-blur-sm border border-slate-200/50 hover:border-slate-400 text-slate-700 hover:text-slate-900"
-	 )}
+	 className="group/btn relative h-8 text-xs px-3 overflow-hidden transition-all duration-300 hover:scale-[1.02] hover:shadow-md bg-white/60 backdrop-blur-sm border border-blue-200/50 hover:border-blue-400 text-blue-700 hover:text-blue-800"
  onClick={() => onSaveToCollection(document.document_id)}
  >
  {/* Gradient overlay on hover */}
-	 <div className={cn(
-	"absolute inset-0 opacity-0 group-hover/btn:opacity-100 transition-opacity duration-300 -z-10",
-	 isJudgmentStyle
-	 ? "bg-gradient-to-r from-blue-50/80 via-indigo-50/60 to-blue-50/80"
-	 : "bg-gradient-to-r from-slate-50/80 via-slate-100/60 to-slate-50/80"
-	 )} />
+	 <div className="absolute inset-0 opacity-0 group-hover/btn:opacity-100 transition-opacity duration-300 -z-10 bg-gradient-to-r from-blue-50/80 via-indigo-50/60 to-blue-50/80" />
 
  {/* Content */}
  <span className="relative z-10 flex items-center gap-1.5">

--- a/frontend/components/dashboard/document-card-compact.tsx
+++ b/frontend/components/dashboard/document-card-compact.tsx
@@ -14,7 +14,6 @@ import { cleanDocumentIdForUrl } from "@/lib/document-utils";
 function formatDocumentType(type: string): string {
  const typeMap: Record<string, string> = {
  judgment: "Judgment",
- tax_interpretation: "Legal Document",
  legal_act: "Legal Act",
  regulation: "Regulation",
  };
@@ -71,14 +70,11 @@ export function DocumentCardCompact({
  };
  // Determine document type
  const docType = type?.toLowerCase().replace(/[_\s]/g, '') || '';
- const isTaxInterpretation = docType.includes('taxinterpretation');
  const isJudgment = docType.includes('judgment');
 
  // Determine background color based on document type
  const getCardBackground = () => {
- if (isTaxInterpretation) {
- return 'bg-gradient-to-br from-amber-50/60 via-amber-50/40 to-orange-50/30';
- } else if (isJudgment) {
+ if (isJudgment) {
  return 'bg-gradient-to-br from-blue-50/60 via-blue-50/40 to-indigo-50/30';
  }
  return 'bg-gradient-to-br from-slate-50/70 via-slate-50/50 to-slate-100/40';
@@ -86,9 +82,7 @@ export function DocumentCardCompact({
 
  // Get metadata box background
  const getMetadataBackground = () => {
- if (isTaxInterpretation) {
- return 'bg-gradient-to-br from-amber-50 via-amber-100/80 to-orange-100/60 border-amber-200/50';
- } else if (isJudgment) {
+ if (isJudgment) {
  return 'bg-gradient-to-br from-blue-50 via-blue-100/80 to-indigo-100/60 border-blue-200/50';
  }
  return 'bg-gradient-to-br from-slate-50 via-slate-100 to-slate-200/90 border-slate-200/80';
@@ -96,19 +90,12 @@ export function DocumentCardCompact({
 
  // Get icon background
  const getIconBackground = () => {
- if (isTaxInterpretation) {
- return 'bg-gradient-to-br from-amber-500 via-amber-600 to-orange-600 shadow-md shadow-amber-500/20';
- } else if (isJudgment) {
- return 'bg-gradient-to-br from-blue-500 via-blue-600 to-indigo-600 shadow-md shadow-blue-500/20';
- }
  return 'bg-gradient-to-br from-blue-500 via-blue-600 to-indigo-600 shadow-md shadow-blue-500/20';
  };
 
  // Get keyword badge background
  const getKeywordBadgeBackground = () => {
- if (isTaxInterpretation) {
- return 'bg-gradient-to-r from-amber-50/90 to-orange-50/70 border-amber-200/60 text-amber-800 hover:from-amber-100/90 hover:to-amber-50/80 shadow-sm hover:shadow-md';
- } else if (isJudgment) {
+ if (isJudgment) {
  return 'bg-gradient-to-r from-blue-50/90 to-indigo-50/70 border-blue-200/60 text-blue-800 hover:from-blue-100/90 hover:to-blue-50/80 shadow-sm hover:shadow-md';
  }
  return 'bg-gradient-to-r from-slate-50/90 to-slate-100/70 border-slate-200/60 text-slate-800 hover:from-slate-100/90 hover:to-slate-50/80 shadow-sm hover:shadow-md';
@@ -116,9 +103,7 @@ export function DocumentCardCompact({
 
  // Get date badge background
  const getDateBadgeBackground = () => {
- if (isTaxInterpretation) {
- return 'bg-gradient-to-r from-amber-50/90 to-orange-50/70 border-amber-200/60 text-amber-800 shadow-sm hover:shadow-md';
- } else if (isJudgment) {
+ if (isJudgment) {
  return 'bg-gradient-to-r from-blue-50/90 to-indigo-50/70 border-blue-200/60 text-blue-800 shadow-sm hover:shadow-md';
  }
  return 'bg-gradient-to-r from-slate-50/90 to-slate-100/70 border-slate-200/60 text-slate-800 shadow-sm hover:shadow-md';
@@ -126,22 +111,12 @@ export function DocumentCardCompact({
 
  // Get hover border color
  const getHoverBorderColor = () => {
- if (isTaxInterpretation) {
- return 'hover:border-amber-500/50';
- } else if (isJudgment) {
- return 'hover:border-blue-500/50';
- }
  return 'hover:border-blue-500/50';
  };
 
  // Get button colors
  const getButtonColors = () => {
- if (isTaxInterpretation) {
- return {
- primary: 'bg-gradient-to-r from-amber-600 to-orange-600 hover:from-amber-700 hover:to-orange-700',
- outline: 'border-amber-300 hover:border-amber-500 hover:bg-amber-50'
- };
- } else if (isJudgment) {
+ if (isJudgment) {
  return {
  primary: 'bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700',
  outline: 'border-blue-300 hover:border-blue-500 hover:bg-blue-50'
@@ -155,9 +130,7 @@ export function DocumentCardCompact({
 
  // Get footer background
  const getFooterBackground = () => {
- if (isTaxInterpretation) {
- return 'bg-gradient-to-r from-amber-50/90 via-amber-100/70 to-orange-100/50 border-amber-200/30';
- } else if (isJudgment) {
+ if (isJudgment) {
  return 'bg-gradient-to-r from-blue-50/90 via-blue-100/70 to-indigo-100/50 border-blue-200/30';
  }
  return 'bg-gradient-to-r from-slate-50 via-slate-100 to-slate-200/80 border-slate-200/50';

--- a/frontend/components/similarity-viz/types.ts
+++ b/frontend/components/similarity-viz/types.ts
@@ -2,12 +2,10 @@
  * Type definitions for Document Similarity Visualization
  */
 
-import { DocumentType } from '@/types/search';
-
 export interface GraphNode {
   id: string;
   title: string;
-  documentType: DocumentType;
+  documentType: string;
   documentId: string;
   fullText: string;
   summary?: string;
@@ -52,7 +50,6 @@ export interface GraphData {
 }
 
 export interface SimilarityFilters {
-  documentTypes: DocumentType[];
   languages: string[];
   dateRange: {
     start: Date;
@@ -94,7 +91,7 @@ export interface SimilarityAPIResponse {
   documents: Array<{
     document_id: string;
     title: string | null;
-    document_type: DocumentType;
+    document_type: string;
     full_text: string;
     summary?: string | null;
     created_at: string;
@@ -109,22 +106,17 @@ export interface SimilarityAPIResponse {
 
 export interface GraphColors {
   judgment: string;
-  tax_interpretation: string;
   regulation: string;
-  error: string;
   default: string;
 }
 
 export const GRAPH_COLORS: GraphColors = {
   judgment: '#6366f1',           // Indigo
-  tax_interpretation: '#10B981', // Emerald
   regulation: '#F59E0B',         // Amber
-  error: '#EF4444',              // Red
   default: '#8B5CF6',            // Purple
 };
 
 export const DEFAULT_FILTERS: SimilarityFilters = {
-  documentTypes: [],
   languages: [],
   dateRange: null,
   similarityThreshold: 50,

--- a/frontend/hooks/useSearchResults.ts
+++ b/frontend/hooks/useSearchResults.ts
@@ -1,7 +1,7 @@
 import { useRef, useCallback } from 'react';
 import { searchChunks, fetchDocumentsByIds, PaginationMetadata } from '@/lib/api';
-import { SearchChunk, SearchDocument, DocumentType, LegalDocumentMetadata } from '@/types/search';
-import { useSearchStore, isUnknownDocumentType } from '@/lib/store/searchStore';
+import { SearchChunk, SearchDocument, LegalDocumentMetadata } from '@/types/search';
+import { useSearchStore } from '@/lib/store/searchStore';
 import logger from '@/lib/logger';
 
 const searchLogger = logger.child('useSearchResults');
@@ -10,9 +10,25 @@ const searchLogger = logger.child('useSearchResults');
 const PAGE_SIZE = 10; // Documents per load (user preference)
 const DEFAULT_LIMIT_CHUNKS = 150; // Chunks to fetch per request
 
+// Card-view fields requested in the rare fallback case where the search response
+// did not embed the documents (Tasks 6/7 trim this further on the backend).
+const CARD_RETURN_PROPERTIES = [
+  'title',
+  'document_number',
+  'summary',
+  'keywords',
+  'court_name',
+  'presiding_judge',
+  'date_issued',
+  'language',
+  'country',
+  'publication_date',
+  'source_url',
+];
+
 /**
  * Hook for managing search results fetching and conversion
- * Encapsulates the two-phase search process (chunks → documents)
+ * Encapsulates the search process (chunks + embedded documents → metadata)
  */
 export function useSearchResults() {
   const fullDocumentsMapRef = useRef<Map<string, SearchDocument>>(new Map());
@@ -21,15 +37,11 @@ export function useSearchResults() {
   const lastSearchParamsRef = useRef<string>(''); // Track search parameters to detect new searches
 
   const {
-    query,
     searchType,
-    documentTypes,
     selectedLanguages,
-    ignoreUnknownType,
     setIsSearching,
     setError,
     clearChunksCache,
-    setChunksForDocuments,
     setSearchMetadata,
     setPageSize,
     clearSelection,
@@ -40,7 +52,6 @@ export function useSearchResults() {
     setPaginationMetadata,
     setIsLoadingMore,
     appendSearchMetadata,
-    resetSearch,
   } = useSearchStore();
 
   /**
@@ -57,6 +68,7 @@ export function useSearchResults() {
         // Backend returns fields like publication_date, source_url as top-level fields on LegalDocument
         // but SearchDocument expects them in metadata object for the UI component
         // Access fields from the JSON response (they're top-level in the backend response)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const docAny = fullDoc as any;
 
         const metadataObj: SearchDocument['metadata'] = {
@@ -77,7 +89,6 @@ export function useSearchResults() {
 
         return {
           document_id: fullDoc.document_id,
-          document_type: fullDoc.document_type,
           title: fullDoc.title,
           date_issued: fullDoc.date_issued,
           issuing_body: fullDoc.issuing_body,
@@ -109,7 +120,6 @@ export function useSearchResults() {
       // Fallback to metadata-only (shouldn't happen if fetch was successful)
       return {
         document_id: metadata.document_id,
-        document_type: metadata.document_type,
         title: metadata.title || null,
         date_issued: metadata.date_issued,
         language: metadata.language,
@@ -143,16 +153,59 @@ export function useSearchResults() {
   );
 
   /**
-   * Performs a two-phase search:
-   * 1. Search chunks to find relevant documents
-   * 2. Fetch full document data for those documents
+   * Builds metadata for a chunk + (optional) full document. Centralised so the
+   * date-fallback logic stays consistent between initial search and loadMore.
+   */
+  const buildMetadataForChunk = useCallback(
+    (chunk: SearchChunk, fullDoc: SearchDocument | undefined): LegalDocumentMetadata => {
+      const score = chunk.confidence_score ?? chunk.score ?? null;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const docAny = fullDoc as any;
+      const meta = (fullDoc?.metadata as Record<string, unknown> | undefined) || {};
+
+      const dateIssued = fullDoc
+        ? (fullDoc.date_issued ||
+            (typeof docAny.publication_date === 'string' ? docAny.publication_date : null) ||
+            (typeof meta.publication_date === 'string' ? (meta.publication_date as string) : null) ||
+            null)
+        : null;
+
+      return {
+        uuid: `${chunk.document_id}_chunk_${chunk.chunk_id}`,
+        document_id: chunk.document_id,
+        language: fullDoc ? fullDoc.language || '' : chunk.language || '',
+        keywords: fullDoc
+          ? fullDoc.keywords || []
+          : chunk.tags
+            ? Array.isArray(chunk.tags)
+              ? chunk.tags
+              : [chunk.tags]
+            : [],
+        date_issued: dateIssued,
+        score,
+        title: fullDoc?.title || null,
+        summary: fullDoc?.summary || null,
+        court_name: fullDoc?.court_name || null,
+        document_number: fullDoc?.document_number || null,
+        thesis: fullDoc?.thesis || null,
+      };
+    },
+    []
+  );
+
+  /**
+   * Performs a search:
+   * 1. Search chunks (the response now includes the matching documents).
+   * 2. Build per-chunk metadata using the embedded documents.
+   * 3. Only fall back to a follow-up document fetch when chunks reference docs
+   *    not present in `result.documents`.
    */
   const search = useCallback(
     async (
       searchQuery: string,
       options?: {
         overrideMode?: "thinking" | "rabbit";
-        overrideDocumentTypes?: DocumentType[];
         overrideLanguages?: string[];
         onComplete?: () => void;
       }
@@ -168,7 +221,7 @@ export function useSearchResults() {
         searchLogger.debug('Search already in progress, skipping duplicate request');
         return Promise.resolve();
       }
-      
+
       // If there was a previous error, reset the ref to allow retry
       if (currentError && searchInProgressRef.current) {
         searchLogger.debug('Previous search had error, resetting ref to allow retry');
@@ -176,25 +229,21 @@ export function useSearchResults() {
       }
 
       const modeToUse = options?.overrideMode || searchType;
-      const requestedDocumentTypes = options?.overrideDocumentTypes || documentTypes;
-      const documentTypesToUse =
-        requestedDocumentTypes.length > 0 ? requestedDocumentTypes : [DocumentType.JUDGMENT];
       const languagesToUse =
         options?.overrideLanguages && options.overrideLanguages.length > 0
           ? options.overrideLanguages
           : Array.from(selectedLanguages);
 
-      searchLogger.info('Search initiated (new optimized flow)', {
+      searchLogger.info('search start', {
         query: searchQuery,
-        documentTypes: documentTypesToUse,
-        selectedLanguages: languagesToUse,
-        searchType: modeToUse,
+        mode: modeToUse,
+        languages: languagesToUse,
+        paging: { offset: 0, limit: PAGE_SIZE },
       });
 
       // Create a unique key for this search based on parameters
       const searchParamsKey = JSON.stringify({
         query: searchQuery,
-        documentTypes: documentTypesToUse,
         languages: languagesToUse,
         mode: modeToUse,
       });
@@ -208,52 +257,38 @@ export function useSearchResults() {
         searchIdRef.current += 1;
       }
       const currentSearchId = searchIdRef.current;
-      
-      searchLogger.debug('Starting search', { 
-        searchId: currentSearchId,
-        isNewSearch,
-        params: searchParamsKey,
-      });
 
       // STEP 1: ALWAYS clear state when starting search (even for React Strict Mode duplicates)
       // This prevents cache corruption from parallel search calls
       setError(null);
-      
-      // Log before clearing to see what we're losing
-      const storeBeforeClear = useSearchStore.getState();
-      searchLogger.info('Clearing search state before new search', {
-        chunksCacheSize: Object.keys(storeBeforeClear.chunksCache).length,
-        searchMetadataCount: storeBeforeClear.searchMetadata.length,
-        searchId: currentSearchId,
-      });
-      
       clearChunksCache(); // Clear previous chunks cache
       fullDocumentsMapRef.current.clear(); // Clear previous documents
       setSearchMetadata([], 0, false); // Clear previous search metadata
       clearSelection(); // Clear document selection
-      
+
       // STEP 2: Mark search as in progress (triggers loading state)
       searchInProgressRef.current = true;
       setIsSearching(true);
-      
-      // STEP 3: Now start the actual search (async)
 
+      // STEP 3: Now start the actual search (async)
       try {
-        // Phase 1: Search documents via chunks (chunk-based endpoint) - returns chunks only
-        // Use pagination for infinite scroll - first request gets estimated total count
         const result = await searchChunks({
           query: searchQuery,
-          limit_docs: PAGE_SIZE, // 10 docs per load for fast initial render
-          alpha: modeToUse === 'thinking' ? 0.5 : 0.0, // Pure term search (BM25) for rabbit, hybrid for thinking
+          limit_docs: PAGE_SIZE,
+          alpha: modeToUse === 'thinking' ? 0.5 : 0.0,
           languages: languagesToUse.length > 0 ? languagesToUse : undefined,
-          document_types:
-            documentTypesToUse.length > 0 ? documentTypesToUse.map((dt) => dt.toString()) : undefined,
-          fetch_full_documents: false, // Don't fetch full documents - we'll fetch them in parallel
+          fetch_full_documents: false,
           limit_chunks: DEFAULT_LIMIT_CHUNKS,
-          mode: modeToUse, // Pass mode parameter for thinking mode support
-          offset: 0, // First request starts at 0
-          include_count: true, // Get estimated total count on first request
+          mode: modeToUse,
+          offset: 0,
+          include_count: true,
         });
+
+        // Discard if a newer search has been initiated.
+        if (searchIdRef.current !== currentSearchId) {
+          searchLogger.warn('Search ID mismatch after chunk fetch, discarding stale chunks');
+          return;
+        }
 
         // Store chunks in cache for immediate display
         const chunksByDoc: Record<string, SearchChunk[]> = {};
@@ -264,353 +299,99 @@ export function useSearchResults() {
           chunksByDoc[chunk.document_id].push(chunk);
         });
 
-        searchLogger.info('Storing chunks in cache', {
-          totalChunks: result.chunks.length,
-          documentsWithChunks: Object.keys(chunksByDoc).length,
-          documentIds: Object.keys(chunksByDoc),
-          searchId: currentSearchId,
-        });
-
-        // Check if a new search has been initiated (different parameters)
-        // Don't check for React Strict Mode duplicates (same searchId is OK)
-        if (searchIdRef.current !== currentSearchId) {
-          searchLogger.warn('Search ID mismatch, a new search was initiated, discarding stale chunks', {
-            currentSearchId,
-            latestSearchId: searchIdRef.current,
-          });
-          return; // Discard chunks from old search
-        }
-
-        // Update chunks cache immediately - batch all updates in a single state update
-        // This ensures Zustand detects the change and triggers re-renders for all documents
+        // Single state update for all chunks
         const store = useSearchStore.getState();
         const newCache = { ...store.chunksCache };
         const newLoading = new Set(store.loadingChunks);
-
         Object.entries(chunksByDoc).forEach(([docId, chunks]) => {
           newCache[docId] = chunks;
           newLoading.delete(docId);
         });
-
-        // Single state update for all chunks
         useSearchStore.setState({
           chunksCache: newCache,
-          loadingChunks: Array.from(newLoading)
+          loadingChunks: Array.from(newLoading),
         });
 
-        // Verify chunks were stored correctly
-        const storeAfterSet = useSearchStore.getState();
-        const storedDocIds = Object.keys(storeAfterSet.chunksCache);
-        const expectedDocIds = Object.keys(chunksByDoc);
-        const missingInStore = expectedDocIds.filter(id => !storedDocIds.includes(id));
-        
-        searchLogger.info('Chunks stored in cache', {
-          expectedDocumentIds: expectedDocIds.length,
-          storedDocumentIds: storedDocIds.length,
-          missingInStore: missingInStore.length > 0 ? missingInStore.slice(0, 10) : [],
-          sampleStoredDocIds: storedDocIds.slice(0, 10),
-          searchId: currentSearchId,
-        });
-
-        if (missingInStore.length > 0) {
-          searchLogger.error(
-            `CRITICAL: ${missingInStore.length} document IDs were NOT stored in chunksCache! ` +
-            `Expected: ${expectedDocIds.length}, Stored: ${storedDocIds.length}. ` +
-            `Missing IDs: ${missingInStore.slice(0, 20).join(', ')}`
-          );
+        // Prefer documents embedded in the search response. Only call the
+        // documents endpoint as a fallback when chunks reference IDs the
+        // backend did not include in `result.documents`.
+        const allDocumentIds = Array.from(new Set(result.chunks.map((c) => c.document_id)));
+        let docs: SearchDocument[] = [];
+        if (result.documents && result.documents.length > 0) {
+          docs = result.documents as SearchDocument[];
+          const embeddedIds = new Set(docs.map((d) => d.document_id));
+          const missingIds = allDocumentIds.filter((id) => !embeddedIds.has(id));
+          if (missingIds.length > 0) {
+            const fallback = await fetchDocumentsByIds({
+              document_ids: missingIds,
+              return_properties: CARD_RETURN_PROPERTIES,
+            });
+            docs = docs.concat(fallback.documents as SearchDocument[]);
+          }
+        } else if (allDocumentIds.length > 0) {
+          const fallback = await fetchDocumentsByIds({
+            document_ids: allDocumentIds,
+            return_properties: CARD_RETURN_PROPERTIES,
+          });
+          docs = fallback.documents as SearchDocument[];
         }
 
-        searchLogger.info('Chunk search completed, now fetching full documents', {
+        // Discard if a newer search has been initiated.
+        if (searchIdRef.current !== currentSearchId) {
+          searchLogger.warn('Search ID mismatch after document fetch, discarding stale data');
+          return;
+        }
+
+        searchLogger.info('results received', {
           chunkCount: result.chunks.length,
-          uniqueDocuments: result.unique_documents,
+          docCount: docs.length,
           queryTimeMs: result.query_time_ms,
         });
 
-        // Phase 2: Fetch ALL documents in ONE batch (optimized with return_properties) - AWAIT IT!
-        const allDocumentIds = Array.from(new Set(result.chunks.map((chunk) => chunk.document_id)));
-
-        searchLogger.info('Fetching full documents for chunks', {
-          uniqueDocumentIds: allDocumentIds.length,
-          totalChunks: result.chunks.length,
-          sampleDocumentIds: allDocumentIds.slice(0, 10),
-          searchId: currentSearchId,
-        });
-
-        // Fetch all documents with only needed properties - WAIT for them before rendering
-        const docResponse = await fetchDocumentsByIds({
-          document_ids: allDocumentIds,
-          return_properties: [
-            'title',
-            'document_number',
-            'document_type',
-            'summary',
-            'keywords',
-            'court_name',
-            'presiding_judge',
-            'date_issued',
-            'language',
-            'country',
-            'judges',
-            'parties',
-            'outcome',
-            'legal_bases',
-            'extracted_legal_bases',
-            'references',
-            'factual_state',
-            'legal_state',
-            'department_name',
-            'issuing_body',
-            'publication_date',
-            'source',
-            'source_url',
-            'ingestion_date',
-            'last_updated',
-            'processing_status',
-            'x',
-            'y',
-          ],
-        });
-
-        const fetchedDocumentIds = new Set(docResponse.documents.map(doc => doc.document_id));
-        const missingDocumentIds = allDocumentIds.filter(id => !fetchedDocumentIds.has(id));
-        
-        searchLogger.info('All documents fetched in one batch', {
-          documentCount: docResponse.documents.length,
-          requestedCount: allDocumentIds.length,
-          missingCount: missingDocumentIds.length,
-          missingDocumentIds: missingDocumentIds.slice(0, 20), // Log first 20 missing IDs
-          searchId: currentSearchId,
-        });
-
-        if (missingDocumentIds.length > 0) {
-          searchLogger.warn(
-            `Only ${docResponse.documents.length} out of ${allDocumentIds.length} documents were found. ` +
-            `${missingDocumentIds.length} documents referenced by chunks do not exist in the database. ` +
-            `This indicates a data consistency issue - chunks exist for documents that were deleted or never ingested. ` +
-            `Missing document IDs (first 20): ${missingDocumentIds.slice(0, 20).join(', ')}`
-          );
-        }
-
-        // Check if a new search has been initiated (different parameters)
-        if (searchIdRef.current !== currentSearchId) {
-          searchLogger.warn('Search ID mismatch after fetching documents, a new search was initiated, discarding stale data', {
-            currentSearchId,
-            latestSearchId: searchIdRef.current,
-          });
-          return; // Discard documents from old search
-        }
-
         // Create document map for fast lookup
-        const docMap = new Map(docResponse.documents.map((doc) => [doc.document_id, doc]));
+        const docMap = new Map(docs.map((doc) => [doc.document_id, doc]));
 
         // Store full documents in ref for use in convertMetadataToSearchDocument
         fullDocumentsMapRef.current.clear();
-        docResponse.documents.forEach((doc) => {
-          fullDocumentsMapRef.current.set(doc.document_id, doc as SearchDocument);
+        docs.forEach((doc) => {
+          fullDocumentsMapRef.current.set(doc.document_id, doc);
         });
 
-        // Convert chunks to metadata format WITH full document data
-        // IMPORTANT: Include ALL chunks, even if the parent document doesn't exist
-        // This handles data consistency issues where chunks exist but documents don't
-        // CRITICAL: We create metadata for ALL chunks to ensure documents with missing IDs are still displayed
+        // Convert chunks to metadata WITH full document data when available.
+        // Include ALL chunks even if their parent document is missing — the UI
+        // copes with that via the metadata-only fallback path.
         const metadata: LegalDocumentMetadata[] = result.chunks.map((chunk) => {
-          const score = chunk.confidence_score ?? chunk.score ?? null;
           const fullDoc = docMap.get(chunk.document_id);
-          const hasFullDoc = !!fullDoc;
-
-          // Log warning if chunk references a missing document
-          if (!hasFullDoc) {
+          if (!fullDoc) {
             searchLogger.warn(
-              `Chunk ${chunk.chunk_id} references document ${chunk.document_id} which does not exist in database. ` +
-              `Using chunk data as fallback.`
+              `Chunk ${chunk.chunk_id} references missing document ${chunk.document_id}; using chunk fallback.`
             );
           }
-
-          // CRITICAL: All chunks are guaranteed to have document_type - use ONLY chunk.document_type
-          // ONLY TWO VALID TYPES: JUDGMENT and TAX_INTERPRETATION - throw exception if invalid or missing
-          if (!chunk.document_type) {
-            throw new Error(
-              `Missing document_type in chunk for document ${chunk.document_id}, chunk ${chunk.chunk_id}. ` +
-              `All chunks are guaranteed to have document_type.`
-            );
-          }
-          
-          // Parse document_type from chunk - only JUDGMENT and TAX_INTERPRETATION are valid
-          const normalized = String(chunk.document_type).toLowerCase().trim();
-          let docType: DocumentType;
-          
-          if (normalized === 'judgment' || normalized === 'judgement') {
-            docType = DocumentType.JUDGMENT;
-          } else if (normalized === 'tax_interpretation' || normalized === 'tax interpretation') {
-            docType = DocumentType.TAX_INTERPRETATION;
-          } else {
-            throw new Error(
-              `Invalid document_type in chunk: "${chunk.document_type}" for document ${chunk.document_id}, chunk ${chunk.chunk_id}. ` +
-              `Only JUDGMENT and TAX_INTERPRETATION are valid. Got: "${chunk.document_type}"`
-            );
-          }
-
-          return {
-            uuid: `${chunk.document_id}_chunk_${chunk.chunk_id}`, // Generate UUID from document_id and chunk_id
-            document_id: chunk.document_id,
-            document_type: docType, // Always one of the two valid types: JUDGMENT or TAX_INTERPRETATION
-            language: fullDoc ? fullDoc.language || '' : chunk.language || '', // Use empty string as default since language is required
-            keywords: fullDoc
-              ? fullDoc.keywords || []
-              : chunk.tags
-                ? Array.isArray(chunk.tags)
-                  ? chunk.tags
-                  : [chunk.tags]
-                : [],
-            // IMPORTANT: On main, date filtering falls back to publication_date
-            // when date_issued is missing. For tax interpretations we also have
-            // ETL-specific fields like issue_date. To keep behaviour consistent
-            // across document types, we store a unified "effective date" in
-            // date_issued, drawing from all known sources.
-            date_issued: fullDoc
-              ? (() => {
-                  const docAny = fullDoc as any;
-                  const meta = (fullDoc as any).metadata || {};
-                  return (
-                    // Canonical issued date (judgments, some interpretations)
-                    fullDoc.date_issued ||
-                    // Publication date (often set for court judgments)
-                    docAny.publication_date ||
-                    meta.publication_date ||
-                    // Tax interpretation specific: original "issue_date" field
-                    docAny.issue_date ||
-                    meta.issue_date ||
-                    // Historical/legacy naming used in some extraction configs
-                    meta.interpretation_date ||
-                    null
-                  );
-                })()
-              : null,
-            score: score,
-            title: fullDoc ? fullDoc.title : null,
-            summary: fullDoc ? fullDoc.summary : null,
-            court_name: fullDoc ? fullDoc.court_name : null,
-            document_number: fullDoc ? fullDoc.document_number : null,
-            thesis: fullDoc ? fullDoc.thesis : null,
-          };
+          return buildMetadataForChunk(chunk, fullDoc);
         });
 
-        // CRITICAL: Do NOT filter out any documents - display ALL chunks including unknown types and missing IDs
-        // All documents should be displayed regardless of document_type or whether full document exists
-        const filteredMetadata = metadata;
-
-        // Log how many metadata entries we have for documents with/without full docs
-        const metadataWithFullDoc = filteredMetadata.filter(m => {
-          const fullDoc = docMap.get(m.document_id);
-          return !!fullDoc;
-        });
-        const metadataWithoutFullDoc = filteredMetadata.filter(m => {
-          const fullDoc = docMap.get(m.document_id);
-          return !fullDoc;
-        });
-        
-        searchLogger.info('Metadata created from chunks', {
-          totalMetadata: filteredMetadata.length,
-          metadataWithFullDoc: metadataWithFullDoc.length,
-          metadataWithoutFullDoc: metadataWithoutFullDoc.length,
-          uniqueDocIdsWithFullDoc: new Set(metadataWithFullDoc.map(m => m.document_id)).size,
-          uniqueDocIdsWithoutFullDoc: new Set(metadataWithoutFullDoc.map(m => m.document_id)).size,
-          sampleDocIdsWithoutFullDoc: Array.from(new Set(metadataWithoutFullDoc.map(m => m.document_id))).slice(0, 10),
-          searchId: currentSearchId,
-        });
-
-        // CRITICAL: Log chunks cache state after filtering to diagnose missing chunks
-        const storeAfterFilter = useSearchStore.getState();
-        const uniqueDocIdsInMetadata = new Set(filteredMetadata.map(m => m.document_id));
-        const chunksInCache = Object.keys(storeAfterFilter.chunksCache);
-        const missingChunksForMetadata = Array.from(uniqueDocIdsInMetadata).filter(
-          docId => !chunksInCache.includes(docId)
-        );
-        
-        searchLogger.info('Metadata filtering and chunks cache check', {
-          totalMetadata: metadata.length,
-          filteredMetadata: filteredMetadata.length,
-          uniqueDocumentsInMetadata: uniqueDocIdsInMetadata.size,
-          chunksInCacheCount: chunksInCache.length,
-          missingChunksForMetadata: missingChunksForMetadata.slice(0, 10),
-          sampleMetadataDocIds: Array.from(uniqueDocIdsInMetadata).slice(0, 10),
-          sampleChunksCacheDocIds: chunksInCache.slice(0, 10),
-          searchId: currentSearchId,
-        });
-
-        if (missingChunksForMetadata.length > 0) {
-          searchLogger.error(
-            `CRITICAL: ${missingChunksForMetadata.length} documents in metadata have NO chunks in cache! ` +
-            `This means chunks were not stored or were cleared. Missing document IDs: ${missingChunksForMetadata.slice(0, 20).join(', ')}`
-          );
-        }
-
-        // Sort metadata by score (descending - highest score first)
-        // Chunks from backend are already sorted, but ensure we maintain that order
-        filteredMetadata.sort((a, b) => {
+        // Sort by score descending; chunks come pre-sorted but defensive sort is cheap.
+        metadata.sort((a, b) => {
           const scoreA = a.score ?? -Infinity;
           const scoreB = b.score ?? -Infinity;
-          return scoreB - scoreA; // Descending order (highest score first)
+          return scoreB - scoreA;
         });
 
-        // No longer limiting to 50 - we use pagination from backend now
-        const finalMetadata = filteredMetadata;
-
-        // CRITICAL: Verify chunks are still in cache before storing metadata
-        const storeBeforeMetadata = useSearchStore.getState();
-        const finalMetadataDocIds = new Set(finalMetadata.map(m => m.document_id));
-        const chunksCacheDocIds = new Set(Object.keys(storeBeforeMetadata.chunksCache));
-        const missingChunksBeforeMetadata = Array.from(finalMetadataDocIds).filter(
-          docId => !chunksCacheDocIds.has(docId)
-        );
-        
-        if (missingChunksBeforeMetadata.length > 0) {
-          searchLogger.error(
-            `CRITICAL: ${missingChunksBeforeMetadata.length} documents in finalMetadata have NO chunks in cache BEFORE storing metadata! ` +
-            `This means chunks were lost between storing and metadata creation. ` +
-            `Missing document IDs: ${missingChunksBeforeMetadata.slice(0, 20).join(', ')}`
-          );
-        }
-
-        // Store metadata with full document data and pagination info
-        // Ensure error is cleared on successful search
+        // Store metadata + pagination, clear loading flag.
         setError(null);
-        setSearchMetadata(finalMetadata, finalMetadata.length, false);
-
-        // Store pagination metadata for infinite scroll
+        setSearchMetadata(metadata, metadata.length, false);
         if (result.pagination) {
           setPaginationMetadata(result.pagination);
-          searchLogger.info('Pagination metadata stored', {
-            offset: result.pagination.offset,
-            loaded_count: result.pagination.loaded_count,
-            estimated_total: result.pagination.estimated_total,
-            has_more: result.pagination.has_more,
-            next_offset: result.pagination.next_offset,
-          });
         }
-
         setPageSize(10);
         clearSelection();
-        setIsSearching(false); // Stop loading spinner - now render with FULL data!
-        
-        // Final verification after metadata is stored
-        const storeAfterMetadata = useSearchStore.getState();
-        const chunksAfterMetadata = Object.keys(storeAfterMetadata.chunksCache);
-        searchLogger.info('Final state after search completion', {
-          metadataCount: finalMetadata.length,
-          uniqueMetadataDocIds: finalMetadataDocIds.size,
-          chunksCacheSize: chunksAfterMetadata.length,
-          chunksCacheDocIds: chunksAfterMetadata.slice(0, 10),
-          searchId: currentSearchId,
+        setIsSearching(false);
+
+        searchLogger.info('render ready', {
+          metadataCount: metadata.length,
+          hasMore: result.pagination?.has_more ?? false,
         });
 
-        searchLogger.info('Search completed with full document metadata', {
-          chunkCount: result.chunks.length,
-          uniqueDocuments: result.unique_documents,
-          documentsWithFullData: metadata.filter((m) => m.title !== null).length,
-        });
-
-        // Call onComplete callback if provided
         if (options?.onComplete) {
           options.onComplete();
         }
@@ -619,18 +400,15 @@ export function useSearchResults() {
           query: searchQuery,
           errorMessage: err instanceof Error ? err.message : String(err),
         });
-        // Clear metadata and set error state
-        setSearchMetadata([], 0, false); // Clear results
+        setSearchMetadata([], 0, false);
         setError('search_error');
         setIsSearching(false);
       } finally {
-        // Always reset the flag to allow new searches
         searchInProgressRef.current = false;
       }
     },
     [
       searchType,
-      documentTypes,
       selectedLanguages,
       setIsSearching,
       setError,
@@ -639,6 +417,7 @@ export function useSearchResults() {
       setPageSize,
       clearSelection,
       setPaginationMetadata,
+      buildMetadataForChunk,
     ]
   );
 
@@ -663,13 +442,6 @@ export function useSearchResults() {
       return;
     }
 
-    searchLogger.info('Loading more results', {
-      currentOffset: currentPagination.offset,
-      nextOffset: currentPagination.next_offset,
-      loadedCount: currentPagination.loaded_count,
-      estimatedTotal: state.cachedEstimatedTotal,
-    });
-
     setIsLoadingMore(true);
 
     try {
@@ -679,10 +451,6 @@ export function useSearchResults() {
         limit_docs: PAGE_SIZE,
         alpha: state.searchType === 'thinking' ? 0.5 : 0.0,
         languages: Array.from(state.selectedLanguages),
-        document_types:
-          state.documentTypes.length > 0
-            ? state.documentTypes.map((dt) => dt.toString())
-            : undefined,
         fetch_full_documents: false,
         limit_chunks: DEFAULT_LIMIT_CHUNKS,
         mode: state.searchType,
@@ -707,118 +475,45 @@ export function useSearchResults() {
       });
       useSearchStore.setState({ chunksCache: newCache });
 
-      // Fetch full documents for the new chunks
+      // Prefer documents embedded in the search response.
       const newDocumentIds = Array.from(new Set(result.chunks.map((c) => c.document_id)));
-
-      searchLogger.info('Fetching full documents for loadMore', {
-        documentIds: newDocumentIds,
-        count: newDocumentIds.length,
-      });
-
-      const docResponse = await fetchDocumentsByIds({
-        document_ids: newDocumentIds,
-        return_properties: [
-          'title',
-          'document_number',
-          'document_type',
-          'summary',
-          'keywords',
-          'court_name',
-          'presiding_judge',
-          'date_issued',
-          'language',
-          'country',
-          'judges',
-          'parties',
-          'outcome',
-          'legal_bases',
-          'extracted_legal_bases',
-          'references',
-          'factual_state',
-          'legal_state',
-          'department_name',
-          'issuing_body',
-          'publication_date',
-          'source',
-          'source_url',
-          'ingestion_date',
-          'last_updated',
-          'processing_status',
-          'x',
-          'y',
-        ],
-      });
-
-      searchLogger.info('Full documents fetched for loadMore', {
-        fetched: docResponse.documents.length,
-        requested: newDocumentIds.length,
-      });
+      let docs: SearchDocument[] = [];
+      if (result.documents && result.documents.length > 0) {
+        docs = result.documents as SearchDocument[];
+        const embeddedIds = new Set(docs.map((d) => d.document_id));
+        const missingIds = newDocumentIds.filter((id) => !embeddedIds.has(id));
+        if (missingIds.length > 0) {
+          const fallback = await fetchDocumentsByIds({
+            document_ids: missingIds,
+            return_properties: CARD_RETURN_PROPERTIES,
+          });
+          docs = docs.concat(fallback.documents as SearchDocument[]);
+        }
+      } else if (newDocumentIds.length > 0) {
+        const fallback = await fetchDocumentsByIds({
+          document_ids: newDocumentIds,
+          return_properties: CARD_RETURN_PROPERTIES,
+        });
+        docs = fallback.documents as SearchDocument[];
+      }
 
       // Store full documents in ref
-      docResponse.documents.forEach((doc) => {
-        fullDocumentsMapRef.current.set(doc.document_id, doc as SearchDocument);
+      docs.forEach((doc) => {
+        fullDocumentsMapRef.current.set(doc.document_id, doc);
       });
 
       // Create document map
-      const docMap = new Map(docResponse.documents.map((doc) => [doc.document_id, doc]));
+      const docMap = new Map(docs.map((doc) => [doc.document_id, doc]));
 
-      // Convert chunks to metadata - matching initial search logic
+      // Convert chunks to metadata
       const newMetadata: LegalDocumentMetadata[] = result.chunks.map((chunk) => {
-        const score = chunk.confidence_score ?? chunk.score ?? null;
         const fullDoc = docMap.get(chunk.document_id);
-
-        // Log if document is missing
         if (!fullDoc) {
           searchLogger.warn(
-            `loadMore: Chunk ${chunk.chunk_id} references document ${chunk.document_id} which does not exist in database. ` +
-            `Using chunk data as fallback.`
+            `loadMore: Chunk ${chunk.chunk_id} references missing document ${chunk.document_id}.`
           );
         }
-
-        // Parse document_type from chunk - only JUDGMENT and TAX_INTERPRETATION are valid
-        const normalized = String(chunk.document_type).toLowerCase().trim();
-        let docType: DocumentType;
-        if (normalized === 'judgment' || normalized === 'judgement') {
-          docType = DocumentType.JUDGMENT;
-        } else if (normalized === 'tax_interpretation' || normalized === 'tax interpretation') {
-          docType = DocumentType.TAX_INTERPRETATION;
-        } else {
-          docType = DocumentType.ERROR; // Fallback for unknown types
-        }
-
-        return {
-          uuid: `${chunk.document_id}_chunk_${chunk.chunk_id}`,
-          document_id: chunk.document_id,
-          document_type: docType,
-          language: fullDoc?.language || chunk.language || '',
-          keywords: fullDoc?.keywords || (chunk.tags ? (Array.isArray(chunk.tags) ? chunk.tags : [chunk.tags]) : []),
-          // Match initial search date handling - check all possible date sources
-          date_issued: fullDoc
-            ? (() => {
-                const docAny = fullDoc as any;
-                const meta = (fullDoc as any).metadata || {};
-                return (
-                  // Canonical issued date (judgments, some interpretations)
-                  fullDoc.date_issued ||
-                  // Publication date (often set for court judgments)
-                  docAny.publication_date ||
-                  meta.publication_date ||
-                  // Tax interpretation specific: original "issue_date" field
-                  docAny.issue_date ||
-                  meta.issue_date ||
-                  // Historical/legacy naming
-                  meta.interpretation_date ||
-                  null
-                );
-              })()
-            : null,
-          score,
-          title: fullDoc?.title || null,
-          summary: fullDoc?.summary || null,
-          court_name: fullDoc?.court_name || null,
-          document_number: fullDoc?.document_number || null,
-          thesis: fullDoc?.thesis || null,
-        };
+        return buildMetadataForChunk(chunk, fullDoc);
       });
 
       // Append new metadata to existing
@@ -835,20 +530,13 @@ export function useSearchResults() {
         };
         setPaginationMetadata(updatedPagination);
       }
-
-      searchLogger.info('Load more completed', {
-        newChunks: result.chunks.length,
-        newDocuments: uniqueNewDocCount,
-        totalLoaded: (currentPagination.loaded_count || 0) + uniqueNewDocCount,
-        hasMore: result.pagination?.has_more,
-      });
     } catch (err) {
       searchLogger.error('Load more failed', err);
       setError('load_more_error');
     } finally {
       setIsLoadingMore(false);
     }
-  }, [setIsLoadingMore, appendSearchMetadata, setPaginationMetadata, setError]);
+  }, [setIsLoadingMore, appendSearchMetadata, setPaginationMetadata, setError, buildMetadataForChunk]);
 
   return {
     search,

--- a/frontend/hooks/useSearchUrlParams.ts
+++ b/frontend/hooks/useSearchUrlParams.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useRouter, useSearchParams, usePathname } from 'next/navigation';
-import { DocumentType } from '@/types/search';
 import { useSearchStore } from '@/lib/store/searchStore';
 import logger from '@/lib/logger';
 
@@ -36,14 +35,12 @@ export function useSearchUrlParams({
 
   const {
     query,
-    documentTypes,
     selectedLanguages,
     searchType,
     currentPage,
     pageSize,
     filters,
     setQuery,
-    setDocumentTypes,
     setSelectedLanguages,
     setSearchType,
     setCurrentPage,
@@ -84,15 +81,6 @@ export function useSearchUrlParams({
           params.set('q', encodeURIComponent(query.trim()));
         }
 
-        // Add document types
-        if (documentTypes.length > 0) {
-          if (documentTypes.length === 1) {
-            params.set('type', documentTypes[0]);
-          } else {
-            params.set('type', documentTypes.join(','));
-          }
-        }
-
         // Add languages
         if (selectedLanguages.size > 0) {
           params.set('lang', Array.from(selectedLanguages).join(','));
@@ -118,9 +106,6 @@ export function useSearchUrlParams({
         }
         if (filters.legalConcepts.size > 0) {
           params.set('legalConcepts', Array.from(filters.legalConcepts).join(','));
-        }
-        if (filters.documentTypes.size > 0) {
-          params.set('filterTypes', Array.from(filters.documentTypes).join(','));
         }
         if (filters.issuingBodies.size > 0) {
           params.set('issuingBodies', Array.from(filters.issuingBodies).join(','));
@@ -182,7 +167,6 @@ export function useSearchUrlParams({
       hasPerformedSearch,
       isSearching,
       query,
-      documentTypes,
       selectedLanguages,
       searchType,
       currentPage,
@@ -203,14 +187,12 @@ export function useSearchUrlParams({
     updatingUrlRef.current = true;
 
     const queryParam = searchParams.get('q');
-    const typeParam = searchParams.get('type');
     const langParam = searchParams.get('lang');
     const modeParam = searchParams.get('mode');
     const pageParam = searchParams.get('page');
     const pageSizeParam = searchParams.get('pageSize');
     const keywordsParam = searchParams.get('keywords');
     const legalConceptsParam = searchParams.get('legalConcepts');
-    const filterTypesParam = searchParams.get('filterTypes');
     const issuingBodiesParam = searchParams.get('issuingBodies');
     const dateFromParam = searchParams.get('dateFrom');
     const dateToParam = searchParams.get('dateTo');
@@ -222,14 +204,12 @@ export function useSearchUrlParams({
     // If no parameters are present, clear everything
     if (
       !queryParam &&
-      !typeParam &&
       !langParam &&
       !modeParam &&
       !pageParam &&
       !pageSizeParam &&
       !keywordsParam &&
       !legalConceptsParam &&
-      !filterTypesParam &&
       !issuingBodiesParam &&
       !dateFromParam &&
       !dateToParam &&
@@ -240,7 +220,6 @@ export function useSearchUrlParams({
       ) {
         // Clear all search state
         setQuery('');
-        setDocumentTypes([DocumentType.JUDGMENT]);
         setSearchMetadata([], 0, false);
         clearChunksCache();
         setError(null);
@@ -256,21 +235,6 @@ export function useSearchUrlParams({
     if (queryParam) {
       setQuery(decodeURIComponent(queryParam));
       shouldSearch = true;
-    }
-
-    // Set document types from URL parameter (supports single or comma-separated)
-    if (typeParam) {
-      const types = typeParam
-        .split(',')
-        .filter((t) => t.trim() === DocumentType.JUDGMENT)
-        .map((t) => t.trim() as DocumentType);
-      if (types.length > 0) {
-        setDocumentTypes(types);
-      } else {
-        setDocumentTypes([DocumentType.JUDGMENT]);
-      }
-    } else {
-      setDocumentTypes([DocumentType.JUDGMENT]);
     }
 
     // Set language from URL parameter
@@ -309,7 +273,6 @@ export function useSearchUrlParams({
     const newFilters = {
       keywords: new Set<string>(),
       legalConcepts: new Set<string>(),
-      documentTypes: new Set<string>(),
       issuingBodies: new Set<string>(),
       languages: currentState.filters.languages, // Preserve existing languages filter
       dateFrom: undefined as Date | undefined,
@@ -327,10 +290,6 @@ export function useSearchUrlParams({
     if (legalConceptsParam) {
       const concepts = legalConceptsParam.split(',').filter((c) => c.trim());
       newFilters.legalConcepts = new Set(concepts);
-    }
-    if (filterTypesParam) {
-      const types = filterTypesParam.split(',').filter((t) => t.trim());
-      newFilters.documentTypes = new Set(types);
     }
     if (issuingBodiesParam) {
       const bodies = issuingBodiesParam.split(',').filter((b) => b.trim());
@@ -375,7 +334,6 @@ export function useSearchUrlParams({
     if (
       keywordsParam ||
       legalConceptsParam ||
-      filterTypesParam ||
       issuingBodiesParam ||
       dateFromParam ||
       dateToParam ||

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -1,4 +1,3 @@
-import { DocumentType } from "@/types/search";
 export type { SearchResult } from "@/types/search";
 import logger from "@/lib/logger";
 
@@ -6,7 +5,7 @@ export const apiLogger = logger.child('api');
 
 export interface DocumentRetrievalInput {
   question: string;
-  document_types?: DocumentType[] | null;
+  document_types?: string[] | null;
   languages?: string[] | null;
   max_documents?: number | null;
   score_threshold?: number | null;
@@ -46,7 +45,7 @@ export interface StreamData {
 export interface SearchDocumentsInput {
   question: string;
   maxDocuments: number;
-  documentTypes?: DocumentType[];
+  documentTypes?: string[];
   languages?: string[];
   mode?: "rabbit" | "thinking";
 }

--- a/frontend/lib/api/generated/openapi.ts
+++ b/frontend/lib/api/generated/openapi.ts
@@ -5275,7 +5275,7 @@ export interface paths {
          *         {
          *             "message": "I need to extract drug information from court documents",
          *             "collection_id": "drug-cases",
-         *             "document_type": "tax_interpretation",
+         *             "document_type": "judgment",
          *             "mode": "rabbit"
          *         }
          *         ```
@@ -8525,7 +8525,7 @@ export interface components {
             chat_history?: (components["schemas"]["HumanMessage"] | components["schemas"]["AIMessage"])[] | null;
             /**
              * Document Types
-             * @description List of document types to filter (e.g., ['judgment', 'tax_interpretation'])
+             * @description List of document types to filter (e.g., ['judgment'])
              */
             document_types?: string[] | null;
             /**
@@ -8683,9 +8683,14 @@ export interface components {
         /**
          * DocumentType
          * @description Enumeration of supported legal document types.
+         *
+         *     Search is judgment-only as of 2026-05-09; the enum is retained as a
+         *     one-value placeholder so existing imports keep compiling. See
+         *     ``docs/superpowers/specs/2026-05-09-search-judgment-only-blazing-fast.md``
+         *     for the migration that collapsed the enum.
          * @enum {string}
          */
-        DocumentType: "judgment" | "tax_interpretation";
+        DocumentType: "judgment";
         /**
          * DocumentVersion
          * @description A single version entry for a document.
@@ -10843,7 +10848,7 @@ export interface components {
             date_to?: string | null;
             /**
              * Document Types
-             * @description Filter by document types (e.g., 'judgment', 'tax_interpretation')
+             * @description Filter by document types (e.g., 'judgment')
              */
             document_types?: string[] | null;
             /**
@@ -12082,7 +12087,7 @@ export interface components {
             /**
              * Document Type
              * @description Document type for schema generation
-             * @default tax_interpretation
+             * @default judgment
              */
             document_type: string;
             /**
@@ -12483,21 +12488,6 @@ export interface components {
              */
             decision_types?: string[] | null;
             /**
-             * Document Types
-             * @description Document types to filter by. Accepts 'judgment' or 'tax_interpretation'
-             * @example [
-             *       "tax_interpretation"
-             *     ]
-             * @example [
-             *       "judgment"
-             *     ]
-             * @example [
-             *       "tax_interpretation",
-             *       "judgment"
-             *     ]
-             */
-            document_types?: string[] | null;
-            /**
              * Fetch Full Documents
              * @description Whether to fetch full document objects in addition to chunks
              * @default false
@@ -12604,6 +12594,13 @@ export interface components {
              * @example interpretacja podatkowa
              */
             query: string;
+            /**
+             * Result View
+             * @description Payload size selector: 'card' returns a trimmed ~10-field card-friendly document (default, fastest), 'full' returns the legacy complete LegalDocument payload.
+             * @default card
+             * @enum {string}
+             */
+            result_view: "card" | "full";
             /**
              * Segment Types
              * @description Segment types to filter by (e.g., 'uzasadnienie', 'sentencja').
@@ -17941,8 +17938,6 @@ export interface operations {
                 sample_size?: number;
                 /** @description Minimum shared references for an edge */
                 min_shared_refs?: number;
-                /** @description Comma-separated document types to filter */
-                document_types?: string | null;
             };
             header?: never;
             path?: never;

--- a/frontend/lib/api/search.ts
+++ b/frontend/lib/api/search.ts
@@ -1,4 +1,4 @@
-import { DocumentType, SearchDocumentsDirectResponse, SearchChunk, SearchDocument } from "@/types/search";
+import { SearchDocumentsDirectResponse, SearchChunk, SearchDocument } from "@/types/search";
 import { apiLogger } from './client';
 import { logger } from "@/lib/logger";
 
@@ -6,7 +6,6 @@ export interface SearchDocumentsDirectInput {
   query: string;
   mode: "rabbit" | "thinking";
   languages?: string[];
-  document_types?: string[];
   return_properties?: string[];
 }
 
@@ -15,7 +14,6 @@ export interface SearchChunksInput {
   limit_docs?: number;
   alpha?: number;
   languages?: string[];
-  document_types?: string[];
   segment_types?: string[];
   fetch_full_documents?: boolean;
   limit_chunks?: number;
@@ -57,7 +55,6 @@ export async function searchDocuments(
   query: string,
   maxDocuments: number,
   options?: {
-    documentTypes?: DocumentType[];
     languages?: string[];
     mode?: "rabbit" | "thinking";
     page?: number;
@@ -69,8 +66,6 @@ export async function searchDocuments(
     question: query,
     maxDocuments: maxDocuments,
     maxThreshold: options?.maxThreshold || null,
-    documentTypes: options?.documentTypes || null,
-    documentType: options?.documentTypes?.[0] || null, // For backward compatibility
     languages: options?.languages || null,
     mode: options?.mode || "rabbit",
     page: options?.page || 1,
@@ -102,7 +97,6 @@ export async function searchDocumentsDirect(
     query: input.query,
     mode: input.mode,
     languages: input.languages,
-    document_types: input.document_types,
     return_properties: input.return_properties,
   });
 
@@ -138,7 +132,6 @@ export async function searchChunks(
     limit_docs: input.limit_docs,
     alpha: input.alpha,
     languages: input.languages,
-    document_types: input.document_types,
     segment_types: input.segment_types,
     fetch_full_documents: input.fetch_full_documents,
     limit_chunks: input.limit_chunks,

--- a/frontend/lib/hooks/useGraphData.ts
+++ b/frontend/lib/hooks/useGraphData.ts
@@ -11,12 +11,11 @@ import {
   DocumentSimilarity,
   GRAPH_COLORS,
 } from '@/components/similarity-viz/types';
-import { DocumentType } from '@/types/search';
 
 interface Document {
   document_id: string;
   title: string | null;
-  document_type: DocumentType;
+  document_type: string;
   full_text: string;
   summary?: string | null;
   created_at: string | null | undefined;
@@ -93,14 +92,6 @@ const findSharedConcepts = (
  * Check if a document matches the current filters
  */
 const matchesFilters = (doc: Document, filters: SimilarityFilters): boolean => {
-  // Document type filter
-  if (
-    filters.documentTypes.length > 0 &&
-    !filters.documentTypes.includes(doc.document_type)
-  ) {
-    return false;
-  }
-
   // Language filter
   if (
     filters.languages.length > 0 &&
@@ -256,7 +247,10 @@ export const useGraphData = (
  * Get node color based on document type
  */
 export const getNodeColor = (node: GraphNode): string => {
-  return GRAPH_COLORS[node.documentType] || GRAPH_COLORS.default;
+  // The graph today only renders judgments, but keep the lookup defensive in
+  // case other document types ever flow through.
+  const key = node.documentType as keyof typeof GRAPH_COLORS;
+  return GRAPH_COLORS[key] ?? GRAPH_COLORS.default;
 };
 
 /**

--- a/frontend/lib/store/searchStore.ts
+++ b/frontend/lib/store/searchStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { SearchResult, SearchDocument, SearchChunk, DocumentType, LegalDocumentMetadata } from '@/types/search';
+import { SearchResult, SearchDocument, SearchChunk, LegalDocumentMetadata } from '@/types/search';
 import { PaginationMetadata } from '@/lib/api';
 import { parseISO, isValid } from 'date-fns';
 import logger from '@/lib/logger';
@@ -11,7 +11,6 @@ type DateRange = { from?: Date; to?: Date } | null;
 interface SearchFilters {
   keywords: Set<string>;
   legalConcepts: Set<string>;
-  documentTypes: Set<string>;
   issuingBodies: Set<string>;
   languages: Set<string>;
   dateFrom: Date | undefined;
@@ -26,7 +25,6 @@ interface SearchFilters {
 interface AvailableFilters {
   keywords: string[];
   legalConcepts: string[];
-  documentTypes: string[];
   issuingBodies: string[];
   languages: string[];
   // Advanced filters
@@ -39,10 +37,8 @@ interface AvailableFilters {
 interface SearchState {
   // Search params
   query: string;
-  documentTypes: DocumentType[];
   selectedLanguages: Set<string>;
   searchType: "rabbit" | "thinking";
-  ignoreUnknownType: boolean; // Filter out documents with unknown/null/error document_type
 
   // Pagination
   currentPage: number;
@@ -84,9 +80,7 @@ interface SearchState {
 
   // Actions
   setQuery: (query: string) => void;
-  setDocumentTypes: (documentTypes: DocumentType[]) => void;
   setSelectedLanguages: (selectedLanguages: Set<string>) => void;
-  setIgnoreUnknownType: (ignore: boolean) => void;
   setSearchResults: (results: SearchResult | null) => void;
   setIsSearching: (isSearching: boolean) => void;
   setError: (error: string | null) => void;
@@ -159,16 +153,6 @@ interface SearchState {
 const setToArray = (set: Set<string>): string[] => Array.from(set);
 const arrayToSet = (array: string[] | undefined): Set<string> => new Set(array || []);
 
-// Helper function to check if a document_type is unknown/error
-// Only tax_interpretation and judgment are valid document types
-// Export this so it can be used in other modules
-export const isUnknownDocumentType = (documentType: string | DocumentType | null | undefined): boolean => {
-  if (!documentType) return true;
-
-  // Only check against DocumentType enum values - no string comparisons
-  return documentType !== DocumentType.JUDGMENT && documentType !== DocumentType.TAX_INTERPRETATION;
-};
-
 // Normalize language codes to avoid duplicates (en -> uk)
 // Database stores English as "uk", so we normalize "en" to "uk"
 const DEFAULT_LANGUAGE = "pl";
@@ -195,10 +179,8 @@ const normalizeLanguages = (languages: Set<string>): Set<string> => {
 export const useSearchStore = create<SearchState>()((set, get) => ({
   // Search params
   query: "",
-  documentTypes: [],
   selectedLanguages: new Set(["uk", "pl"]),
   searchType: "thinking",
-  ignoreUnknownType: true, // Default to ignoring unknown_type documents
 
   // Pagination
   currentPage: 1,
@@ -227,7 +209,6 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
   filters: {
     keywords: new Set<string>(),
     legalConcepts: new Set<string>(),
-    documentTypes: new Set<string>(),
     issuingBodies: new Set<string>(),
     languages: new Set<string>(),
     dateFrom: undefined,
@@ -255,7 +236,6 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
 
   // Actions
   setQuery: (query: string) => set({ query }),
-  setDocumentTypes: (documentTypes: DocumentType[]) => set({ documentTypes }),
   setSelectedLanguages: (selectedLanguages: Set<string>) => {
     const normalized = normalizeLanguages(new Set(selectedLanguages));
     if (normalized.size === 0) {
@@ -264,7 +244,6 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
     }
     set({ selectedLanguages: normalized });
   },
-  setIgnoreUnknownType: (ignore: boolean) => set({ ignoreUnknownType: ignore }),
   setSearchResults: (results: SearchResult | null) => {
     set({
       searchResults: results,
@@ -425,7 +404,6 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
         filters: {
           keywords: new Set<string>(),
           legalConcepts: new Set<string>(),
-          documentTypes: new Set<string>(),
           issuingBodies: new Set<string>(),
           languages: new Set<string>(),
           dateFrom: undefined,
@@ -491,7 +469,6 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
         const loadedFilters = {
           keywords: arrayToSet(parsedState.filters?.keywords),
           legalConcepts: arrayToSet(parsedState.filters?.legalConcepts),
-          documentTypes: arrayToSet(parsedState.filters?.documentTypes),
           issuingBodies: arrayToSet(parsedState.filters?.issuingBodies),
           languages: arrayToSet(parsedState.filters?.languages),
           dateFrom: parsedState.filters?.dateFrom ? new Date(parsedState.filters.dateFrom) : undefined,
@@ -538,7 +515,6 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
 
         storeLogger.debug('State loaded from localStorage', {
           query: parsedState.query,
-          documentTypes: parsedState.documentTypes,
           selectedLanguages: Array.from(selectedLanguages),
           dateFrom: mergedFilters.dateFrom?.toISOString(),
           dateTo: mergedFilters.dateTo?.toISOString(),
@@ -562,7 +538,6 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
           ...state.filters,
           keywords: setToArray(state.filters.keywords),
           legalConcepts: setToArray(state.filters.legalConcepts),
-          documentTypes: setToArray(state.filters.documentTypes),
           issuingBodies: setToArray(state.filters.issuingBodies),
           languages: setToArray(state.filters.languages),
           dateFrom: state.filters.dateFrom?.toISOString() || undefined,
@@ -600,9 +575,6 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
 
       if (filters.legalConcepts.size > 0 &&
           !doc.legal_concepts?.some(concept => filters.legalConcepts.has(concept.concept_name))) return false;
-
-      if (filters.documentTypes.size > 0 &&
-          !filters.documentTypes.has(doc.document_type ?? '')) return false;
 
       if (filters.issuingBodies.size > 0 &&
           !filters.issuingBodies.has(doc.issuing_body?.name || '')) return false;
@@ -722,9 +694,6 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
       if (filters.legalConcepts.size > 0 &&
           !doc.legal_concepts?.some(concept => filters.legalConcepts.has(concept.concept_name))) return false;
 
-      if (filters.documentTypes.size > 0 &&
-          !filters.documentTypes.has(doc.document_type ?? '')) return false;
-
       if (filters.issuingBodies.size > 0 &&
           !filters.issuingBodies.has(doc.issuing_body?.name || '')) return false;
 
@@ -825,21 +794,12 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
     // Use filtered metadata for new optimized flow, fallback to old flow
     const filteredMetadata = get().getFilteredMetadata();
     if (filteredMetadata.length > 0) {
-      // Skip undefined/error document types when selecting all
-      const allIds = new Set(
-        filteredMetadata
-          .filter(m => m.document_type !== DocumentType.ERROR)
-          .map(m => m.document_id)
-      );
+      const allIds = new Set(filteredMetadata.map(m => m.document_id));
       set({ selectedDocumentIds: allIds });
     } else {
       // Fallback to old flow
       const filteredDocs = get().getFilteredDocuments();
-      const allIds = new Set(
-        filteredDocs
-          .filter(doc => doc.document_type !== DocumentType.ERROR)
-          .map(doc => doc.document_id)
-      );
+      const allIds = new Set(filteredDocs.map(doc => doc.document_id));
       set({ selectedDocumentIds: allIds });
     }
   },
@@ -862,7 +822,6 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
       // Convert metadata to SearchDocument (minimal conversion for compatibility)
       return selectedMetadata.map(m => ({
         document_id: m.document_id,
-        document_type: m.document_type,
         language: m.language,
         keywords: m.keywords || [],
         date_issued: m.date_issued?.toString() || null,
@@ -994,12 +953,6 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
       // Keywords filter
       if (filters.keywords.size > 0 &&
           !metadata.keywords?.some(keyword => filters.keywords.has(keyword))) {
-        return false;
-      }
-
-      // Document types filter
-      if (filters.documentTypes.size > 0 &&
-          !filters.documentTypes.has(metadata.document_type)) {
         return false;
       }
 
@@ -1137,7 +1090,6 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
       return {
         keywords: [],
         legalConcepts: [],
-        documentTypes: [],
         issuingBodies: [],
         languages: [],
         jurisdictions: [],
@@ -1149,7 +1101,6 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
 
     // Extract unique values from filtered metadata
     const keywordsSet = new Set<string>();
-    const documentTypesSet = new Set<string>();
     const issuingBodiesSet = new Set<string>();
     const languagesSet = new Set<string>();
     const jurisdictionsSet = new Set<string>();
@@ -1166,11 +1117,6 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
       // Language
       if (metadata.language) {
         languagesSet.add(metadata.language);
-      }
-
-      // Document types - already filtered by getFilteredMetadata(), so just add all
-      if (metadata.document_type) {
-        documentTypesSet.add(metadata.document_type);
       }
 
       // Court names (using as issuing bodies)
@@ -1202,7 +1148,6 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
     return {
       keywords: Array.from(keywordsSet),
       legalConcepts: [],
-      documentTypes: Array.from(documentTypesSet),
       issuingBodies: Array.from(issuingBodiesSet),
       languages: Array.from(languagesSet),
       jurisdictions: Array.from(jurisdictionsSet),

--- a/frontend/lib/store/searchStore.ts
+++ b/frontend/lib/store/searchStore.ts
@@ -504,8 +504,6 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
           filters: mergedFilters,
           selectedLanguages,
           selectedDocumentIds,
-          // Default ignoreUnknownType to true if not present (for backward compatibility)
-          ignoreUnknownType: parsedState.ignoreUnknownType !== undefined ? parsedState.ignoreUnknownType : true,
           // Don't restore these states
           isSearching: false,
           error: null,

--- a/frontend/lib/styles/components/advanced-filter-panel.tsx
+++ b/frontend/lib/styles/components/advanced-filter-panel.tsx
@@ -30,7 +30,6 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 interface FiltersState {
  keywords: Set<string>;
  legalConcepts: Set<string>;
- documentTypes: Set<string>;
  issuingBodies: Set<string>;
  languages: Set<string>;
  dateFrom: Date | undefined;
@@ -44,7 +43,6 @@ interface FiltersState {
 interface AvailableFilters {
  keywords: string[];
  legalConcepts: string[];
- documentTypes: string[];
  issuingBodies: string[];
  languages: string[];
  jurisdictions: string[];

--- a/frontend/lib/styles/components/document-card.tsx
+++ b/frontend/lib/styles/components/document-card.tsx
@@ -35,7 +35,6 @@ function buildDocumentHref(documentId: string, from?: string, chatId?: string): 
 function formatDocumentType(type?: string | null): string {
   if (!type) return "Document";
   if (type === "judgment" || type === "judgement") return "Judgment";
-  if (type === "tax_interpretation") return "Document";
   return type.replace(/_/g, " ");
 }
 

--- a/frontend/lib/styles/components/filter-toggle-group.tsx
+++ b/frontend/lib/styles/components/filter-toggle-group.tsx
@@ -75,13 +75,13 @@ export interface FilterToggleGroupProps<T = string> {
  * @example
  * ```tsx
  * <FilterToggleGroup
- * label="Document Type: "
+ * label="Mode: "
  * options={[
- * { value: 'judgment', label: 'Judgment' },
- * { value: 'tax_interpretation', label: 'Tax Interpretation' }
+ * { value: 'rabbit', label: 'Fast' },
+ * { value: 'thinking', label: 'Deep' }
  * ]}
- * value={selectedType}
- * onChange={setSelectedType}
+ * value={selectedMode}
+ * onChange={setSelectedMode}
  * />
  * ```
  */

--- a/frontend/lib/styles/components/search-filters.tsx
+++ b/frontend/lib/styles/components/search-filters.tsx
@@ -9,19 +9,16 @@
 import React from "react";
 import { Badge, Button, Calendar, AdvancedFilterPanel } from "@/lib/styles/components";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { X, CalendarIcon, Filter, Scale, Calculator } from "lucide-react";
+import { X, CalendarIcon, Filter } from "lucide-react";
 import { format } from "date-fns";
 import { cn, formatSnakeCaseToHumanReadable } from "@/lib/utils";
 import type { DateRange } from "react-day-picker";
-import { getActiveButtonStyle } from "@/lib/styles/components/buttons";
 import { AccentButton } from "@/lib/styles/components";
-import { DocumentType } from "@/types/search";
 
 
 interface FiltersState {
  keywords: Set<string>;
  legalConcepts: Set<string>;
- documentTypes: Set<string>;
  issuingBodies: Set<string>;
  languages: Set<string>;
  dateFrom: Date | undefined;
@@ -35,7 +32,6 @@ interface FiltersState {
 interface AvailableFilters {
  keywords: string[];
  legalConcepts: string[];
- documentTypes: string[];
  issuingBodies: string[];
  languages: string[];
  jurisdictions: string[];
@@ -53,7 +49,6 @@ export interface SearchFiltersProps {
  activeFilterCount: number;
  searchResults?: { documents: Array<{
  keywords?: string[] | null;
- document_type?: string | null;
  language?: string | null;
  jurisdiction?: string | null;
  court_level?: string | null;
@@ -66,21 +61,6 @@ export interface SearchFiltersProps {
  /** Custom metadata values available for each key */
  customMetadataValues?: Record<string, string[]>;
 }
-
-
-
-// Helper function to get icon for document type
-const getDocumentTypeIcon = (type: string): React.ComponentType<{ className?: string }> | null => {
- const normalizedType = type.toLowerCase();
- if (normalizedType === 'judgment' || normalizedType === 'court_judgment') {
- return Scale;
- }
- if (normalizedType === 'tax_interpretation' || normalizedType === 'interpretation') {
- return Calculator;
- }
- // Intentionally no icon for error/undefined document type
- return null;
-};
 
 // Date range input component
 const DateRangeInput = ({ label, date, onSelect, minDate, maxDate }: {
@@ -164,20 +144,6 @@ export function SearchFilters({
  .sort((a, b) => b.count - a.count) // Sort by count descending
  .map(({ keyword }) => keyword)
  : availableFilters.keywords;
-
- // Calculate document type counts and filter/sort
- const documentTypeCounts = searchResults?.documents
- ? availableFilters.documentTypes
- .map(type => {
- const count = searchResults.documents.filter(doc =>
- doc.document_type === type
- ).length;
- return { type, count };
- })
- .filter(({ count }) => count > 1) // Filter out document types with only 1 result
- .sort((a, b) => b.count - a.count) // Sort by count descending
- .map(({ type }) => type)
- : availableFilters.documentTypes;
 
  // Calculate language counts and filter/sort
  const languageCounts = searchResults?.documents
@@ -298,65 +264,6 @@ export function SearchFilters({
  {lang === 'pl' ? '🇵🇱' : lang === 'uk' || lang === 'en' ? '🇬🇧' : ''} {lang.toUpperCase()}
  </button>
  ))}
- </div>
- </div>
- )}
-
- {/* Document types filter - Only show if there are document types */}
- {documentTypeCounts.length > 0 && (
- <div className="space-y-3">
- <h3 className="text-sm font-bold text-slate-900">
- Document Types
- </h3>
- <div className="flex flex-wrap gap-3">
- {documentTypeCounts.map((type) => {
- const Icon = getDocumentTypeIcon(type);
- const label =
- type === DocumentType.ERROR
- ? "? Undefined"
- : formatSnakeCaseToHumanReadable(type);
- return (
- <button
- key={type}
- type="button"
- className={cn(
- // Technical Chip Architecture
-"inline-flex items-center",
-"px-4 py-2",
-"rounded-lg", // 0.5rem - Squarer
-"gap-2",
-"bg-white/40",
-"border border-white/80",
-"text-slate-500",
-"text-sm",
-"font-medium",
-"cursor-pointer",
-"transition-all duration-200 ease-in-out",
-"flex items-center gap-1.5",
- filters.documentTypes.has(type)
- ? cn(
-"bg-blue-500/8",
-"border-blue-500",
-"text-blue-700",
-"shadow-sm"
- )
- : cn(
-"hover:bg-white",
-"hover:text-slate-900",
-"hover:-translate-y-0.5",
-"hover:shadow-sm"
- )
- )}
- onClick={(e) => {
- e.stopPropagation();
- onFilterToggle('documentTypes', type);
- }}
- >
- {Icon && <Icon className="h-3 w-3"/>}
- {label}
- </button>
- );
- })}
  </div>
  </div>
  )}

--- a/frontend/lib/styles/components/search/ExampleQueries.tsx
+++ b/frontend/lib/styles/components/search/ExampleQueries.tsx
@@ -1,154 +1,78 @@
 import { Sparkles } from 'lucide-react';
-import { DocumentType } from '@/types/search';
 import { cn } from '@/lib/utils';
 
 interface ExampleQuery {
  title: string;
  query: string;
  mode: 'rabbit' | 'thinking';
- documentType: DocumentType;
  language: string;
 }
 
 interface ExampleQueriesProps {
  show: boolean;
- documentTypes: DocumentType[];
  onExampleClick: (
  query: string,
  mode: 'rabbit' | 'thinking',
- documentType: DocumentType,
  language: string
  ) => void;
 }
 
-const examplesByDocumentType: Record<DocumentType, ExampleQuery[]> = {
- [DocumentType.JUDGMENT]: [
+const JUDGMENT_EXAMPLES: ExampleQuery[] = [
  {
  title: 'Copyright infringement',
  query: 'What are the key elements of copyright infringement?',
  mode: 'thinking',
- documentType: DocumentType.JUDGMENT,
  language: 'uk',
  },
  {
  title: 'Swiss franc loans',
  query: 'Key legal issues and court rulings on Swiss franc loans in Poland',
  mode: 'thinking',
- documentType: DocumentType.JUDGMENT,
  language: 'uk',
  },
  {
  title: 'Data privacy cases',
  query: 'Summarize recent data privacy cases',
  mode: 'thinking',
- documentType: DocumentType.JUDGMENT,
  language: 'uk',
  },
  {
  title: 'Fair use doctrine',
  query: 'Explain fair use doctrine in intellectual property',
  mode: 'thinking',
- documentType: DocumentType.JUDGMENT,
  language: 'uk',
  },
  {
  title: 'Consumer protection',
  query: 'Consumer protection in online transactions',
  mode: 'thinking',
- documentType: DocumentType.JUDGMENT,
  language: 'uk',
  },
  {
  title: 'Wrongful termination',
  query: 'Wrongful termination case precedents',
  mode: 'thinking',
- documentType: DocumentType.JUDGMENT,
  language: 'uk',
  },
  {
  title: 'Contract disputes',
  query: 'Contract breach remedies and damages',
  mode: 'thinking',
- documentType: DocumentType.JUDGMENT,
  language: 'uk',
  },
  {
  title: 'Real estate law',
  query: 'Property ownership transfer disputes',
  mode: 'thinking',
- documentType: DocumentType.JUDGMENT,
  language: 'uk',
  },
- ],
- [DocumentType.TAX_INTERPRETATION]: [
- {
- title: 'IP Box relief',
- query: 'Requirements for IP Box tax relief in Poland',
- mode: 'thinking',
- documentType: DocumentType.TAX_INTERPRETATION,
- language: 'pl',
- },
- {
- title: 'VAT digital services',
- query: 'VAT application to international digital services',
- mode: 'thinking',
- documentType: DocumentType.TAX_INTERPRETATION,
- language: 'pl',
- },
- {
- title: 'R&D deductions',
- query: 'Expenses qualifying for R&D tax deductions',
- mode: 'thinking',
- documentType: DocumentType.TAX_INTERPRETATION,
- language: 'pl',
- },
- {
- title: 'Tax residency',
- query: 'Tax residency determination for individuals',
- mode: 'thinking',
- documentType: DocumentType.TAX_INTERPRETATION,
- language: 'pl',
- },
- {
- title: 'Corporate income tax',
- query: 'Corporate income tax optimization strategies',
- mode: 'thinking',
- documentType: DocumentType.TAX_INTERPRETATION,
- language: 'pl',
- },
- {
- title: 'Transfer pricing',
- query: 'Transfer pricing documentation requirements',
- mode: 'thinking',
- documentType: DocumentType.TAX_INTERPRETATION,
- language: 'pl',
- },
- {
- title: 'Withholding tax',
- query: 'Withholding tax on cross-border payments',
- mode: 'thinking',
- documentType: DocumentType.TAX_INTERPRETATION,
- language: 'pl',
- },
- {
- title: 'VAT exemptions',
- query: 'VAT exemptions for financial services',
- mode: 'thinking',
- documentType: DocumentType.TAX_INTERPRETATION,
- language: 'pl',
- },
- ],
- [DocumentType.ERROR]: [], // Empty array for error document type
-};
+];
 
-export function ExampleQueries({ show, documentTypes, onExampleClick }: ExampleQueriesProps): React.JSX.Element | null {
+export function ExampleQueries({ show, onExampleClick }: ExampleQueriesProps): React.JSX.Element | null {
  if (!show) return null;
 
- // Get current examples based on selected document type
- const currentExamples = examplesByDocumentType[documentTypes[0] || DocumentType.JUDGMENT];
-
  // Show 8 examples as compact pills
- const displayedExamples = currentExamples.slice(0, 8);
+ const displayedExamples = JUDGMENT_EXAMPLES.slice(0, 8);
 
  return (
  <div className="w-full">
@@ -162,7 +86,7 @@ export function ExampleQueries({ show, documentTypes, onExampleClick }: ExampleQ
  <button
  key={index}
  onClick={() =>
- onExampleClick(example.query, example.mode, example.documentType, example.language)
+ onExampleClick(example.query, example.mode, example.language)
  }
  className={cn(
 "px-4 py-2 text-sm font-medium rounded-full",

--- a/frontend/lib/styles/components/search/SearchConfiguration.tsx
+++ b/frontend/lib/styles/components/search/SearchConfiguration.tsx
@@ -1,16 +1,15 @@
 /**
  * Search Configuration Component
- * Configuration card for search query settings (document type, mode, language)
+ * Configuration card for search query settings (mode, language)
  * Separate from SearchFilters which is for filtering results
- * Provides toggles for document types, search mode, and language selection
+ * Provides toggles for search mode and language selection
  */
 
 "use client";
 
 import React, { useEffect, useRef } from 'react';
-import { Zap, Brain, Scale, Calculator, Rabbit } from 'lucide-react';
-import { DocumentType } from '@/types/search';
-import { FilterToggleGroup, AIBadge } from '@/lib/styles/components';
+import { Brain, Rabbit } from 'lucide-react';
+import { AIBadge } from '@/lib/styles/components';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/lib/styles/components/tooltip';
 import { cn } from '@/lib/utils';
@@ -22,8 +21,6 @@ interface Language {
 }
 
 export interface SearchConfigurationProps {
- documentTypes: DocumentType[];
- onDocumentTypeToggle: (type: DocumentType) => void;
  searchType: 'rabbit' | 'thinking';
  onSearchTypeChange: (type: 'rabbit' | 'thinking') => void;
  selectedLanguages: Set<string>;
@@ -31,19 +28,12 @@ export interface SearchConfigurationProps {
  isSearching?: boolean;
 }
 
-const availableDocumentTypes = [
- { value: DocumentType.JUDGMENT, label: 'Judgment', icon: Scale },
- { value: DocumentType.TAX_INTERPRETATION, label: 'Tax Interpretation', icon: Calculator },
-];
-
 const availableLanguages: Language[] = [
  { code: 'pl', name: 'Polish', flag: '🇵🇱' },
  { code: 'uk', name: 'English', flag: '🇬🇧' },
 ];
 
 export function SearchConfiguration({
- documentTypes,
- onDocumentTypeToggle,
  searchType,
  onSearchTypeChange,
  selectedLanguages,
@@ -87,36 +77,7 @@ export function SearchConfiguration({
  <h3 className="text-sm font-medium text-slate-900 mb-1">Search Configuration</h3>
 
  <div className="grid grid-cols-2 gap-4">
- {/* Row 1: Search In - Spans full width */}
- <div className="flex flex-row items-center gap-1 col-span-2">
- <label className="text-xs font-medium text-slate-900 w-20 shrink-0">Search In:</label>
- <div className="relative flex h-12 rounded-lg p-2 flex-1 gap-2.5">
- {availableDocumentTypes.map((type) => {
- const isSelected = documentTypes.includes(type.value);
- const Icon = type.icon;
- const displayLabel = type.label === 'Tax Interpretation' ? 'Tax Interpretations' : type.label;
-
- return (
- <button
- key={type.value}
- type="button"
- onClick={() => !isSearching && onDocumentTypeToggle(type.value)}
- disabled={isSearching}
- className={cn(
-"neo-chip flex-1",
- isSelected &&"neo-chip--active",
- isSearching &&"opacity-50 cursor-not-allowed"
- )}
- >
- <Icon className="h-5 w-5 shrink-0"/>
- <span className="whitespace-nowrap text-sm font-medium">{displayLabel}</span>
- </button>
- );
- })}
- </div>
- </div>
-
- {/* Row 2, Col 1: Mode */}
+ {/* Mode */}
  <div className="flex flex-row items-center gap-1">
  <label className="text-xs font-medium text-slate-900 w-20 shrink-0">Mode:</label>
  <Popover open={searchType === 'rabbit' ? isFastPopoverOpen : searchType === 'thinking' ? isThinkingPopoverOpen : false} onOpenChange={(open) => {
@@ -207,32 +168,27 @@ export function SearchConfiguration({
  </Popover>
  </div>
 
- {/* Row 2, Col 2: Language */}
+ {/* Language */}
  <div className="flex flex-row items-center gap-1">
  <label className="text-xs font-medium text-slate-900 w-20 shrink-0">Language:</label>
  <div className="relative flex h-12 rounded-lg p-2 flex-1 gap-2.5">
  {availableLanguages.map((lang) => {
- const hasOnlyTaxInterpretation =
- documentTypes.length === 1 && documentTypes.includes(DocumentType.TAX_INTERPRETATION);
- const isEnglish = lang.code === 'en' || lang.code === 'uk';
- const isTaxInterpretationDisabled = hasOnlyTaxInterpretation && isEnglish;
  const isSelected = selectedLanguages.has(lang.code);
- const isDisabled = isTaxInterpretationDisabled;
 
  return (
  <button
  key={lang.code}
  type="button"
  onClick={() => {
- if (!isDisabled && !isSearching) {
+ if (!isSearching) {
  onLanguageToggle(lang.code);
  }
  }}
- disabled={isSearching || isDisabled}
+ disabled={isSearching}
  className={cn(
 "neo-chip flex-1",
  isSelected &&"neo-chip--active",
- (isSearching || isDisabled) &&"opacity-50 cursor-not-allowed"
+ isSearching &&"opacity-50 cursor-not-allowed"
  )}
  >
  <span className="text-lg shrink-0">{lang.flag}</span>

--- a/frontend/lib/styles/components/search/SearchForm.tsx
+++ b/frontend/lib/styles/components/search/SearchForm.tsx
@@ -7,7 +7,6 @@ import DOMPurify from "dompurify";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { AutocompleteSuggestion } from "@/hooks/useSearchAutocomplete";
-import { DocumentType } from "@/types/search";
 
 type SearchMode = "thinking" | "rabbit";
 
@@ -27,11 +26,8 @@ export interface SearchFormProps {
   setQuery: (value: string) => void;
   searchType: SearchMode;
   setSearchType: (value: SearchMode) => void;
-  documentTypes: DocumentType[];
-  toggleDocumentType: (type: DocumentType) => void;
   selectedLanguages: Set<string>;
   toggleLanguage: (language: string) => void;
-  setDocumentTypes: (types: DocumentType[]) => void;
   setSelectedLanguages: (languages: Set<string>) => void;
   isSearching: boolean;
   hasResults: boolean;
@@ -46,7 +42,6 @@ export interface SearchFormProps {
 type PopularSearch = {
   label: string;
   mode: SearchMode;
-  documentTypes: DocumentType[];
   languages: Set<string>;
 };
 
@@ -54,19 +49,16 @@ const POPULAR_SEARCHES: PopularSearch[] = [
   {
     label: "Kredyty frankowe",
     mode: "thinking",
-    documentTypes: [DocumentType.JUDGMENT],
     languages: new Set(["pl"]),
   },
   {
     label: "Intellectual property",
     mode: "thinking",
-    documentTypes: [DocumentType.JUDGMENT],
     languages: new Set(["uk"]),
   },
   {
     label: "Prawo pracy",
     mode: "thinking",
-    documentTypes: [DocumentType.JUDGMENT],
     languages: new Set(["pl"]),
   },
 ];
@@ -76,7 +68,6 @@ export const SearchForm = forwardRef<HTMLInputElement, SearchFormProps>(function
     query,
     setQuery,
     setSearchType,
-    setDocumentTypes,
     setSelectedLanguages,
     isSearching,
     hasResults,
@@ -116,7 +107,6 @@ export const SearchForm = forwardRef<HTMLInputElement, SearchFormProps>(function
   const handlePopularSearch = (item: PopularSearch): void => {
     setQuery(item.label);
     setSearchType(item.mode);
-    setDocumentTypes(item.documentTypes);
     setSelectedLanguages(item.languages);
     internalRef.current?.focus();
   };

--- a/frontend/scripts/validate-document-types.js
+++ b/frontend/scripts/validate-document-types.js
@@ -28,6 +28,7 @@ const SEARCH_PATTERNS = {
     /documentType[\s]*:\s*DocumentType\b/, // Single document/example values are OK
     /documentType[\s]*\??:\s*string(?:\s*\|\s*null)?\b/, // DTO fields for one document are OK
     /documentType[\s]*:\s*documentType\b/, // Object literals forwarding one document field are OK
+    /documentType[\s]*:\s*['"][a-z_]+['"]/, // String-literal singular values for a single node/document are OK
     /\/\/ For backward compatibility/, // Explicit backward compatibility comments are OK
   ]
 };
@@ -136,39 +137,13 @@ function validateDocumentTypes() {
   }
 }
 
-// Additional check: Verify DocumentType enum is properly defined
-function validateDocumentTypeEnum() {
-  const enumFile = path.join(FRONTEND_ROOT, 'types', 'search.ts');
-  
-  try {
-    const content = fs.readFileSync(enumFile, 'utf8');
-    
-    const requiredEnumValues = [
-      'JUDGMENT',
-      'TAX_INTERPRETATION',
-      'ERROR'
-    ];
-    
-    let foundValues = 0;
-    requiredEnumValues.forEach(value => {
-      if (content.includes(`${value} =`)) {
-        foundValues++;
-      }
-    });
-    
-    if (foundValues === requiredEnumValues.length) {
-      console.log('✅ DocumentType enum is properly defined');
-    } else {
-      console.log(`❌ DocumentType enum missing some values. Found ${foundValues}/${requiredEnumValues.length}`);
-      process.exit(1);
-    }
-  } catch (error) {
-    console.log(`❌ Could not validate DocumentType enum: ${error.message}`);
-    process.exit(1);
-  }
-}
+// NOTE: The legacy `validateDocumentTypeEnum` check enforced existence of
+// `JUDGMENT`, `TAX_INTERPRETATION`, `ERROR` members on a `DocumentType` enum.
+// As of the 2026-05-09 search-judgment-only refactor (see
+// `docs/superpowers/specs/2026-05-09-search-judgment-only-blazing-fast.md`)
+// search is judgment-only and the enum was removed entirely, so the check is
+// no longer applicable.
 
 if (require.main === module) {
-  validateDocumentTypeEnum();
   validateDocumentTypes();
 }

--- a/frontend/tests/e2e-docker/api-integration.spec.ts
+++ b/frontend/tests/e2e-docker/api-integration.spec.ts
@@ -81,14 +81,13 @@ test.describe('Dashboard API', () => {
     const response = await request.get('/dashboard/stats');
     expect(response.ok()).toBeTruthy();
     const data = await response.json();
-    expect(data).toHaveProperty('total_documents');
-    expect(data).toHaveProperty('judgments');
-    expect(data).toHaveProperty('tax_interpretations');
-    expect(data).toHaveProperty('added_this_week');
-    expect(typeof data.total_documents).toBe('number');
-    expect(typeof data.judgments).toBe('number');
-    expect(typeof data.tax_interpretations).toBe('number');
-    expect(typeof data.added_this_week).toBe('number');
+    // Search collapsed to judgment-only — DashboardStats now exposes
+    // `total_judgments` plus jurisdiction breakdowns; the legacy
+    // `tax_interpretations` / `total_documents` / `added_this_week` keys
+    // were removed.
+    expect(data).toHaveProperty('total_judgments');
+    expect(typeof data.total_judgments).toBe('number');
+    expect(data).toHaveProperty('jurisdictions');
   });
 
   test('GET /dashboard/trending-topics returns topic list', async ({ request }) => {

--- a/frontend/tests/e2e/api/backend-api.spec.ts
+++ b/frontend/tests/e2e/api/backend-api.spec.ts
@@ -120,7 +120,6 @@ test.describe('Backend API Integration', () => {
         data: {
           query: "Swiss franc loans consumer protection",
           max_documents: 10,
-          document_types: ["judgment"],
           languages: ["pl"],
           mode: "rabbit"
         }
@@ -155,7 +154,6 @@ test.describe('Backend API Integration', () => {
         data: {
           query: "copyright infringement legal precedent",
           max_documents: 5,
-          document_types: ["judgment", "tax_interpretation"],
           languages: ["pl", "uk"],
           mode: "thinking"
         }

--- a/frontend/tests/e2e/helpers/api-mocks.ts
+++ b/frontend/tests/e2e/helpers/api-mocks.ts
@@ -9,7 +9,7 @@ export interface MockDocument {
   document_id: string;
   title: string;
   content: string;
-  document_type: 'judgment' | 'tax_interpretation' | 'ruling';
+  document_type: 'judgment';
   language?: string;
   date?: string;
   court_name?: string;

--- a/frontend/tests/e2e/search/complete-search-flow.spec.ts
+++ b/frontend/tests/e2e/search/complete-search-flow.spec.ts
@@ -132,7 +132,7 @@ test.describe('Complete Search Flow', () => {
             document_id: `doc${i}`,
             title: `Document ${i}`,
             content: `Content for document ${i}`,
-            document_type: i % 2 === 0 ? 'judgment' : 'tax_interpretation',
+            document_type: 'judgment',
             language: 'pl',
             date: `2023-0${(i % 9) + 1}-01`,
             court_name: i % 2 === 0 ? 'Supreme Court' : 'Administrative Court',

--- a/frontend/tests/e2e/search/search-flow.spec.ts
+++ b/frontend/tests/e2e/search/search-flow.spec.ts
@@ -111,7 +111,7 @@ test.describe('Search Functionality', () => {
           documents: Array.from({length: 5}, (_, i) => ({
             document_id: `doc${i}`,
             title: `Document ${i}`,
-            document_type: i % 2 === 0 ? 'judgment' : 'tax_interpretation',
+            document_type: 'judgment',
             date: `2023-0${i + 1}-01`,
             content: `Content for document ${i}`
           })),

--- a/frontend/types/chat-sources.ts
+++ b/frontend/types/chat-sources.ts
@@ -98,13 +98,6 @@ export const DOCUMENT_TYPE_CONFIGS: Record<string, DocumentTypeConfig> = {
     bgColor: 'bg-judgment/10',
     emoji: '⚖️',
   },
-  tax_interpretation: {
-    icon: 'FileText',
-    label: 'Document',
-    color: 'text-document',
-    bgColor: 'bg-document/10',
-    emoji: '📄',
-  },
   regulation: {
     icon: 'BookOpen',
     label: 'Legal Regulation',

--- a/frontend/types/saved-search.ts
+++ b/frontend/types/saved-search.ts
@@ -6,7 +6,6 @@ export interface SavedSearch {
   folder: string | null;
   query: string;
   search_config: SavedSearchConfig;
-  document_types: string[];
   languages: string[];
   search_mode: 'rabbit' | 'thinking';
   is_shared: boolean;
@@ -21,7 +20,6 @@ export interface SavedSearchConfig {
   filters?: {
     keywords?: string[];
     legalConcepts?: string[];
-    documentTypes?: string[];
     issuingBodies?: string[];
     languages?: string[];
     dateFrom?: string;
@@ -32,7 +30,6 @@ export interface SavedSearchConfig {
     customMetadata?: Record<string, string[]>;
   };
   pageSize?: number;
-  ignoreUnknownType?: boolean;
 }
 
 export interface CreateSavedSearchInput {
@@ -41,7 +38,6 @@ export interface CreateSavedSearchInput {
   folder?: string;
   query: string;
   search_config: SavedSearchConfig;
-  document_types?: string[];
   languages?: string[];
   search_mode?: 'rabbit' | 'thinking';
   is_shared?: boolean;
@@ -53,7 +49,6 @@ export interface UpdateSavedSearchInput {
   folder?: string | null;
   query?: string;
   search_config?: SavedSearchConfig;
-  document_types?: string[];
   languages?: string[];
   search_mode?: 'rabbit' | 'thinking';
   is_shared?: boolean;

--- a/frontend/types/search.ts
+++ b/frontend/types/search.ts
@@ -1,9 +1,3 @@
-export enum DocumentType {
-  JUDGMENT = "judgment",
-  TAX_INTERPRETATION = "tax_interpretation",
-  ERROR = "error"
-}
-
 export interface SearchChunk {
   document_id: string;
   chunk_id: string | number;
@@ -17,7 +11,6 @@ export interface SearchChunk {
   parent_segment_id?: string;
   score?: number;
   // Additional fields that may come from backend DocumentChunk
-  document_type?: string;
   language?: string;
   [key: string]: unknown;
 }
@@ -33,7 +26,6 @@ export enum DocumentProcessingStatus {
 // Raw Weaviate document structure (matches the schema exactly)
 export interface WeaviateDocument {
   document_id: string;
-  document_type: string;
   title: string | null;
   date_issued: string | null;
   document_number: string | null;
@@ -71,7 +63,6 @@ export interface WeaviateDocument {
 // Frontend-friendly SearchDocument interface (for UI components)
 export interface SearchDocument {
   document_id: string;
-  document_type?: string;
   title?: string | null;
   date_issued: string | null;
   issuing_body: {
@@ -137,7 +128,6 @@ export interface SearchResult {
 export interface LegalDocumentMetadata {
   uuid: string;
   document_id: string;
-  document_type: DocumentType;
   language: string;
   keywords: string[];
   date_issued: string | null;

--- a/scripts/openapi-snapshot.json
+++ b/scripts/openapi-snapshot.json
@@ -4916,7 +4916,7 @@
                 "type": "null"
               }
             ],
-            "description": "List of document types to filter (e.g., ['judgment', 'tax_interpretation'])",
+            "description": "List of document types to filter (e.g., ['judgment'])",
             "title": "Document Types"
           },
           "languages": {
@@ -5261,10 +5261,9 @@
         "type": "object"
       },
       "DocumentType": {
-        "description": "Enumeration of supported legal document types.",
+        "description": "Enumeration of supported legal document types.\n\nSearch is judgment-only as of 2026-05-09; the enum is retained as a\none-value placeholder so existing imports keep compiling. See\n``docs/superpowers/specs/2026-05-09-search-judgment-only-blazing-fast.md``\nfor the migration that collapsed the enum.",
         "enum": [
-          "judgment",
-          "tax_interpretation"
+          "judgment"
         ],
         "title": "DocumentType",
         "type": "string"
@@ -9599,7 +9598,7 @@
                 "type": "null"
               }
             ],
-            "description": "Filter by document types (e.g., 'judgment', 'tax_interpretation')",
+            "description": "Filter by document types (e.g., 'judgment')",
             "title": "Document Types"
           },
           "language": {
@@ -12294,7 +12293,7 @@
             "title": "Current Schema"
           },
           "document_type": {
-            "default": "tax_interpretation",
+            "default": "judgment",
             "description": "Document type for schema generation",
             "title": "Document Type",
             "type": "string"
@@ -13061,33 +13060,6 @@
             ],
             "title": "Decision Types"
           },
-          "document_types": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Document types to filter by. Accepts 'judgment' or 'tax_interpretation'",
-            "examples": [
-              [
-                "tax_interpretation"
-              ],
-              [
-                "judgment"
-              ],
-              [
-                "tax_interpretation",
-                "judgment"
-              ]
-            ],
-            "title": "Document Types"
-          },
           "fetch_full_documents": {
             "default": false,
             "description": "Whether to fetch full document objects in addition to chunks",
@@ -13266,6 +13238,16 @@
               "interpretacja podatkowa"
             ],
             "title": "Query",
+            "type": "string"
+          },
+          "result_view": {
+            "default": "card",
+            "description": "Payload size selector: 'card' returns a trimmed ~10-field card-friendly document (default, fastest), 'full' returns the legacy complete LegalDocument payload.",
+            "enum": [
+              "card",
+              "full"
+            ],
+            "title": "Result View",
             "type": "string"
           },
           "segment_types": {
@@ -23430,24 +23412,6 @@
               "title": "Min Shared Refs",
               "type": "integer"
             }
-          },
-          {
-            "description": "Comma-separated document types to filter",
-            "in": "query",
-            "name": "document_types",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Comma-separated document types to filter",
-              "title": "Document Types"
-            }
           }
         ],
         "responses": {
@@ -31447,7 +31411,7 @@
     },
     "/schema-generator/chat": {
       "post": {
-        "description": "Process conversational messages for schema generation.\n\nThis endpoint provides a chat-based interface for creating and refining\nextraction schemas. It maintains conversation state across requests using\nsession IDs.\n\nArgs:\n    params: Chat request with message and context\n    request: FastAPI request object\n\nReturns:\n    Chat response with AI message and schema state\n\nExample:\n    ```\n    POST /api/schema-generator/chat\n    {\n        \"message\": \"I need to extract drug information from court documents\",\n        \"collection_id\": \"drug-cases\",\n        \"document_type\": \"tax_interpretation\",\n        \"mode\": \"rabbit\"\n    }\n    ```",
+        "description": "Process conversational messages for schema generation.\n\nThis endpoint provides a chat-based interface for creating and refining\nextraction schemas. It maintains conversation state across requests using\nsession IDs.\n\nArgs:\n    params: Chat request with message and context\n    request: FastAPI request object\n\nReturns:\n    Chat response with AI message and schema state\n\nExample:\n    ```\n    POST /api/schema-generator/chat\n    {\n        \"message\": \"I need to extract drug information from court documents\",\n        \"collection_id\": \"drug-cases\",\n        \"document_type\": \"judgment\",\n        \"mode\": \"rabbit\"\n    }\n    ```",
         "operationId": "schema_chat_schema_generator_chat_post",
         "requestBody": {
           "content": {

--- a/supabase/migrations/20260509000003_drop_tax_interpretation_dashboard_stats.sql
+++ b/supabase/migrations/20260509000003_drop_tax_interpretation_dashboard_stats.sql
@@ -1,0 +1,31 @@
+-- Drop seeded tax_interpretation* rows from dashboard stats.
+--
+-- Search and dashboard now treat the application as judgment-only;
+-- these rows would otherwise display as zero counts.
+--
+-- The seed rows live in `public.doc_type_stats` (column `doc_type`),
+-- written by `public.refresh_dashboard_stats()` in
+-- `20260325000001_create_dashboard_precomputed_stats.sql` lines 530-532.
+-- The companion table `public.dashboard_precomputed_stats` (column
+-- `stat_key`) does not currently seed any tax_interpretation* rows, but
+-- the equivalent DELETE is included for defence-in-depth in case a
+-- future seed adds them under those keys.
+--
+-- Note: `refresh_dashboard_stats()` will re-insert the doc_type_stats
+-- rows on its next call (it TRUNCATEs and re-INSERTs from a static
+-- VALUES list). Updating that function to stop seeding them is owned
+-- by Task 3 (backend tax_interpretation purge) per the design spec.
+
+delete from public.doc_type_stats
+where doc_type in (
+  'tax_interpretation',
+  'tax_interpretation_pl',
+  'tax_interpretation_uk'
+);
+
+delete from public.dashboard_precomputed_stats
+where stat_key in (
+  'tax_interpretation',
+  'tax_interpretation_pl',
+  'tax_interpretation_uk'
+);

--- a/supabase/migrations/20260509000004_fix_refresh_dashboard_stats_judgment_only.sql
+++ b/supabase/migrations/20260509000004_fix_refresh_dashboard_stats_judgment_only.sql
@@ -1,0 +1,453 @@
+-- Redefine `public.refresh_dashboard_stats()` so it no longer re-seeds the
+-- three `tax_interpretation*` rows in `public.doc_type_stats`.
+--
+-- Background: search and dashboard are now judgment-only as of 2026-05-09
+-- (see `docs/superpowers/specs/2026-05-09-search-judgment-only-blazing-fast.md`).
+-- Migration 20260509000003_drop_tax_interpretation_dashboard_stats.sql deletes
+-- the legacy rows from `doc_type_stats` and `dashboard_precomputed_stats`,
+-- but `refresh_dashboard_stats()` (defined in
+-- 20260325000001_create_dashboard_precomputed_stats.sql lines 105-535)
+-- TRUNCATEs `doc_type_stats` and re-INSERTs from a static VALUES list that
+-- still contained the three tax_interpretation* rows. The next call to the
+-- function would therefore re-seed the rows we just deleted.
+--
+-- This migration uses `CREATE OR REPLACE FUNCTION` to redefine the function
+-- with the tax_interpretation* VALUES rows removed. The rest of the function
+-- body — the `dashboard_precomputed_stats` rebuild plus the judgment/jurisdiction
+-- VALUES rows in `doc_type_stats` — is reproduced verbatim from the source
+-- migration so the precomputed analytics keep working.
+
+CREATE OR REPLACE FUNCTION public.refresh_dashboard_stats()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_total          BIGINT;
+    v_total_pl       BIGINT;
+    v_total_uk       BIGINT;
+    v_now            TIMESTAMPTZ := NOW();
+BEGIN
+
+    -- -------------------------------------------------------------------------
+    -- Pre-aggregate frequently reused scalars to avoid repeated full scans
+    -- -------------------------------------------------------------------------
+    SELECT
+        COUNT(*)                                            INTO v_total
+    FROM public.judgments;
+
+    SELECT COUNT(*) INTO v_total_pl
+    FROM public.judgments
+    WHERE jurisdiction = 'PL';
+
+    SELECT COUNT(*) INTO v_total_uk
+    FROM public.judgments
+    WHERE jurisdiction = 'UK';
+
+    -- =========================================================================
+    -- dashboard_precomputed_stats
+    -- =========================================================================
+    TRUNCATE public.dashboard_precomputed_stats;
+
+    -- -------------------------------------------------------------------------
+    -- Category: counts
+    -- -------------------------------------------------------------------------
+
+    -- total_judgments
+    INSERT INTO public.dashboard_precomputed_stats (stat_key, stat_value, category, computed_at)
+    VALUES (
+        'total_judgments',
+        to_jsonb(v_total),
+        'counts',
+        v_now
+    );
+
+    -- judgments_by_jurisdiction
+    INSERT INTO public.dashboard_precomputed_stats (stat_key, stat_value, category, computed_at)
+    VALUES (
+        'judgments_by_jurisdiction',
+        jsonb_build_object('PL', v_total_pl, 'UK', v_total_uk),
+        'counts',
+        v_now
+    );
+
+    -- -------------------------------------------------------------------------
+    -- Category: distribution
+    -- -------------------------------------------------------------------------
+
+    -- court_level_distribution
+    INSERT INTO public.dashboard_precomputed_stats (stat_key, stat_value, category, computed_at)
+    SELECT
+        'court_level_distribution',
+        COALESCE(
+            jsonb_agg(
+                jsonb_build_object(
+                    'level',       COALESCE(court_level, 'Unknown'),
+                    'count',       cnt,
+                    'jurisdiction', jurisdiction
+                )
+                ORDER BY cnt DESC
+            ),
+            '[]'::jsonb
+        ),
+        'distribution',
+        v_now
+    FROM (
+        SELECT
+            jurisdiction,
+            COALESCE(court_level, 'Unknown') AS court_level,
+            COUNT(*)                          AS cnt
+        FROM public.judgments
+        GROUP BY jurisdiction, court_level
+    ) sub;
+
+    -- top_courts (top 15)
+    INSERT INTO public.dashboard_precomputed_stats (stat_key, stat_value, category, computed_at)
+    SELECT
+        'top_courts',
+        COALESCE(
+            jsonb_agg(
+                jsonb_build_object(
+                    'name',        court_name,
+                    'count',       cnt,
+                    'jurisdiction', jurisdiction
+                )
+                ORDER BY cnt DESC
+            ),
+            '[]'::jsonb
+        ),
+        'distribution',
+        v_now
+    FROM (
+        SELECT
+            jurisdiction,
+            COALESCE(court_name, 'Unknown') AS court_name,
+            COUNT(*)                         AS cnt
+        FROM public.judgments
+        WHERE court_name IS NOT NULL
+        GROUP BY jurisdiction, court_name
+        ORDER BY cnt DESC
+        LIMIT 15
+    ) sub;
+
+    -- decisions_per_year
+    INSERT INTO public.dashboard_precomputed_stats (stat_key, stat_value, category, computed_at)
+    SELECT
+        'decisions_per_year',
+        COALESCE(
+            jsonb_agg(
+                jsonb_build_object('year', yr, 'count', cnt)
+                ORDER BY yr
+            ),
+            '[]'::jsonb
+        ),
+        'distribution',
+        v_now
+    FROM (
+        SELECT
+            EXTRACT(YEAR FROM decision_date)::INT AS yr,
+            COUNT(*)                               AS cnt
+        FROM public.judgments
+        WHERE decision_date IS NOT NULL
+        GROUP BY yr
+    ) sub;
+
+    -- date_range
+    INSERT INTO public.dashboard_precomputed_stats (stat_key, stat_value, category, computed_at)
+    SELECT
+        'date_range',
+        jsonb_build_object(
+            'oldest', to_char(MIN(decision_date), 'YYYY-MM-DD'),
+            'newest', to_char(MAX(decision_date), 'YYYY-MM-DD')
+        ),
+        'distribution',
+        v_now
+    FROM public.judgments
+    WHERE decision_date IS NOT NULL;
+
+    -- case_type_distribution
+    INSERT INTO public.dashboard_precomputed_stats (stat_key, stat_value, category, computed_at)
+    SELECT
+        'case_type_distribution',
+        COALESCE(
+            jsonb_agg(
+                jsonb_build_object('type', ct, 'count', cnt)
+                ORDER BY cnt DESC
+            ),
+            '[]'::jsonb
+        ),
+        'distribution',
+        v_now
+    FROM (
+        SELECT
+            COALESCE(case_type, 'Unknown') AS ct,
+            COUNT(*)                        AS cnt
+        FROM public.judgments
+        GROUP BY case_type
+    ) sub;
+
+    -- decision_type_distribution
+    INSERT INTO public.dashboard_precomputed_stats (stat_key, stat_value, category, computed_at)
+    SELECT
+        'decision_type_distribution',
+        COALESCE(
+            jsonb_agg(
+                jsonb_build_object('type', dt, 'count', cnt)
+                ORDER BY cnt DESC
+            ),
+            '[]'::jsonb
+        ),
+        'distribution',
+        v_now
+    FROM (
+        SELECT
+            COALESCE(decision_type, 'Unknown') AS dt,
+            COUNT(*)                            AS cnt
+        FROM public.judgments
+        GROUP BY decision_type
+    ) sub;
+
+    -- outcome_distribution
+    INSERT INTO public.dashboard_precomputed_stats (stat_key, stat_value, category, computed_at)
+    SELECT
+        'outcome_distribution',
+        COALESCE(
+            jsonb_agg(
+                jsonb_build_object('outcome', oc, 'count', cnt)
+                ORDER BY cnt DESC
+            ),
+            '[]'::jsonb
+        ),
+        'distribution',
+        v_now
+    FROM (
+        SELECT
+            COALESCE(outcome, 'Unknown') AS oc,
+            COUNT(*)                      AS cnt
+        FROM public.judgments
+        GROUP BY outcome
+    ) sub;
+
+    -- -------------------------------------------------------------------------
+    -- Category: completeness
+    -- -------------------------------------------------------------------------
+
+    INSERT INTO public.dashboard_precomputed_stats (stat_key, stat_value, category, computed_at)
+    SELECT
+        'data_completeness',
+        jsonb_build_object(
+            'embeddings_pct',
+            CASE WHEN v_total > 0
+                 THEN ROUND(
+                     (COUNT(*) FILTER (WHERE embedding IS NOT NULL))::NUMERIC
+                     / v_total * 100, 1)
+                 ELSE 0 END,
+
+            'structure_extraction_pct',
+            CASE WHEN v_total > 0
+                 THEN ROUND(
+                     (COUNT(*) FILTER (WHERE structure_extraction_status = 'completed'))::NUMERIC
+                     / v_total * 100, 1)
+                 ELSE 0 END,
+
+            'deep_analysis_pct',
+            CASE WHEN v_total > 0
+                 THEN ROUND(
+                     (COUNT(*) FILTER (WHERE deep_analysis_status = 'completed'))::NUMERIC
+                     / v_total * 100, 1)
+                 ELSE 0 END,
+
+            'with_summary_pct',
+            CASE WHEN v_total > 0
+                 THEN ROUND(
+                     (COUNT(*) FILTER (WHERE summary IS NOT NULL AND summary <> ''))::NUMERIC
+                     / v_total * 100, 1)
+                 ELSE 0 END,
+
+            'with_keywords_pct',
+            CASE WHEN v_total > 0
+                 THEN ROUND(
+                     (COUNT(*) FILTER (WHERE keywords IS NOT NULL AND array_length(keywords, 1) > 0))::NUMERIC
+                     / v_total * 100, 1)
+                 ELSE 0 END,
+
+            'with_legal_topics_pct',
+            CASE WHEN v_total > 0
+                 THEN ROUND(
+                     (COUNT(*) FILTER (WHERE legal_topics IS NOT NULL AND array_length(legal_topics, 1) > 0))::NUMERIC
+                     / v_total * 100, 1)
+                 ELSE 0 END,
+
+            'with_cited_legislation_pct',
+            CASE WHEN v_total > 0
+                 THEN ROUND(
+                     (COUNT(*) FILTER (WHERE cited_legislation IS NOT NULL AND array_length(cited_legislation, 1) > 0))::NUMERIC
+                     / v_total * 100, 1)
+                 ELSE 0 END,
+
+            'avg_text_length_chars',
+            COALESCE(ROUND(AVG(COALESCE(LENGTH(full_text), 0))), 0)
+        ),
+        'completeness',
+        v_now
+    FROM public.judgments;
+
+    -- -------------------------------------------------------------------------
+    -- Category: legal_insights
+    -- -------------------------------------------------------------------------
+
+    -- top_legal_domains (top 20, unnested from deep_legal_domains[])
+    INSERT INTO public.dashboard_precomputed_stats (stat_key, stat_value, category, computed_at)
+    SELECT
+        'top_legal_domains',
+        COALESCE(
+            jsonb_agg(
+                jsonb_build_object('name', domain, 'count', cnt)
+                ORDER BY cnt DESC
+            ),
+            '[]'::jsonb
+        ),
+        'legal_insights',
+        v_now
+    FROM (
+        SELECT
+            TRIM(domain) AS domain,
+            COUNT(*)      AS cnt
+        FROM public.judgments,
+             UNNEST(COALESCE(deep_legal_domains, ARRAY[]::TEXT[])) AS domain
+        WHERE TRIM(domain) <> ''
+        GROUP BY TRIM(domain)
+        ORDER BY cnt DESC
+        LIMIT 20
+    ) sub;
+
+    -- top_keywords (top 30, unnested from keywords[])
+    INSERT INTO public.dashboard_precomputed_stats (stat_key, stat_value, category, computed_at)
+    SELECT
+        'top_keywords',
+        COALESCE(
+            jsonb_agg(
+                jsonb_build_object('name', kw, 'count', cnt)
+                ORDER BY cnt DESC
+            ),
+            '[]'::jsonb
+        ),
+        'legal_insights',
+        v_now
+    FROM (
+        SELECT
+            TRIM(kw) AS kw,
+            COUNT(*) AS cnt
+        FROM public.judgments,
+             UNNEST(COALESCE(keywords, ARRAY[]::TEXT[])) AS kw
+        WHERE TRIM(kw) <> ''
+        GROUP BY TRIM(kw)
+        ORDER BY cnt DESC
+        LIMIT 30
+    ) sub;
+
+    -- top_cited_legislation (top 20, unnested from cited_legislation[])
+    INSERT INTO public.dashboard_precomputed_stats (stat_key, stat_value, category, computed_at)
+    SELECT
+        'top_cited_legislation',
+        COALESCE(
+            jsonb_agg(
+                jsonb_build_object('name', leg, 'count', cnt)
+                ORDER BY cnt DESC
+            ),
+            '[]'::jsonb
+        ),
+        'legal_insights',
+        v_now
+    FROM (
+        SELECT
+            TRIM(leg) AS leg,
+            COUNT(*)   AS cnt
+        FROM public.judgments,
+             UNNEST(COALESCE(cited_legislation, ARRAY[]::TEXT[])) AS leg
+        WHERE TRIM(leg) <> ''
+        GROUP BY TRIM(leg)
+        ORDER BY cnt DESC
+        LIMIT 20
+    ) sub;
+
+    -- -------------------------------------------------------------------------
+    -- Category: complexity
+    -- -------------------------------------------------------------------------
+
+    -- complexity_metrics
+    INSERT INTO public.dashboard_precomputed_stats (stat_key, stat_value, category, computed_at)
+    SELECT
+        'complexity_metrics',
+        jsonb_build_object(
+            'avg_complexity',
+            COALESCE(ROUND(AVG(deep_complexity_score::NUMERIC), 2), 0),
+
+            'avg_reasoning_quality',
+            COALESCE(ROUND(AVG(deep_reasoning_quality_score::NUMERIC), 2), 0),
+
+            'precedential_value_distribution',
+            jsonb_build_object(
+                'high',   COUNT(*) FILTER (WHERE deep_precedential_value = 'high'),
+                'medium', COUNT(*) FILTER (WHERE deep_precedential_value = 'medium'),
+                'low',    COUNT(*) FILTER (WHERE deep_precedential_value = 'low'),
+                'none',   COUNT(*) FILTER (WHERE deep_precedential_value = 'none')
+            ),
+
+            'research_value_distribution',
+            jsonb_build_object(
+                'high',   COUNT(*) FILTER (WHERE deep_research_value = 'high'),
+                'medium', COUNT(*) FILTER (WHERE deep_research_value = 'medium'),
+                'low',    COUNT(*) FILTER (WHERE deep_research_value = 'low')
+            )
+        ),
+        'complexity',
+        v_now
+    FROM public.judgments;
+
+    -- judicial_tone_distribution
+    INSERT INTO public.dashboard_precomputed_stats (stat_key, stat_value, category, computed_at)
+    SELECT
+        'judicial_tone_distribution',
+        COALESCE(
+            jsonb_agg(
+                jsonb_build_object('tone', tone, 'count', cnt)
+                ORDER BY cnt DESC
+            ),
+            '[]'::jsonb
+        ),
+        'complexity',
+        v_now
+    FROM (
+        SELECT
+            COALESCE(deep_judicial_tone, 'Unknown') AS tone,
+            COUNT(*)                                 AS cnt
+        FROM public.judgments
+        WHERE deep_judicial_tone IS NOT NULL
+        GROUP BY deep_judicial_tone
+    ) sub;
+
+    -- =========================================================================
+    -- doc_type_stats  (legacy table, judgment-only as of 2026-05-09)
+    -- =========================================================================
+    -- The three tax_interpretation* rows that previously lived here have been
+    -- removed; search and dashboard are judgment-only and the data was
+    -- always 0 anyway (tax_interpretations are not stored in `judgments`).
+    TRUNCATE public.doc_type_stats;
+
+    INSERT INTO public.doc_type_stats (doc_type, count, created_at)
+    VALUES
+        -- Grand total
+        ('TOTAL',                  v_total,    v_now),
+        -- All judgments regardless of jurisdiction
+        ('judgment',               v_total,    v_now),
+        -- By jurisdiction
+        ('judgment_pl',            v_total_pl, v_now),
+        ('judgment_uk',            v_total_uk, v_now);
+
+END;
+$$;
+
+-- Re-run once now so the previously seeded tax_interpretation* rows do not
+-- come back the next time anything calls refresh_dashboard_stats().
+SELECT public.refresh_dashboard_stats();

--- a/supabase/migrations/20260509000005_add_count_judgments_filtered.sql
+++ b/supabase/migrations/20260509000005_add_count_judgments_filtered.sql
@@ -1,0 +1,56 @@
+-- =============================================================================
+-- Migration: Add count_judgments_filtered() helper
+-- =============================================================================
+-- The /search hot path returns paginated chunks via search_judgments_hybrid.
+-- Until now, the response carried estimated_total = NULL because counting
+-- across the full filtered judgments table requires its own pass.
+--
+-- This function returns the total number of judgments matching the search
+-- filters (the same WHERE clauses as search_judgments_hybrid) but ignoring
+-- query/text-relevance — i.e. the size of the candidate pool. The backend
+-- calls this only on the first page (offset == 0) when the client requests
+-- include_count, so the cost is bounded.
+--
+-- The result is "estimated" in the user-facing sense: it is an exact COUNT(*)
+-- of filter matches, but does not reflect reranker / similarity-threshold
+-- pruning. That is acceptable per spec C4.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.count_judgments_filtered(
+    filter_jurisdictions text[] DEFAULT NULL,
+    filter_court_names text[] DEFAULT NULL,
+    filter_court_levels text[] DEFAULT NULL,
+    filter_case_types text[] DEFAULT NULL,
+    filter_decision_types text[] DEFAULT NULL,
+    filter_outcomes text[] DEFAULT NULL,
+    filter_keywords text[] DEFAULT NULL,
+    filter_legal_topics text[] DEFAULT NULL,
+    filter_cited_legislation text[] DEFAULT NULL,
+    filter_date_from date DEFAULT NULL,
+    filter_date_to date DEFAULT NULL
+)
+RETURNS bigint
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT COUNT(*)::bigint
+    FROM public.judgments j
+    WHERE (filter_jurisdictions IS NULL OR j.jurisdiction = ANY(filter_jurisdictions))
+        AND (filter_court_names IS NULL OR j.court_name = ANY(filter_court_names))
+        AND (filter_court_levels IS NULL OR j.court_level = ANY(filter_court_levels))
+        AND (filter_case_types IS NULL OR j.case_type = ANY(filter_case_types))
+        AND (filter_decision_types IS NULL OR j.decision_type = ANY(filter_decision_types))
+        AND (filter_outcomes IS NULL OR j.outcome = ANY(filter_outcomes))
+        AND (filter_date_from IS NULL OR j.decision_date >= filter_date_from)
+        AND (filter_date_to IS NULL OR j.decision_date <= filter_date_to)
+        AND (filter_keywords IS NULL OR j.keywords && filter_keywords)
+        AND (filter_legal_topics IS NULL OR j.legal_topics && filter_legal_topics)
+        AND (filter_cited_legislation IS NULL OR j.cited_legislation && filter_cited_legislation);
+$$;
+
+COMMENT ON FUNCTION public.count_judgments_filtered IS
+    'Returns COUNT(*) of judgments matching the same filter set as '
+    'search_judgments_hybrid. Used by the /documents/search endpoint to '
+    'populate PaginationMetadata.estimated_total on the first page.';
+
+GRANT EXECUTE ON FUNCTION public.count_judgments_filtered TO anon, authenticated, service_role;


### PR DESCRIPTION
## Summary

- **Bug fix**: removes the `document_type` parse/throw in `useSearchResults.ts` that was crashing every search with `Missing document_type in chunk for document ...`.
- **Judgment-only purge**: drops the `tax_interpretation` doc-type across backend, frontend, GraphQL, and DB seed data. The `judgments` table never had a `document_type` column, the backend hard-coded `JUDGMENT`, and the frontend coerced everything to `JUDGMENT` anyway — the field was ceremony, not function.
- **Five perf fixes (C1–C5)** on the `/search` hot path: drop the second round-trip, trim the response payload by ~5–10×, add a Redis full-response cache, populate `estimated_total`, and prune verbose hot-path logging.

Spec: [`docs/superpowers/specs/2026-05-09-search-judgment-only-blazing-fast.md`](./docs/superpowers/specs/2026-05-09-search-judgment-only-blazing-fast.md).

## What changed

### Architectural
- `useSearchResults.search()` and `loadMore()` consume `result.documents` directly when present — eliminates ~150–300 ms second round-trip per search. Falls back to `fetchDocumentsByIds` only for chunks whose parent doc isn't in the response.
- New `result_view: "card" | "full"` parameter on `SearchChunksRequest` (defaults to `"card"`). Card view returns ~10 fields per doc instead of ~30; full view preserves the legacy payload.
- New `backend/app/search_cache.py` Redis full-response cache. SHA-256 cache key over normalised request params. 300 s TTL (env-configurable). Bypassed for `mode="thinking"` (LLM analysis is non-deterministic). Layered above the existing `services.search_cache` raw-RPC cache.
- New SQL function `count_judgments_filtered(...)` powers `pagination.estimated_total` on first-page responses.

### Purge surface
- Shared `juddges_search.models.DocumentType` enum collapsed to a single `JUDGMENT` value.
- Frontend `DocumentType` enum removed entirely; consumers use the literal `"judgment"`.
- Backend: `dashboard`, `precedents`, `search_intelligence`, `graphql_api`, `schema_generator`, `validators` cleaned of `tax_interpretation` references.
- Frontend: chat sources, schema generator, visualizations, badges, styles, search filter UI doc-type segment, save-search dialog, saved-searches page all stripped.
- `get_citation_network` no longer accepts `document_types`.

### Database
Three forward migrations:
- `20260509000003_drop_tax_interpretation_dashboard_stats.sql` — deletes seeded `tax_interpretation*` rows from `doc_type_stats`.
- `20260509000004_fix_refresh_dashboard_stats_judgment_only.sql` — redefines `refresh_dashboard_stats()` so the rows don't regenerate.
- `20260509000005_add_count_judgments_filtered.sql` — new function backing `estimated_total`.

### Logging
~12 hot-path `searchLogger.info` calls in `useSearchResults` pruned to 3 phase markers (search start / results received / render ready).

### Forward-compat
Both Redis cache modules accept an optional `user_id` parameter (default `None`, key unchanged) so RLS hardening is a one-line change later.

## Stats

- **71 files changed**, +1,602 / −1,446 lines
- 11 commits (spec + 9 task commits + 1 cleanup)

## Out of scope (intentionally untouched)
- `ClusteringRequest`, `EvaluationDataset` schemas still expose `document_types` — they're persisted-data shapes, not search filter params.
- `backend/scripts/generate_lawyer_schemas.py` retains 2 `tax_interpretation` strings as legal-domain content (extraction-schema property names for tax authority filings), not doc-type filtering.
- `get_citation_network` reads `document_type` per-row from a different table — kept; not a search filter.

## Test plan

- [x] Backend: `poetry run poe check-all` → 1,732 passed, 15 skipped (pre-existing)
- [x] Frontend: `npm run validate` → lint + tsc + custom validators pass
- [x] Frontend: `npm test` → 1,373 passed across 86 suites
- [ ] **Manual perf smoke** (requires live Redis + Supabase): "Intellectual property" / "podatek VAT" / empty-query edge case — first hit <1 s, warm hit <100 ms
- [ ] **Manual UI smoke**: confirm search page renders, doc-type filter section is gone (jurisdiction/language stay), saved searches load without doc-type badge, chat citations render

## Notes for review

- **Live router** is `backend/app/documents_pkg/__init__.py`, not `backend/app/documents.py` (the latter is a near-duplicate). Most backend changes are mirrored across both — deduplication is separate tech debt.
- **GraphQL `DocumentTypeEnum`** is now single-valued (public schema change). No external consumers expected; if any exist they'll see a one-value enum until they regen their client.
- **OpenAPI client** regenerated via `scripts/regen_openapi_types.sh`.