### PR TITLE
fix(collections): persist description on PUT /collections/{id}

### DIFF
--- a/backend/app/collections.py
+++ b/backend/app/collections.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, Header, HTTPException, Path
+from juddges_search.db.collections_db import UNSET
 from juddges_search.db.supabase_db import get_collections_db
 from loguru import logger
 from pydantic import BaseModel, Field, field_validator
@@ -29,6 +30,7 @@ class CreateCollectionRequest(BaseModel):
 
 class UpdateCollectionRequest(BaseModel):
     name: str = Field(min_length=1, max_length=255)
+    description: str | None = Field(None, max_length=1000)
 
 
 class AddDocumentRequest(BaseModel):
@@ -134,7 +136,12 @@ async def update_collection(
         logger.warning(f"Invalid collection_id format: {collection_id}")
         raise HTTPException(status_code=400, detail=str(e))
 
-    collection = await db.update_collection(collection_id, user_id, request.name)
+    description_arg = (
+        request.description if "description" in request.model_fields_set else UNSET
+    )
+    collection = await db.update_collection(
+        collection_id, user_id, request.name, description_arg
+    )
     return Collection(**collection)
 
 

--- a/backend/packages/juddges_search/juddges_search/db/collections_db.py
+++ b/backend/packages/juddges_search/juddges_search/db/collections_db.py
@@ -8,6 +8,10 @@ from supabase import PostgrestAPIError, StorageException
 
 from ._base import SupabaseClientMixin
 
+# Sentinel for partial-update fields the caller chose not to touch.
+# `None` means "explicitly clear"; UNSET means "leave the field alone".
+UNSET: Any = object()
+
 # ---------------------------------------------------------------------------
 # Column projection constants
 # ---------------------------------------------------------------------------
@@ -164,11 +168,20 @@ class CollectionsDB(SupabaseClientMixin):
             self._handle_error("create_collection", e)
             return {}
 
-    async def update_collection(self, collection_id: str, user_id: str, name: str) -> Dict[str, Any]:
+    async def update_collection(
+        self,
+        collection_id: str,
+        user_id: str,
+        name: str,
+        description: Any = UNSET,
+    ) -> Dict[str, Any]:
         try:
+            update_payload: Dict[str, Any] = {"name": name}
+            if description is not UNSET:
+                update_payload["description"] = description
             response = (
                 self.client.table("collections")
-                .update({"name": name})
+                .update(update_payload)
                 .eq("id", collection_id)
                 .eq("user_id", user_id)
                 .execute()

--- a/backend/tests/app/test_collections_integration.py
+++ b/backend/tests/app/test_collections_integration.py
@@ -186,6 +186,58 @@ async def test_update_collection(authenticated_client: AsyncClient):
 @pytest.mark.api
 @pytest.mark.collections
 @pytest.mark.integration
+async def test_update_collection_omitting_description_preserves_it(
+    authenticated_client: AsyncClient,
+):
+    """PUT without `description` must NOT clobber the existing value."""
+    create_resp = await authenticated_client.post(
+        "/collections",
+        json={
+            "name": f"Preserve Test {uuid.uuid4().hex[:8]}",
+            "description": "keep me",
+        },
+    )
+    assert create_resp.status_code in [200, 201]
+    collection_id = create_resp.json()["id"]
+
+    rename_resp = await authenticated_client.put(
+        f"/collections/{collection_id}",
+        json={"name": f"Renamed {uuid.uuid4().hex[:8]}"},
+    )
+    assert rename_resp.status_code == 200
+    assert rename_resp.json()["description"] == "keep me"
+
+
+@pytest.mark.anyio
+@pytest.mark.api
+@pytest.mark.collections
+@pytest.mark.integration
+async def test_update_collection_explicit_null_clears_description(
+    authenticated_client: AsyncClient,
+):
+    """PUT with `description: null` must clear the existing value."""
+    create_resp = await authenticated_client.post(
+        "/collections",
+        json={
+            "name": f"Clear Test {uuid.uuid4().hex[:8]}",
+            "description": "will be cleared",
+        },
+    )
+    assert create_resp.status_code in [200, 201]
+    collection_id = create_resp.json()["id"]
+
+    clear_resp = await authenticated_client.put(
+        f"/collections/{collection_id}",
+        json={"name": f"Cleared {uuid.uuid4().hex[:8]}", "description": None},
+    )
+    assert clear_resp.status_code == 200
+    assert clear_resp.json()["description"] is None
+
+
+@pytest.mark.anyio
+@pytest.mark.api
+@pytest.mark.collections
+@pytest.mark.integration
 async def test_delete_collection(authenticated_client: AsyncClient):
     """Test deleting a collection."""
     # Create a collection

--- a/backend/tests/packages/juddges_search/test_collections_db.py
+++ b/backend/tests/packages/juddges_search/test_collections_db.py
@@ -279,3 +279,93 @@ class TestDeleteCollectionOwnership:
         )
         assert ("user_id", "user-a") in _filters(delete_chain)
         assert ("id", "col-1") in _filters(delete_chain)
+
+
+# ---------------------------------------------------------------------------
+# update_collection — partial-update semantics for `description`
+# ---------------------------------------------------------------------------
+
+
+def _update_payload(chain) -> dict[str, Any]:
+    """Extract the dict passed to `.update(...)` in a Supabase chain."""
+    for op, args, _ in chain:
+        if op == "update":
+            return args[0]
+    raise AssertionError(f"no update() in chain: {chain}")
+
+
+@pytest.mark.unit
+class TestUpdateCollectionDescriptionSemantics:
+    async def test_omitted_description_is_not_in_update_payload(
+        self, collections_db: CollectionsDB, fake_client: FakeSupabaseClient
+    ):
+        """When the caller omits description (UNSET sentinel), the update
+        payload must contain only `name` — preserving the existing value."""
+
+        def respond(table: str, chain) -> SimpleNamespace:
+            if table == "collections":
+                return SimpleNamespace(data=[{"id": "col-1", "name": "x"}], count=1)
+            return SimpleNamespace(data=[], count=0)
+
+        fake_client.set_responder(respond)
+
+        await collections_db.update_collection("col-1", "user-a", "renamed")
+
+        update_chain = next(
+            chain for table, chain in fake_client.operations if table == "collections"
+        )
+        payload = _update_payload(update_chain)
+        assert payload == {"name": "renamed"}, (
+            "Omitting description must NOT clobber existing value; observed "
+            f"payload: {payload}"
+        )
+
+    async def test_explicit_none_description_is_written(
+        self, collections_db: CollectionsDB, fake_client: FakeSupabaseClient
+    ):
+        """When the caller passes description=None, the update must include
+        `description: None` so the DB clears the field."""
+
+        def respond(table: str, chain) -> SimpleNamespace:
+            if table == "collections":
+                return SimpleNamespace(
+                    data=[{"id": "col-1", "name": "x", "description": None}], count=1
+                )
+            return SimpleNamespace(data=[], count=0)
+
+        fake_client.set_responder(respond)
+
+        await collections_db.update_collection(
+            "col-1", "user-a", "renamed", description=None
+        )
+
+        update_chain = next(
+            chain for table, chain in fake_client.operations if table == "collections"
+        )
+        payload = _update_payload(update_chain)
+        assert payload == {"name": "renamed", "description": None}
+
+    async def test_string_description_is_written(
+        self, collections_db: CollectionsDB, fake_client: FakeSupabaseClient
+    ):
+        """Happy path: a string description is forwarded verbatim."""
+
+        def respond(table: str, chain) -> SimpleNamespace:
+            if table == "collections":
+                return SimpleNamespace(
+                    data=[{"id": "col-1", "name": "x", "description": "new"}],
+                    count=1,
+                )
+            return SimpleNamespace(data=[], count=0)
+
+        fake_client.set_responder(respond)
+
+        await collections_db.update_collection(
+            "col-1", "user-a", "renamed", description="new"
+        )
+
+        update_chain = next(
+            chain for table, chain in fake_client.operations if table == "collections"
+        )
+        payload = _update_payload(update_chain)
+        assert payload == {"name": "renamed", "description": "new"}

--- a/frontend/__tests__/app/api/collections/[id]/route.test.ts
+++ b/frontend/__tests__/app/api/collections/[id]/route.test.ts
@@ -225,6 +225,57 @@ describe("PUT /api/collections/[id]", () => {
     );
   });
 
+  it("forwards description to backend when provided", async () => {
+    mockSupabaseAuth(USER_ID);
+
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: COLLECTION_ID,
+        name: "Renamed",
+        description: "New description",
+      }),
+    });
+
+    const response = await PUT(
+      makePutRequest(COLLECTION_ID, {
+        name: "Renamed",
+        description: "New description",
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledWith(
+      `http://localhost:8004/collections/${COLLECTION_ID}`,
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ name: "Renamed", description: "New description" }),
+      })
+    );
+  });
+
+  it("forwards explicit null description to clear the field", async () => {
+    mockSupabaseAuth(USER_ID);
+
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: COLLECTION_ID, name: "Renamed", description: null }),
+    });
+
+    await PUT(
+      makePutRequest(COLLECTION_ID, { name: "Renamed", description: null })
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: JSON.stringify({ name: "Renamed", description: null }),
+      })
+    );
+  });
+
   it("returns 404 when collection is not found", async () => {
     mockSupabaseAuth(USER_ID);
 

--- a/frontend/app/api/collections/[id]/route.ts
+++ b/frontend/app/api/collections/[id]/route.ts
@@ -107,7 +107,7 @@ export async function PUT(request: NextRequest) {
       );
     }
 
-    const { name } = body;
+    const { name, description } = body;
 
     if (!name) {
       apiLogger.error("Missing name in PUT request for collection: ", id);
@@ -117,7 +117,7 @@ export async function PUT(request: NextRequest) {
       );
     }
 
-    const backendRequestBody = JSON.stringify({ name });
+    const backendRequestBody = JSON.stringify({ name, description });
 
     // Call backend API
     const response = await fetch(`${API_BASE_URL}/collections/${id}`, {

--- a/frontend/lib/api/generated/openapi.ts
+++ b/frontend/lib/api/generated/openapi.ts
@@ -13818,6 +13818,8 @@ export interface components {
         };
         /** UpdateCollectionRequest */
         UpdateCollectionRequest: {
+            /** Description */
+            description?: string | null;
             /** Name */
             name: string;
         };

--- a/scripts/openapi-snapshot.json
+++ b/scripts/openapi-snapshot.json
@@ -15635,6 +15635,18 @@
       },
       "UpdateCollectionRequest": {
         "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "maxLength": 1000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
           "name": {
             "maxLength": 255,
             "minLength": 1,


### PR DESCRIPTION
## Summary

`PUT /api/collections/{id}` silently dropped `description` at three layers (frontend route, FastAPI handler, DB layer). Editing a description in the UI showed success but the value was never persisted; reload restored the old value.

## What changed

- Frontend `app/api/collections/[id]/route.ts` forwards `{ name, description }` to the backend.
- Backend `UpdateCollectionRequest` gains `description: str \| None`.
- DB layer `update_collection` takes a partial-update sentinel (`UNSET`) so callers can distinguish:
  - field omitted → preserve existing value
  - explicit \`null\` → clear the value
  - string → replace
- Route uses Pydantic's `model_fields_set` to pick `UNSET` vs the parsed value.

## Test plan

- [x] Frontend Jest: forwards explicit string description; forwards explicit \`null\`.
- [x] Backend unit (juddges_search/test_collections_db.py): omitted description leaves description out of the update payload; explicit \`None\` and explicit string are both written.
- [x] Backend integration (test_collections_integration.py): PUT preserves existing description when the field is omitted; PUT with \`description: null\` clears it.
- [x] End-to-end smoke against the live dev stack: create with description, rename without sending description → description preserved; PUT with new description → replaced; PUT with \`null\` → cleared.