### PR TITLE
fix(collections): immediate-commit delete (drop fake undo, prevent stranded rows)

### DIFF
--- a/frontend/app/collections/[id]/client.tsx
+++ b/frontend/app/collections/[id]/client.tsx
@@ -435,41 +435,23 @@ const CollectionClient: FC<CollectionClientProps> = ({ id }) => {
  }
 
  setIsDeleting(true);
- try {
- // Actually delete from database
- await deleteCollection(id);
-
  const collectionName = collection.name;
+ try {
+ await deleteCollection(id);
  pageLogger.info('Collection deleted successfully', {
  collectionId: id,
- collectionName
+ collectionName,
  });
-
- // Show toast with undo option
  showSuccessToast({
  title: "Collection deleted",
- description: `"${collectionName}"has been deleted`,
+ description: `"${collectionName}" has been deleted`,
  icon: null,
- secondaryAction: {
- label: "Undo",
- onClick: async () => {
- // Restore collection - reload from server
- await loadCollection();
- pageLogger.info('Collection deletion cancelled', {
- collectionId: id,
- collectionName
  });
- }
- },
- onDismiss: () => {
- // Navigate back to collections page after toast is dismissed
  router.push('/collections');
- }
- });
  } catch (error) {
  pageLogger.error('Failed to delete collection', error, {
  collectionId: id,
- context: 'handleDeleteCollection'
+ context: 'handleDeleteCollection',
  });
  toast.error("Failed to delete collection");
  setIsDeleting(false);

--- a/frontend/app/collections/page.tsx
+++ b/frontend/app/collections/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import { Input } from "@/components/ui/input";
@@ -114,10 +114,6 @@ export default function CollectionsPage() {
  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
  const [collectionToDelete, setCollectionToDelete] = useState<string | null>(null);
  const [isDeleting, setIsDeleting] = useState(false);
- // Track pending deletions (collections that will be actually deleted when toast expires)
- const [pendingDeletions, setPendingDeletions] = useState<Map<string, { collection: CollectionWithDocuments }>>(new Map());
- // Track cancelled deletions (persists across renders)
- const cancelledDeletionsRef = useRef<Set<string>>(new Set());
 
  // Search and sort state
  const [searchQuery, setSearchQuery] = useState('');
@@ -155,15 +151,14 @@ export default function CollectionsPage() {
 
  // Filter collections by search query
  const filteredCollections = useMemo(() => {
- const visibleCollections = collections.filter(c => !pendingDeletions.has(c.id));
- if (!searchQuery.trim()) return visibleCollections;
+ if (!searchQuery.trim()) return collections;
  const query = searchQuery.toLowerCase().trim();
- return visibleCollections.filter(
+ return collections.filter(
  (collection) =>
  collection.name.toLowerCase().includes(query) ||
  (collection.description?.toLowerCase().includes(query) ?? false)
  );
- }, [collections, searchQuery, pendingDeletions]);
+ }, [collections, searchQuery]);
 
  // Sort collections
  const sortedCollections = useMemo(() => {
@@ -228,111 +223,44 @@ export default function CollectionsPage() {
  return;
  }
 
- setIsDeleting(true);
- try {
- // Store collection data for undo
- const collectionToRestore = collections.find(c => c.id === collectionToDelete);
+ const id = collectionToDelete;
+ const collectionToRestore = collections.find(c => c.id === id);
 
- if (!collectionToRestore) {
- setIsDeleting(false);
  setDeleteDialogOpen(false);
  setCollectionToDelete(null);
+
+ if (!collectionToRestore) {
  return;
  }
 
- // Close dialog immediately
- setDeleteDialogOpen(false);
- const collectionIdToDelete = collectionToDelete;
- setCollectionToDelete(null);
- setIsDeleting(false);
-
- // Remove from UI immediately (add to pending deletions)
- setPendingDeletions(prev => {
- const next = new Map(prev);
- next.set(collectionIdToDelete, { collection: collectionToRestore });
- return next;
- });
-
- // Function to actually delete from database
- const performActualDeletion = async (): Promise<void> => {
- // Check if this specific deletion was cancelled
- if (cancelledDeletionsRef.current.has(collectionIdToDelete)) {
- // Remove from cancelled set
- cancelledDeletionsRef.current.delete(collectionIdToDelete);
- // Remove from pending deletions (it was restored)
- setPendingDeletions(prev => {
- const next = new Map(prev);
- next.delete(collectionIdToDelete);
- return next;
- });
- return; // Don't delete if undo was clicked
- }
+ setIsDeleting(true);
+ // Optimistic remove; rollback on error.
+ const snapshot = collections;
+ setCollections(prev => prev.filter(c => c.id !== id));
 
  try {
- // Actually delete from database
- await deleteCollection(collectionIdToDelete);
- // Remove from pending deletions AND from collections state
- setPendingDeletions(prev => {
- const next = new Map(prev);
- if (next.has(collectionIdToDelete)) {
- next.delete(collectionIdToDelete);
- }
- return next;
- });
- // Also remove from collections state to ensure consistency
- setCollections(prev => prev.filter(c => c.id !== collectionIdToDelete));
- pageLogger.info('Collection deleted successfully', {
- deletedId: collectionIdToDelete
- });
- } catch (error) {
- pageLogger.error('Failed to delete collection', error, {
- id: collectionIdToDelete,
- context: 'performActualDeletion'
- });
- // If deletion fails, restore the collection in UI
- setPendingDeletions(prev => {
- const next = new Map(prev);
- next.delete(collectionIdToDelete);
- return next;
- });
- }
- };
-
- // Show toast with undo option
- const toastDuration = 5000; // 5 seconds
- const collectionName = collectionToRestore.name;
+ await deleteCollection(id);
+ pageLogger.info('Collection deleted successfully', { deletedId: id });
  showSuccessToast({
  title: "Collection deleted",
  description: (
  <>
  The collection has been deleted.
  <br />
- <span className="font-semibold text-foreground">&quot;{collectionName}&quot;</span>
+ <span className="font-semibold text-foreground">&quot;{collectionToRestore.name}&quot;</span>
  </>
  ),
- secondaryAction: {
- label: "Undo",
- onClick: async () => {
- // Mark this specific deletion as cancelled
- cancelledDeletionsRef.current.add(collectionIdToDelete);
-
- // Restore collection in UI
- setPendingDeletions(prev => {
- const next = new Map(prev);
- next.delete(collectionIdToDelete);
- return next;
- });
- },
- },
- icon: null, // No icon for delete toast
- duration: toastDuration,
- onDismiss: performActualDeletion, // Trigger actual deletion when toast is dismissed
+ icon: null,
  });
  } catch (error) {
+ pageLogger.error('Failed to delete collection', error, {
+ id,
+ context: 'confirmDeleteCollection',
+ });
+ setCollections(snapshot);
+ toast.error('Failed to delete collection');
+ } finally {
  setIsDeleting(false);
- setDeleteDialogOpen(false);
- setCollectionToDelete(null);
- pageLogger.error('Error in confirmDeleteCollection', error);
  }
  };
 
@@ -386,7 +314,7 @@ export default function CollectionsPage() {
  );
  }
 
- const visibleCollections = collections.filter(collection => !pendingDeletions.has(collection.id));
+ const visibleCollections = collections;
 
  return (
  <PageContainer width="standard"fillViewport className="py-6">

--- a/frontend/tests/e2e/collections/complete-collection-flow.spec.ts
+++ b/frontend/tests/e2e/collections/complete-collection-flow.spec.ts
@@ -313,9 +313,52 @@ test.describe('Collections — delete', () => {
     await expect(confirmDialog).toBeVisible();
     await confirmDialog.getByRole('button', { name: /^delete$/i }).click();
 
+    // DELETE fires immediately on confirm (not on toast dismissal). The
+    // toast appears after the API call resolves.
+    await expect.poll(() => deleteRequested, { timeout: 5_000 }).toBe(true);
     await expect(page.getByText(/collection deleted/i)).toBeVisible();
+  });
 
-    // The actual DELETE call fires when the toast is dismissed (5s). Wait for it.
-    await expect.poll(() => deleteRequested, { timeout: 8_000 }).toBe(true);
+  test('list-page delete commits to the server before navigation', async ({ authenticatedPage: page }) => {
+    const collection = makeCollection({ name: 'Strand Test' });
+    let deleteRequested = false;
+    const list: MockCollection[] = [{ ...collection, documents: [], document_count: 0 }];
+
+    await page.route(`**/api/collections/${COLLECTION_ID}*`, async (route: Route) => {
+      if (route.request().method() === 'DELETE') {
+        deleteRequested = true;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ message: 'Collection deleted successfully' }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(collection),
+      });
+    });
+
+    await page.route('**/api/collections', async (route: Route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(list),
+      });
+    });
+
+    await page.goto('/collections');
+    const card = page.getByText('Strand Test');
+    await expect(card).toBeVisible();
+    await card.hover();
+    await page.getByRole('button', { name: /delete collection/i }).click();
+    const confirmDialog = page.getByRole('dialog');
+    await confirmDialog.getByRole('button', { name: /^delete$/i }).click();
+
+    // Navigate away immediately. Pre-fix this stranded the row because
+    // the actual DELETE was deferred to toast onDismiss (which never fired).
+    await expect.poll(() => deleteRequested, { timeout: 3_000 }).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

The collections delete flow had two correctness bugs:

1. **List page stranded rows.** `confirmDeleteCollection` optimistically removed the card from the UI, then deferred the actual `DELETE` to the toast's `onDismiss` callback (5s later). Navigating away or closing the tab during that window left the toast un-dismissed, so the API call never fired and the row stayed in the DB. On reload it reappeared — \"I deleted this, why is it back?\".
2. **Detail page had a fake \"Undo\".** `handleDeleteCollection` deleted immediately, then offered an \"Undo\" toast button whose handler called `loadCollection()` — which 404'd because the row was already gone.

## What changed

- Both pages now: confirm → optimistic UI update → call `DELETE` immediately → show success toast / navigate. List page rolls back local state on error.
- Removed `pendingDeletions` Map, `cancelledDeletionsRef`, and the deferred `performActualDeletion` closure on the list page.
- Removed the \"Undo\" toast action from the detail page.
- E2E: existing delete test no longer polls 8s for `onDismiss`. Added new test asserting the DELETE request fires within 3s of confirm (regression for stranded rows).

## Test plan

- [x] Frontend lint + typecheck.
- [x] Existing collections route Jest tests pass (42 / 42).
- [ ] E2E (`tests/e2e/collections/complete-collection-flow.spec.ts`) — gated on PR 4 / E2E stabilization to run cleanly. The spec file changes ARE included here so the contract is locked.