### PR TITLE
fix(ci): pass BACKEND_API_KEY to performance test workflow

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -60,6 +60,7 @@ jobs:
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          BACKEND_API_KEY: ${{ secrets.BACKEND_API_KEY }}
         run: |
           poetry run pytest tests/performance/ --performance -v -s --tb=short
 


### PR DESCRIPTION
## Summary

The `Backend Performance Tests` job in `.github/workflows/performance.yml` fails on every PR at test collection because `app/auth.py` raises `ValueError: BACKEND_API_KEY environment variable not set` during import.

The job's `env:` block passes `SUPABASE_*` and `OPENAI_API_KEY` but is missing `BACKEND_API_KEY`. Other workflows (e.g. `search-integration.yml`) already pass this secret correctly.

This one-line change adds `BACKEND_API_KEY: ${{ secrets.BACKEND_API_KEY }}` to the `env:` block of the `backend-performance` job. The `frontend-performance` job only runs Node bundle analysis and does not need the variable.

PR #190 currently fails its `Backend Performance Tests` check for this reason; rebasing it on main once this lands will green that check.

## Test plan

- [ ] CI runs on this PR and `Backend Performance Tests` proceeds past collection (either passes or fails on a real test, not on `app.auth` import).
- [ ] After merge, rebase #190 and confirm the same check passes there.