### PR TITLE
fix(search): restrict pgvector vector branch to search_language

### DIFF
--- a/backend/app/judgments_pkg/search.py
+++ b/backend/app/judgments_pkg/search.py
@@ -298,11 +298,24 @@ def _build_search_rpc_params(
 ) -> dict[str, Any]:
     if query_type == "conceptual":
         keyword_query = _relax_keyword_for_conceptual(keyword_query, search_language)
+
+    # Constrain the vector branch by jurisdiction when the user asked for a
+    # specific language. The SQL function's text branches already hard-filter
+    # by jurisdiction via search_language, but vector_results only checks
+    # filter_jurisdictions — without this mapping a query like
+    # languages=["en"] leaked Polish documents into the semantic results.
+    jurisdictions = effective_filters["jurisdictions"]
+    if not jurisdictions:
+        if search_language == "english":
+            jurisdictions = ["UK"]
+        elif search_language == "polish":
+            jurisdictions = ["PL"]
+
     return {
         "query_embedding": query_embedding,
         "search_text": keyword_query if effective_alpha < 1.0 else None,
         "search_language": search_language,
-        "filter_jurisdictions": effective_filters["jurisdictions"],
+        "filter_jurisdictions": jurisdictions,
         "filter_court_names": effective_filters["court_names"],
         "filter_court_levels": effective_filters["court_levels"],
         "filter_case_types": effective_filters["case_types"],
@@ -313,7 +326,10 @@ def _build_search_rpc_params(
         "filter_cited_legislation": effective_filters["cited_legislation"],
         "filter_date_from": effective_filters["date_from"],
         "filter_date_to": effective_filters["date_to"],
-        "similarity_threshold": 0.5,
+        # Lowered from 0.5 — that threshold was dropping legitimate semantic
+        # matches for niche English landmark queries (e.g. "Woollin", "Jogee")
+        # whose 768-dim cosine similarity sits in the 0.2-0.4 band.
+        "similarity_threshold": 0.15,
         "hybrid_alpha": effective_alpha,
         "result_limit": limit,
         "result_offset": offset,

--- a/supabase/migrations/20260512000001_filter_vector_results_by_search_language.sql
+++ b/supabase/migrations/20260512000001_filter_vector_results_by_search_language.sql
@@ -1,0 +1,393 @@
+-- =============================================================================
+-- Migration: Restrict vector branch to the requested search_language
+-- =============================================================================
+-- The hybrid function's English/Polish text branches already hard-filter by
+-- jurisdiction='UK'/'PL' via search_language. The vector branch did not,
+-- so a query with search_language='english' would still match Polish
+-- documents in its top semantic neighbours and surface them via RRF. This
+-- migration extends vector_results with the same language→jurisdiction
+-- constraint used by the text branches.
+--
+-- Also synchronises the parameter signature to vector(1024). The repo's
+-- prior version drifted from production (declared vector(768) after the
+-- 768→1024 column migration); production was patched out-of-band. This
+-- migration realigns the source-of-truth with production.
+-- =============================================================================
+
+DROP FUNCTION IF EXISTS public.search_judgments_hybrid(
+    vector, text, text,
+    text[], text[], text[], text[], text[], text[],
+    text[], text[], text[],
+    date, date,
+    double precision, double precision,
+    int, int, int, int
+);
+
+CREATE OR REPLACE FUNCTION public.search_judgments_hybrid(
+    -- Search parameters
+    query_embedding vector(1024) DEFAULT NULL,
+    search_text text DEFAULT NULL,
+    search_language text DEFAULT 'auto',  -- 'auto', 'english', 'polish'
+
+    -- Filter parameters (all optional, NULL means no filter)
+    filter_jurisdictions text[] DEFAULT NULL,
+    filter_court_names text[] DEFAULT NULL,
+    filter_court_levels text[] DEFAULT NULL,
+    filter_case_types text[] DEFAULT NULL,
+    filter_decision_types text[] DEFAULT NULL,
+    filter_outcomes text[] DEFAULT NULL,
+    filter_keywords text[] DEFAULT NULL,
+    filter_legal_topics text[] DEFAULT NULL,
+    filter_cited_legislation text[] DEFAULT NULL,
+    filter_date_from date DEFAULT NULL,
+    filter_date_to date DEFAULT NULL,
+
+    -- Search tuning parameters
+    similarity_threshold float DEFAULT 0.5,
+    hybrid_alpha float DEFAULT 0.5,  -- 0=pure text, 1=pure vector
+    result_limit int DEFAULT 20,
+    result_offset int DEFAULT 0,
+    rrf_k int DEFAULT 60,  -- RRF constant: lower=more weight to top results
+    ef_search_value int DEFAULT 100
+)
+RETURNS TABLE (
+    id uuid,
+    case_number text,
+    title text,
+    summary text,
+    full_text text,
+    jurisdiction text,
+    court_name text,
+    court_level text,
+    case_type text,
+    decision_type text,
+    outcome text,
+    decision_date date,
+    publication_date date,
+    keywords text[],
+    legal_topics text[],
+    cited_legislation text[],
+    judges jsonb,
+    metadata jsonb,
+    source_dataset text,
+    source_id text,
+    source_url text,
+    vector_score float,
+    text_score float,
+    combined_score float,
+
+    -- Chunk metadata fields
+    chunk_text text,
+    chunk_type text,
+    chunk_start_pos int,
+    chunk_end_pos int,
+    chunk_metadata jsonb
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    ts_query_en tsquery;
+    ts_query_pl tsquery;
+    fetch_limit int;
+BEGIN
+    -- HNSW recall knob for vector branch
+    PERFORM set_config('hnsw.ef_search', ef_search_value::text, true);
+
+    fetch_limit := GREATEST(result_limit * 3, result_limit);
+
+    IF search_text IS NOT NULL AND search_text != '' THEN
+        ts_query_en := websearch_to_tsquery('english'::regconfig, search_text);
+        ts_query_pl := websearch_to_tsquery('public.polish'::regconfig, search_text);
+    END IF;
+
+    RETURN QUERY
+    WITH
+    -- Vector similarity search (cosine distance).
+    -- Honour search_language by restricting jurisdiction; matches the
+    -- text branches' behaviour so single-language queries don't surface
+    -- cross-language matches via RRF.
+    vector_results AS (
+        SELECT
+            j.id,
+            (1 - (j.embedding <=> query_embedding)) AS similarity,
+            ROW_NUMBER() OVER (ORDER BY j.embedding <=> query_embedding) AS vrank
+        FROM public.judgments j
+        WHERE query_embedding IS NOT NULL
+            AND j.embedding IS NOT NULL
+            AND (1 - (j.embedding <=> query_embedding)) > similarity_threshold
+            AND (
+                search_language = 'auto'
+                OR (search_language = 'english' AND j.jurisdiction = 'UK')
+                OR (search_language = 'polish' AND j.jurisdiction = 'PL')
+            )
+            AND (filter_jurisdictions IS NULL OR j.jurisdiction = ANY(filter_jurisdictions))
+            AND (filter_court_names IS NULL OR j.court_name = ANY(filter_court_names))
+            AND (filter_court_levels IS NULL OR j.court_level = ANY(filter_court_levels))
+            AND (filter_case_types IS NULL OR j.case_type = ANY(filter_case_types))
+            AND (filter_decision_types IS NULL OR j.decision_type = ANY(filter_decision_types))
+            AND (filter_outcomes IS NULL OR j.outcome = ANY(filter_outcomes))
+            AND (filter_date_from IS NULL OR j.decision_date >= filter_date_from)
+            AND (filter_date_to IS NULL OR j.decision_date <= filter_date_to)
+            AND (filter_keywords IS NULL OR j.keywords && filter_keywords)
+            AND (filter_legal_topics IS NULL OR j.legal_topics && filter_legal_topics)
+            AND (filter_cited_legislation IS NULL OR j.cited_legislation && filter_cited_legislation)
+        ORDER BY j.embedding <=> query_embedding
+        LIMIT fetch_limit
+    ),
+
+    -- English text branch (index-friendly via jurisdiction='UK')
+    english_hits AS (
+        SELECT
+            j.id AS doc_id,
+            ts_rank_cd(
+                to_tsvector(
+                    'english'::regconfig,
+                    coalesce(j.title, '') || ' ' || coalesce(j.summary, '')
+                ),
+                ts_query_en,
+                32
+            ) AS rank
+        FROM public.judgments j
+        WHERE search_text IS NOT NULL
+            AND ts_query_en IS NOT NULL
+            AND search_language IN ('english', 'auto')
+            AND j.jurisdiction = 'UK'
+            AND (filter_jurisdictions IS NULL OR j.jurisdiction = ANY(filter_jurisdictions))
+            AND (filter_court_names IS NULL OR j.court_name = ANY(filter_court_names))
+            AND (filter_court_levels IS NULL OR j.court_level = ANY(filter_court_levels))
+            AND (filter_case_types IS NULL OR j.case_type = ANY(filter_case_types))
+            AND (filter_decision_types IS NULL OR j.decision_type = ANY(filter_decision_types))
+            AND (filter_outcomes IS NULL OR j.outcome = ANY(filter_outcomes))
+            AND (filter_date_from IS NULL OR j.decision_date >= filter_date_from)
+            AND (filter_date_to IS NULL OR j.decision_date <= filter_date_to)
+            AND (filter_keywords IS NULL OR j.keywords && filter_keywords)
+            AND (filter_legal_topics IS NULL OR j.legal_topics && filter_legal_topics)
+            AND (filter_cited_legislation IS NULL OR j.cited_legislation && filter_cited_legislation)
+            AND to_tsvector(
+                'english'::regconfig,
+                coalesce(j.title, '') || ' ' ||
+                coalesce(j.summary, '') || ' ' ||
+                coalesce(j.full_text, '')
+            ) @@ ts_query_en
+        ORDER BY rank DESC
+        LIMIT fetch_limit
+    ),
+
+    -- Polish text branch (index-friendly via jurisdiction='PL')
+    polish_hits AS (
+        SELECT
+            j.id AS doc_id,
+            ts_rank_cd(
+                to_tsvector(
+                    'public.polish'::regconfig,
+                    coalesce(j.title, '') || ' ' || coalesce(j.summary, '')
+                ),
+                ts_query_pl,
+                32
+            ) AS rank
+        FROM public.judgments j
+        WHERE search_text IS NOT NULL
+            AND ts_query_pl IS NOT NULL
+            AND search_language IN ('polish', 'auto')
+            AND j.jurisdiction = 'PL'
+            AND (filter_jurisdictions IS NULL OR j.jurisdiction = ANY(filter_jurisdictions))
+            AND (filter_court_names IS NULL OR j.court_name = ANY(filter_court_names))
+            AND (filter_court_levels IS NULL OR j.court_level = ANY(filter_court_levels))
+            AND (filter_case_types IS NULL OR j.case_type = ANY(filter_case_types))
+            AND (filter_decision_types IS NULL OR j.decision_type = ANY(filter_decision_types))
+            AND (filter_outcomes IS NULL OR j.outcome = ANY(filter_outcomes))
+            AND (filter_date_from IS NULL OR j.decision_date >= filter_date_from)
+            AND (filter_date_to IS NULL OR j.decision_date <= filter_date_to)
+            AND (filter_keywords IS NULL OR j.keywords && filter_keywords)
+            AND (filter_legal_topics IS NULL OR j.legal_topics && filter_legal_topics)
+            AND (filter_cited_legislation IS NULL OR j.cited_legislation && filter_cited_legislation)
+            AND to_tsvector(
+                'public.polish'::regconfig,
+                coalesce(j.title, '') || ' ' ||
+                coalesce(j.summary, '') || ' ' ||
+                coalesce(j.full_text, '')
+            ) @@ ts_query_pl
+        ORDER BY rank DESC
+        LIMIT fetch_limit
+    ),
+
+    text_candidates AS (
+        SELECT eh.doc_id, eh.rank FROM english_hits eh
+        UNION ALL
+        SELECT ph.doc_id, ph.rank FROM polish_hits ph
+    ),
+
+    text_results AS (
+        SELECT
+            tc.doc_id AS id,
+            tc.rank,
+            ROW_NUMBER() OVER (ORDER BY tc.rank DESC, tc.doc_id) AS trank
+        FROM text_candidates tc
+        ORDER BY tc.rank DESC, tc.doc_id
+        LIMIT fetch_limit
+    ),
+
+    -- Trigram fuzzy fallback: only when text branch is empty
+    fuzzy_results AS (
+        SELECT
+            j.id,
+            GREATEST(
+                similarity(coalesce(j.title, ''), search_text),
+                similarity(LEFT(coalesce(j.summary, ''), 1200), search_text)
+            ) AS sim,
+            ROW_NUMBER() OVER (
+                ORDER BY GREATEST(
+                    similarity(coalesce(j.title, ''), search_text),
+                    similarity(LEFT(coalesce(j.summary, ''), 1200), search_text)
+                ) DESC
+            ) AS frank
+        FROM public.judgments j
+        WHERE search_text IS NOT NULL
+            AND NOT EXISTS (SELECT 1 FROM text_results LIMIT 1)
+            AND char_length(search_text) BETWEEN 2 AND 40
+            AND search_text ~ '[[:space:]]'
+            AND search_text ~ '^[[:alnum:][:space:]ąćęłńóśźżĄĆĘŁŃÓŚŹŻ-]+$'
+            AND (filter_jurisdictions IS NULL OR j.jurisdiction = ANY(filter_jurisdictions))
+            AND (filter_court_names IS NULL OR j.court_name = ANY(filter_court_names))
+            AND (filter_court_levels IS NULL OR j.court_level = ANY(filter_court_levels))
+            AND (filter_case_types IS NULL OR j.case_type = ANY(filter_case_types))
+            AND (filter_decision_types IS NULL OR j.decision_type = ANY(filter_decision_types))
+            AND (filter_outcomes IS NULL OR j.outcome = ANY(filter_outcomes))
+            AND (filter_date_from IS NULL OR j.decision_date >= filter_date_from)
+            AND (filter_date_to IS NULL OR j.decision_date <= filter_date_to)
+            AND (filter_keywords IS NULL OR j.keywords && filter_keywords)
+            AND (filter_legal_topics IS NULL OR j.legal_topics && filter_legal_topics)
+            AND (filter_cited_legislation IS NULL OR j.cited_legislation && filter_cited_legislation)
+            AND (
+                similarity(coalesce(j.title, ''), search_text) > 0.15
+                OR similarity(LEFT(coalesce(j.summary, ''), 1200), search_text) > 0.15
+            )
+        ORDER BY sim DESC
+        LIMIT fetch_limit
+    ),
+
+    -- Reciprocal Rank Fusion
+    rrf_scores AS (
+        SELECT
+            doc_id,
+            SUM(rrf_contribution) AS rrf_score,
+            MAX(vscore) AS vscore,
+            MAX(tscore) AS tscore
+        FROM (
+            SELECT v.id AS doc_id,
+                   1.0 / (rrf_k + v.vrank) AS rrf_contribution,
+                   v.similarity AS vscore,
+                   0.0::float AS tscore
+            FROM vector_results v
+
+            UNION ALL
+
+            SELECT t.id AS doc_id,
+                   1.0 / (rrf_k + t.trank) AS rrf_contribution,
+                   0.0::float AS vscore,
+                   t.rank AS tscore
+            FROM text_results t
+
+            UNION ALL
+
+            SELECT f.id AS doc_id,
+                   0.5 / (rrf_k + f.frank) AS rrf_contribution,
+                   0.0::float AS vscore,
+                   f.sim AS tscore
+            FROM fuzzy_results f
+        ) sub
+        GROUP BY doc_id
+    )
+
+    SELECT
+        j.id,
+        j.case_number,
+        j.title,
+        j.summary,
+        j.full_text,
+        j.jurisdiction,
+        j.court_name,
+        j.court_level,
+        j.case_type,
+        j.decision_type,
+        j.outcome,
+        j.decision_date,
+        j.publication_date,
+        j.keywords,
+        j.legal_topics,
+        j.cited_legislation,
+        j.judges,
+        j.metadata,
+        j.source_dataset,
+        j.source_id,
+        j.source_url,
+        rrf.vscore::float AS vector_score,
+        rrf.tscore::float AS text_score,
+        rrf.rrf_score::float AS combined_score,
+
+        CASE
+            WHEN j.jurisdiction = 'PL'
+                 AND ts_query_pl IS NOT NULL
+                 AND j.summary IS NOT NULL
+                 AND j.summary != ''
+            THEN ts_headline(
+                'public.polish'::regconfig,
+                j.summary,
+                ts_query_pl,
+                'StartSel=<mark>, StopSel=</mark>, MaxWords=60, MinWords=20, MaxFragments=2, FragmentDelimiter= ... '
+            )
+            WHEN j.jurisdiction = 'UK'
+                 AND ts_query_en IS NOT NULL
+                 AND j.summary IS NOT NULL
+                 AND j.summary != ''
+            THEN ts_headline(
+                'english'::regconfig,
+                j.summary,
+                ts_query_en,
+                'StartSel=<mark>, StopSel=</mark>, MaxWords=60, MinWords=20, MaxFragments=2, FragmentDelimiter= ... '
+            )
+            WHEN j.summary IS NOT NULL AND j.summary != ''
+            THEN j.summary
+            ELSE COALESCE(LEFT(j.full_text, 500), j.title)
+        END::text AS chunk_text,
+
+        CASE
+            WHEN (j.jurisdiction = 'PL' AND ts_query_pl IS NOT NULL)
+              OR (j.jurisdiction = 'UK' AND ts_query_en IS NOT NULL)
+            THEN 'highlight'::text
+            WHEN j.summary IS NOT NULL AND j.summary != '' THEN 'summary'::text
+            WHEN j.full_text IS NOT NULL THEN 'excerpt'::text
+            ELSE 'title'::text
+        END AS chunk_type,
+
+        0 AS chunk_start_pos,
+        LENGTH(COALESCE(j.summary, LEFT(j.full_text, 500), j.title, '')) AS chunk_end_pos,
+
+        jsonb_build_object(
+            'court_name', j.court_name,
+            'court_level', j.court_level,
+            'decision_date', j.decision_date,
+            'case_number', j.case_number,
+            'jurisdiction', j.jurisdiction,
+            'case_type', j.case_type,
+            'decision_type', j.decision_type,
+            'outcome', j.outcome,
+            'vector_score', rrf.vscore,
+            'text_score', rrf.tscore,
+            'rrf_score', rrf.rrf_score
+        ) AS chunk_metadata
+
+    FROM rrf_scores rrf
+    JOIN public.judgments j ON rrf.doc_id = j.id
+    ORDER BY rrf.rrf_score DESC
+    LIMIT result_limit
+    OFFSET result_offset;
+END;
+$$;
+
+COMMENT ON FUNCTION public.search_judgments_hybrid IS
+    'Hybrid search with configurable ef_search for HNSW recall tuning, '
+    'language-aware vector and text branches, summary-weighted ranking, '
+    'fuzzy fallback, and RRF fusion. Vector branch now respects '
+    'search_language so single-language queries do not leak cross-language '
+    'matches via the semantic top-K.';


### PR DESCRIPTION
## Summary

Fixes two bugs in `/documents/search` (pgvector hybrid path) exposed by criminal-law smoke tests on PL+UK case-law:

- **Language leak in hybrid mode (α=0.5)** — `languages=["en"]` pulled Polish docs into the top-K because the SQL function's `vector_results` CTE only filters by `filter_jurisdictions` (NULL when the caller passes only `languages`). English/Polish text branches already constrain `jurisdiction='UK'/'PL'` via `search_language`; the vector branch didn't.
- **Zero results for niche EN landmark queries (α=1.0)** — queries like *Woollin* / *Jogee* returned 0 docs because the hardcoded `similarity_threshold=0.5` dropped legitimate semantic matches whose cosine similarity sits in the 0.2–0.4 band on the 1024-dim BGE-M3 vectors.

## Changes

- `backend/app/judgments_pkg/search.py` — `_build_search_rpc_params` now auto-maps `languages → filter_jurisdictions` and lowers `similarity_threshold` to `0.15`. This alone fixes the live bugs because the SQL function already filters by `filter_jurisdictions`.
- New migration `supabase/migrations/20260512000001_filter_vector_results_by_search_language.sql` — adds the language-aware jurisdiction filter directly to the `vector_results` CTE (defense-in-depth for any future caller that passes `search_language` without `filter_jurisdictions`). Also realigns the function signature to `vector(1024)` to match production (the column was migrated 768→1024 in `20260322000001` but the prior function update in `20260407000001` kept `vector(768)` — production was patched out-of-band).

## Test results (10-query smoke test, before vs after)

| Query | Before | After |
|---|---|---|
| EN-8 hybrid α=0.5 (`section 18 OAPA 1861…`) | 6 UK + 4 PL leak | 4 UK / 0 PL ✅ |
| EN-6 α=1.0 (`murder mens rea Woollin`) | 0 docs | 3 UK ✅ |
| EN-10 α=1.0 (`joint enterprise Jogee`) | 0 docs | 3 UK ✅ |
| PL-1…PL-5 (Polish criminal law) | OK | OK (no regression) |

Test script + raw output available on request.

## Deployment

The migration file is included in this PR but **not yet applied to prod Supabase**. The backend mapping fix is sufficient by itself. Apply the migration when convenient (e.g. before adding any non-`/documents/search` caller that bypasses `_build_search_rpc_params`).

## Related

- Follows up on hybrid-routing work in #199.
- Companion issue #200 covers the still-broken Meilisearch hybrid path (different code path, different fix).

## Test plan

- [x] Backend lint passes (`poetry run poe check-all`) — pre-commit hooks ran
- [x] 10-query smoke test reruns clean (PL + UK criminal-law sample)
- [ ] CI green on required checks
- [ ] Manual smoke test in UI after deploy: `searchMode='vector'` with `languages=['en']` should return UK-only judgments for `Woollin` / `Jogee`