### PR TITLE
fix(search): default /search to text mode and hide broken hybrid

### DIFF
--- a/frontend/components/search/SearchModeToggle.tsx
+++ b/frontend/components/search/SearchModeToggle.tsx
@@ -12,10 +12,11 @@ export interface SearchModeToggleProps {
   className?: string;
 }
 
+// Hybrid is hidden while the Meilisearch bge-m3 embedder is unregistered
+// (issue #200). Restore the option once hybrid stops returning 502s.
 const OPTIONS: Array<{ value: SearchMode; label: string; hint: string }> = [
   { value: "text", label: "Text", hint: "Lexical full-text via Meilisearch" },
   { value: "vector", label: "Vector", hint: "Semantic similarity via pgvector" },
-  { value: "hybrid", label: "Hybrid", hint: "Balanced lexical + semantic" },
 ];
 
 export function SearchModeToggle({

--- a/frontend/hooks/useSearchUrlParams.ts
+++ b/frontend/hooks/useSearchUrlParams.ts
@@ -266,9 +266,13 @@ export function useSearchUrlParams({
       setSearchType(modeParam);
     }
 
-    // Backend search mode (text/vector/hybrid)
-    if (searchModeParam && (searchModeParam === 'text' || searchModeParam === 'vector' || searchModeParam === 'hybrid')) {
+    // Backend search mode (text/vector). Bookmarks carrying `searchMode=hybrid`
+    // are coerced to text — Meili hybrid is broken until issue #200 ships the
+    // bge-m3 embedder registration.
+    if (searchModeParam === 'text' || searchModeParam === 'vector') {
       setSearchMode(searchModeParam);
+    } else if (searchModeParam === 'hybrid') {
+      setSearchMode('text');
     }
 
     // Extracted-field numeric ranges

--- a/frontend/lib/store/searchStore.ts
+++ b/frontend/lib/store/searchStore.ts
@@ -57,7 +57,9 @@ interface SearchState {
   query: string;
   selectedLanguages: Set<string>;
   searchType: "rabbit" | "thinking";
-  /** Backend selector: "text" → Meilisearch, "vector"/"hybrid" → pgvector. */
+  /** Backend selector: "text"/"hybrid" → Meilisearch, "vector" → pgvector.
+   *  Hybrid is currently hidden from the UI (issue #200) — bge-m3 embedder
+   *  not registered in the Meili index, so semantic_ratio>0 returns 502. */
   searchMode: SearchMode;
   /** Numeric prefilters on base_* extracted columns (text mode only). */
   baseFilters: BaseFilters;
@@ -527,8 +529,17 @@ export const useSearchStore = create<SearchState>()((set, get) => ({
         // Convert array back to Set for selectedDocumentIds
         const selectedDocumentIds = arrayToSet(parsedState.selectedDocumentIds);
 
+        // Coerce away the broken hybrid mode. Meilisearch hybrid is currently
+        // a no-op because the bge-m3 embedder isn't registered in the index
+        // (see issue #200), so any returning user with searchMode='hybrid' in
+        // localStorage would land on a 502-loop. Fall back to text until the
+        // embedder is wired up; remove once #200 ships.
+        const restoredSearchMode: SearchMode =
+          parsedState.searchMode === 'hybrid' ? 'text' : parsedState.searchMode;
+
         set({
           ...parsedState,
+          searchMode: restoredSearchMode,
           filters: mergedFilters,
           selectedLanguages,
           selectedDocumentIds,


### PR DESCRIPTION
## Summary

Ensures the `/search` page lands on the working **Text** mode for every user — current, returning, and bookmark-driven — while #200 (Meilisearch bge-m3 embedder unregistered) is open. Also drops the **Hybrid** option from the mode toggle so users cannot newly select it and trigger 502s.

## Why

Hybrid mode pipes through Meilisearch with `semantic_ratio=0.5` and `embedder=bge-m3`, but the embedder is not registered in the index → 400 from Meili → 502 from the backend. Tracked in #200.

The Zustand store default for `searchMode` is already `"text"`, but two paths kept stranding users on hybrid:

- `searchStore.loadState` spreads the entire saved state from localStorage on mount, including any prior `searchMode: 'hybrid'`.
- `useSearchUrlParams` honored `?searchMode=hybrid` from bookmarks/links.

## Changes

| File | Change |
|---|---|
| `frontend/lib/store/searchStore.ts` | In `loadState`, coerce restored `searchMode === 'hybrid'` to `'text'` before applying the saved state. Comment on the type now correctly notes hybrid routes through Meili, not pgvector. |
| `frontend/hooks/useSearchUrlParams.ts` | URL param `searchMode=hybrid` is rewritten to `'text'`; `text` / `vector` still pass through unchanged. |
| `frontend/components/search/SearchModeToggle.tsx` | Drop the **Hybrid** entry from `OPTIONS`. Comment points to #200. |

The hybrid code path in `useSearchResults.ts` is left intact. Once #200 ships the embedder registration:
1. Add the Hybrid option back to `SearchModeToggle.OPTIONS`.
2. Remove the two coercions above.

## Test plan

- [x] `npm run validate` (ESLint + document-types) passes.
- [x] `tsc --noEmit` clean on the three changed files (pre-existing errors in `__tests__/lib/schema-editor/*` unrelated).
- [ ] Manual smoke after deploy: fresh load → toggle shows `Text | Vector` only; returning user with `searchState.searchMode='hybrid'` in localStorage → first render is Text; visiting `/search?searchMode=hybrid` → URL keeps the param but the store reads Text.

## Related

- #200 — root cause (Meili bge-m3 embedder not registered)
- #201 — pgvector vector branch language filter + threshold fix (unblocks Vector mode as the semantic alternative)