### PR TITLE
chore(deps): pin ws to ^8.20.1 to close uninit-memory CVE

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "juddges-frontend",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "juddges-frontend",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",
@@ -16644,28 +16644,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/lighthouse/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
@@ -22544,9 +22522,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -179,7 +179,8 @@
       "react-dom": "^19.0.0"
     },
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "ws": "^8.20.1"
   },
   "optionalDependencies": {
     "lightningcss-linux-arm64-musl": "^1.30.1",


### PR DESCRIPTION
## Summary

- Adds a top-level npm `overrides` entry forcing `ws@^8.20.1` (resolves to `8.21.0`) so all four transitive paths (`@supabase/realtime-js`, `jsdom`, `puppeteer-core`, `lighthouse`) pick up the patched version.
- Closes Dependabot alert **#43** — *ws: Uninitialized memory disclosure* (medium, GHSA-pp).
- Lockfile refresh also syncs the top-level `version` field (1.2.1 → 1.3.0).

## Context — most other open alerts are stale

After investigating, the bulk of the 44 open Dependabot alerts are already addressed in `main` but Dependabot hasn't rescanned:

| Cluster | Status |
|---|---|
| `next` (26 alerts) | already at `15.5.18` in lockfile |
| `uuid` (2 alerts) | already at `13.0.1` in lockfile |
| `postcss` top-level (1 alert) | already at `8.5.12` |
| `protobufjs` / `@grpc/grpc-js` / `fast-uri` (12 alerts) | packages no longer in the dep tree |
| `ws` (this PR) | **fixed here** |
| `@ai-sdk/provider-utils` (low) | no upstream patch available yet |

The plan after merge is to dismiss the stale alerts and let Dependabot rescan; only `@ai-sdk/provider-utils` will legitimately remain open.

## Test plan
- [x] `npm run validate` (document-types + ESLint) passes
- [x] `npm run typecheck` passes
- [x] `npm ls ws` shows `8.21.0` everywhere, no remaining `8.20.0`
- [ ] CI: Backend Lint, Backend Unit Tests, Frontend Lint & Typecheck, Frontend Unit Tests