### PR TITLE
chore(deps): bump dompurify and markdown-it to close XSS/parser advisories

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -57,7 +57,7 @@
         "cmdk": "^1.0.0",
         "date-fns": "^4.1.0",
         "docx": "^9.5.1",
-        "dompurify": "^3.2.2",
+        "dompurify": "^3.4.8",
         "exceljs": "^4.4.0",
         "framer-motion": "^12.9.4",
         "highlight.js": "^11.10.0",
@@ -11947,9 +11947,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
-      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -16911,9 +16911,19 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -17152,14 +17162,24 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,7 +79,7 @@
     "cmdk": "^1.0.0",
     "date-fns": "^4.1.0",
     "docx": "^9.5.1",
-    "dompurify": "^3.2.2",
+    "dompurify": "^3.4.8",
     "exceljs": "^4.4.0",
     "framer-motion": "^12.9.4",
     "highlight.js": "^11.10.0",
@@ -180,7 +180,8 @@
     },
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "ws": "^8.20.1"
+    "ws": "^8.20.1",
+    "markdown-it": "^14.2.0"
   },
   "optionalDependencies": {
     "lightningcss-linux-arm64-musl": "^1.30.1",


### PR DESCRIPTION
## Summary

- `dompurify`: constraint bumped `^3.2.2 → ^3.4.8` (resolves to `3.4.11`). Closes Dependabot alert **#47** — dompurify XSS via mutation (low).
- `markdown-it`: new npm `overrides` entry pinning `^14.2.0` (transitive via `prosemirror-markdown` → `@tiptap/pm`). Closes Dependabot alert **#48** — markdown-it (medium).

## Test plan
- [x] `npm run validate` (document-types + ESLint) passes
- [x] `npm run typecheck` passes
- [x] `npm ls dompurify` shows `3.4.11` everywhere
- [x] `npm ls markdown-it` shows `14.2.0` (overridden)
- [ ] CI: 4 required checks