### PR TITLE
feat(seo): public-page SEO for Next.js frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,10 @@ DATABASE_URL=postgresql://user:password@localhost:5432/juddges_db
 NEXT_PUBLIC_APP_NAME="Juddges App"
 NEXT_PUBLIC_APP_URL=http://localhost:3007
 NEXT_PUBLIC_API_URL=${BACKEND_URL}
+# Canonical public origin for SEO: metadataBase, robots.txt, sitemap.xml, OG
+# images, changelog RSS. No trailing slash. Falls back to
+# https://juddges.augustyniak.ai when unset. See docs/reference/seo-metadata.md
+NEXT_PUBLIC_SITE_URL=https://juddges.augustyniak.ai
 AUTH_REDIRECT_ALLOWED_HOSTS=localhost:3007
 
 # Feature flags

--- a/docs/reference/environment-configuration.md
+++ b/docs/reference/environment-configuration.md
@@ -203,3 +203,4 @@ grep -q "^\.env$" .gitignore || echo ".env" >> .gitignore
 - `docker-compose.yml` - Production service configuration
 - `docker-compose.dev.yml` - Development service configuration
 - `CLAUDE.md` - Project overview and development commands
+- [`seo-metadata.md`](./seo-metadata.md) - SEO/metadata; set `NEXT_PUBLIC_SITE_URL` in production for canonical/OG/sitemap URLs

--- a/docs/reference/seo-metadata.md
+++ b/docs/reference/seo-metadata.md
@@ -1,0 +1,66 @@
+# SEO & Metadata Reference
+
+How search-engine and social-sharing metadata is produced for the Next.js
+frontend (`frontend/`). The app is **auth-gated**: only the unauthenticated
+allow-list in `lib/supabase/middleware.ts` is crawlable, so SEO is intentionally
+scoped to those public surfaces.
+
+## Canonical site URL
+
+Single source of truth: `frontend/lib/site.ts` → `SITE_URL` / `siteMetadataBase`.
+
+Resolution precedence:
+
+1. `NEXT_PUBLIC_SITE_URL`
+2. `VERCEL_PROJECT_PRODUCTION_URL`
+3. `VERCEL_URL`
+4. Fallback `https://juddges.augustyniak.ai`
+
+The value is normalised to a bare origin (no trailing slash). Consumed by the
+root layout `metadataBase`, `robots.ts`, `sitemap.ts`, and the changelog RSS
+feed (`app/changelog/feed.xml/route.ts`). **Set `NEXT_PUBLIC_SITE_URL` in
+production** so canonical/OG/sitemap URLs are correct.
+
+## What lives where
+
+| Concern | File |
+|---|---|
+| Global metadata (title template, description, keywords, OG, Twitter, robots) | `app/layout.tsx` |
+| Title template | `%s · Juddges` — per-page `title` values must be **bare** (e.g. `"Changelog"`, not `"Changelog — Juddges"`) to avoid double-branding |
+| `robots.txt` | `app/robots.ts` — allows `/`, disallows API/admin/auth + authenticated app sections, points to the sitemap |
+| `sitemap.xml` | `app/sitemap.ts` — lists only public routes (`/`, `/about`, `/ecosystem`) |
+| Open Graph image (1200×630, dynamic) | `app/opengraph-image.tsx` — rendered via `next/og` `ImageResponse` in the Editorial Jurisprudence palette; no binary asset |
+| Twitter image | `app/twitter-image.tsx` — re-exports the OG image |
+| JSON-LD structured data | `lib/structured-data.ts` (Organization + WebSite + SoftwareApplication `@graph`) rendered by `components/JsonLd.tsx` in the root layout |
+| PWA manifest | `app/manifest.ts` |
+
+## Middleware interaction (important)
+
+The middleware matcher excludes static-extension paths (`.txt`, `.xml`, …), so
+`/robots.txt` and `/sitemap.xml` are served without auth. The metadata **image**
+routes (`/opengraph-image`, `/twitter-image`) have **no extension**, so they are
+matched by middleware and must be present in the unauthenticated allow-list in
+`lib/supabase/middleware.ts` — otherwise social/search crawlers receive a 307
+redirect to `/auth/login` instead of the image.
+
+## Adding a new public (indexable) page
+
+1. Add its path prefix to the allow-list in `lib/supabase/middleware.ts`.
+2. Add an entry to `app/sitemap.ts`.
+3. Export page `metadata` with a **bare** `title` plus a `description`
+   (and `alternates.canonical` if the path differs from the slug).
+
+> Do **not** add `/search` or its APIs to the public allow-list — search stays
+> auth-gated by product decision.
+
+## Verify locally
+
+```bash
+cd frontend && npm run build && npx next start -p 3099
+curl -s localhost:3099/robots.txt
+curl -s localhost:3099/sitemap.xml
+curl -s -o /dev/null -w '%{http_code} %{content_type}\n' localhost:3099/opengraph-image  # 200 image/png
+```
+
+External validators: Google Rich Results Test, Schema.org Validator, Facebook
+Sharing Debugger, PageSpeed Insights.

--- a/frontend/app/auth/login/page.tsx
+++ b/frontend/app/auth/login/page.tsx
@@ -6,7 +6,7 @@ import { createClient } from "@/lib/supabase/server";
 import { sanitizeNextPath } from "@/lib/auth/next-path";
 
 export const metadata: Metadata = {
-  title: "Sign In | JuDDGES",
+  title: "Sign In",
   description:
     "Sign in to your JuDDGES account to access AI-powered judgments analysis and extraction tools.",
 };

--- a/frontend/app/changelog/[version]/page.tsx
+++ b/frontend/app/changelog/[version]/page.tsx
@@ -17,9 +17,9 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { version } = await params;
   const entry = await loadChangelogEntry(version);
-  if (!entry) return { title: "Release not found — Juddges" };
+  if (!entry) return { title: "Release not found" };
   return {
-    title: `${entry.title} — Juddges Changelog`,
+    title: `${entry.title} — Changelog`,
     description: `Release notes for Juddges ${entry.title}.`,
   };
 }

--- a/frontend/app/changelog/feed.xml/route.ts
+++ b/frontend/app/changelog/feed.xml/route.ts
@@ -1,4 +1,5 @@
 import { loadChangelogEntries } from "@/lib/changelog";
+import { SITE_URL } from "@/lib/site";
 
 export const dynamic = "force-static";
 
@@ -12,8 +13,7 @@ function escapeXml(s: string): string {
 }
 
 export async function GET() {
-  const siteUrl =
-    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") || "https://juddges.app";
+  const siteUrl = SITE_URL;
   const entries = await loadChangelogEntries();
 
   const items = entries

--- a/frontend/app/changelog/page.tsx
+++ b/frontend/app/changelog/page.tsx
@@ -4,7 +4,7 @@ import { loadChangelogEntries } from "@/lib/changelog";
 import { PageContainer, Header } from "@/lib/styles/components";
 
 export const metadata: Metadata = {
-  title: "Changelog — Juddges",
+  title: "Changelog",
   description: "Release notes and product updates for Juddges.",
 };
 

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -12,6 +12,9 @@ import { AppLayoutWrapper } from "@/components/layouts/AppLayoutWrapper";
 import { ChunkErrorBoundary } from "@/components/ChunkErrorBoundary";
 import { SonnerToaster } from "@/lib/styles/components";
 import { getBrandConfig, getCurrentBrand } from "@/lib/brand";
+import { siteMetadataBase } from "@/lib/site";
+import { JsonLd } from "@/components/JsonLd";
+import { getSiteStructuredData } from "@/lib/structured-data";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -29,24 +32,6 @@ const instrumentSerif = Instrument_Serif({
   variable: "--font-instrument-serif",
   preload: false, // Only used on admin and landing pages, not globally
 });
-
-const fallbackSiteUrl = "https://juddges.com";
-const configuredSiteUrl =
-  process.env.NEXT_PUBLIC_SITE_URL ||
-  process.env.VERCEL_PROJECT_PRODUCTION_URL ||
-  process.env.VERCEL_URL ||
-  fallbackSiteUrl;
-
-const metadataBase = (() => {
-  try {
-    const url = configuredSiteUrl.startsWith("http")
-      ? configuredSiteUrl
-      : `https://${configuredSiteUrl}`;
-    return new URL(url);
-  } catch {
-    return new URL(fallbackSiteUrl);
-  }
-})();
 
 // Get brand configuration at build/render time
 const currentBrand = getCurrentBrand();
@@ -75,9 +60,31 @@ export const viewport: Viewport = {
 };
 
 export const metadata: Metadata = {
-  title: brandConfig.name,
-  description: brandConfig.tagline,
-  metadataBase,
+  metadataBase: siteMetadataBase,
+  title: {
+    default: brandConfig.metadata.title,
+    template: `%s · ${brandConfig.name}`,
+  },
+  description: brandConfig.metadata.description,
+  applicationName: brandConfig.name,
+  keywords: [
+    "judicial decisions",
+    "court judgments",
+    "case law search",
+    "Polish court judgments",
+    "UK court judgments",
+    "legal AI",
+    "semantic search",
+    "legal research",
+    "NLP",
+    "Juddges",
+  ],
+  authors: [{ name: brandConfig.copyrightHolder }],
+  creator: brandConfig.copyrightHolder,
+  publisher: brandConfig.copyrightHolder,
+  alternates: {
+    canonical: "/",
+  },
   icons: {
     icon: brandConfig.logo || '/icon.svg?v=2',
     apple: brandConfig.logo || '/apple-icon.svg?v=2',
@@ -86,6 +93,30 @@ export const metadata: Metadata = {
     capable: true,
     statusBarStyle: "default",
     title: brandConfig.shortName,
+  },
+  openGraph: {
+    type: "website",
+    siteName: brandConfig.name,
+    title: brandConfig.metadata.ogTitle,
+    description: brandConfig.metadata.description,
+    url: "/",
+    locale: "en_US",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: brandConfig.metadata.ogTitle,
+    description: brandConfig.metadata.description,
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
   },
   other: {
     "mobile-web-app-capable": "yes",
@@ -133,6 +164,7 @@ export default function RootLayout({
         />
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} ${instrumentSerif.variable} font-sans antialiased`}>
+        <JsonLd data={getSiteStructuredData()} />
         <ChunkErrorBoundary>
           <QueryProvider>
             <AuthProvider>

--- a/frontend/app/legal/disclaimer/page.tsx
+++ b/frontend/app/legal/disclaimer/page.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 
 export const metadata: Metadata = {
- title: "Legal Disclaimer | JuDDGES",
+ title: "Legal Disclaimer",
  description:
 "Important legal disclaimers and limitations regarding the use of JuDDGES platform.",
 };

--- a/frontend/app/legal/terms/page.tsx
+++ b/frontend/app/legal/terms/page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Terms of Service | JuDDGES",
+  title: "Terms of Service",
   description: "Terms of service for JuDDGES judgments analysis platform",
 };
 

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -9,7 +9,7 @@ import {
 import { PageContainer } from "@/lib/styles/components";
 
 export const metadata: Metadata = {
-  title: "Get started — JUDDGES",
+  title: "Get started",
   description:
     "A tour of JUDDGES for legal researchers: search the corpus, build a collection, and read the base coding schema.",
 };

--- a/frontend/app/opengraph-image.tsx
+++ b/frontend/app/opengraph-image.tsx
@@ -1,0 +1,107 @@
+import { ImageResponse } from "next/og";
+import { getBrandConfig } from "@/lib/brand";
+
+// Editorial Jurisprudence palette (see docs/reference/DESIGN.md).
+const PARCHMENT = "#F5F1E8";
+const INK = "#1A1A2E";
+const INK_SOFT = "#5A5A75";
+const OXBLOOD = "#8B1E3F";
+const GOLD = "#B8954A";
+const RULE = "#C9C2B0";
+
+export const alt =
+  "Juddges — Judicial Decision Data Gathering, Encoding, and Sharing";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OpengraphImage(): ImageResponse {
+  const brand = getBrandConfig();
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          backgroundColor: PARCHMENT,
+          padding: "72px 80px",
+          fontFamily: "Georgia, serif",
+        }}
+      >
+        {/* Eyebrow */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 16,
+            fontSize: 22,
+            letterSpacing: 6,
+            textTransform: "uppercase",
+            color: INK_SOFT,
+            fontFamily: "monospace",
+          }}
+        >
+          <span style={{ color: OXBLOOD }}>§</span>
+          <span>Legal-AI Research Platform</span>
+        </div>
+
+        {/* Title block */}
+        <div style={{ display: "flex", flexDirection: "column", gap: 28 }}>
+          <div
+            style={{
+              fontSize: 132,
+              lineHeight: 1,
+              color: INK,
+              fontWeight: 700,
+              letterSpacing: -2,
+            }}
+          >
+            {brand.name}
+          </div>
+          <div
+            style={{
+              width: 160,
+              height: 6,
+              backgroundColor: GOLD,
+              display: "flex",
+            }}
+          />
+          <div
+            style={{
+              fontSize: 40,
+              lineHeight: 1.25,
+              color: INK_SOFT,
+              fontStyle: "italic",
+              maxWidth: 920,
+            }}
+          >
+            {brand.tagline}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            borderTop: `2px solid ${RULE}`,
+            paddingTop: 28,
+            fontSize: 24,
+            letterSpacing: 2,
+            textTransform: "uppercase",
+            color: INK,
+            fontFamily: "monospace",
+          }}
+        >
+          <span>Polish & UK Court Judgments</span>
+          <span style={{ color: OXBLOOD }}>Semantic Search · Extraction · Analytics</span>
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -1,0 +1,39 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
+
+/**
+ * robots.txt
+ *
+ * Only marketing/landing routes are reachable unauthenticated (see
+ * `lib/supabase/middleware.ts`); everything else 307-redirects to
+ * `/auth/login`. We additionally disallow API, admin, auth and the
+ * authenticated app sections so crawlers don't waste budget on
+ * login-redirect URLs or index sensitive paths.
+ */
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: [
+          "/api/",
+          "/admin/",
+          "/auth/",
+          "/settings/",
+          "/search/",
+          "/chat/",
+          "/collections/",
+          "/saved-searches/",
+          "/extractions/",
+          "/extract/",
+          "/documents/",
+          "/schema-chat/",
+          "/reasoning-lines/",
+        ],
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,0 +1,34 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
+
+/**
+ * Sitemap.
+ *
+ * Lists only the publicly crawlable routes (the unauthenticated allow-list in
+ * `lib/supabase/middleware.ts`). Authenticated app routes are intentionally
+ * excluded — they redirect to login and are not indexable.
+ */
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+
+  return [
+    {
+      url: `${SITE_URL}/`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${SITE_URL}/about`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/ecosystem`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+  ];
+}

--- a/frontend/app/twitter-image.tsx
+++ b/frontend/app/twitter-image.tsx
@@ -1,0 +1,2 @@
+// Twitter card image reuses the Open Graph image (same 1200×630 artwork).
+export { default, alt, size, contentType } from "./opengraph-image";

--- a/frontend/components/JsonLd.tsx
+++ b/frontend/components/JsonLd.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+interface JsonLdProps {
+  /** A schema.org object, or an array of them. */
+  data: Record<string, unknown> | Record<string, unknown>[];
+}
+
+/**
+ * Renders JSON-LD structured data.
+ *
+ * `<` is escaped to `<` so the serialized JSON can never break out of the
+ * surrounding `<script>` element (XSS-safe).
+ */
+export function JsonLd({ data }: JsonLdProps): React.JSX.Element {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data).replace(/</g, "\\u003c"),
+      }}
+    />
+  );
+}

--- a/frontend/lib/site.ts
+++ b/frontend/lib/site.ts
@@ -1,0 +1,33 @@
+/**
+ * Canonical site URL resolution.
+ *
+ * Single source of truth for the production origin used by metadata,
+ * `robots.ts`, `sitemap.ts`, OG images, and the changelog RSS feed.
+ *
+ * Precedence: explicit `NEXT_PUBLIC_SITE_URL`, then Vercel-provided hosts,
+ * then the production fallback. The value is normalised to a bare origin
+ * (scheme + host, no trailing slash).
+ */
+
+const FALLBACK_SITE_URL = "https://juddges.augustyniak.ai";
+
+function resolveSiteUrl(): string {
+  const configured =
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.VERCEL_PROJECT_PRODUCTION_URL ||
+    process.env.VERCEL_URL ||
+    FALLBACK_SITE_URL;
+
+  try {
+    const url = configured.startsWith("http") ? configured : `https://${configured}`;
+    return new URL(url).origin;
+  } catch {
+    return FALLBACK_SITE_URL;
+  }
+}
+
+/** Bare production origin, e.g. `https://juddges.augustyniak.ai` (no trailing slash). */
+export const SITE_URL = resolveSiteUrl();
+
+/** `metadataBase` value for Next.js Metadata. */
+export const siteMetadataBase = new URL(SITE_URL);

--- a/frontend/lib/structured-data.ts
+++ b/frontend/lib/structured-data.ts
@@ -1,0 +1,53 @@
+/**
+ * Site-wide schema.org structured data (JSON-LD).
+ *
+ * Returned as a single `@graph` so the Organization is declared once and
+ * referenced by `@id` from the WebSite and SoftwareApplication nodes.
+ */
+
+import { SITE_URL } from "@/lib/site";
+import { getBrandConfig } from "@/lib/brand";
+
+export function getSiteStructuredData(): Record<string, unknown> {
+  const brand = getBrandConfig();
+  const organizationId = `${SITE_URL}/#organization`;
+
+  const organization = {
+    "@type": "Organization",
+    "@id": organizationId,
+    name: brand.name,
+    url: SITE_URL,
+    logo: `${SITE_URL}${brand.logo}`,
+    description: brand.tagline,
+    sameAs: [
+      "https://github.com/pwr-ai/juddges-app",
+      "https://huggingface.co/JuDDGES",
+    ],
+  };
+
+  const website = {
+    "@type": "WebSite",
+    "@id": `${SITE_URL}/#website`,
+    name: brand.name,
+    url: SITE_URL,
+    description: brand.metadata.description,
+    inLanguage: "en",
+    publisher: { "@id": organizationId },
+  };
+
+  const software = {
+    "@type": "SoftwareApplication",
+    name: brand.name,
+    applicationCategory: "BusinessApplication",
+    operatingSystem: "Web",
+    url: SITE_URL,
+    description: brand.metadata.description,
+    offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+    publisher: { "@id": organizationId },
+  };
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [organization, website, software],
+  };
+}

--- a/frontend/lib/supabase/middleware.ts
+++ b/frontend/lib/supabase/middleware.ts
@@ -69,6 +69,9 @@ export async function updateSession(request: NextRequest) {
     !request.nextUrl.pathname.startsWith("/auth") &&
     !request.nextUrl.pathname.startsWith("/about") &&
     !request.nextUrl.pathname.startsWith("/ecosystem") &&
+    // Metadata image routes must be reachable by social/search crawlers.
+    !request.nextUrl.pathname.startsWith("/opengraph-image") &&
+    !request.nextUrl.pathname.startsWith("/twitter-image") &&
     !request.nextUrl.pathname.startsWith("/onboarding") &&
     !request.nextUrl.pathname.startsWith("/api/health") &&
     !request.nextUrl.pathname.startsWith("/api/dashboard/stats") &&


### PR DESCRIPTION
## Summary

Adds search-engine and social-sharing SEO for the Next.js frontend, **scoped to the unauthenticated, crawlable surface** (the middleware allow-list: `/`, `/about`, `/ecosystem`). Authenticated app routes stay excluded since they redirect to login and are not indexable.

Canonical production domain: **`juddges.augustyniak.ai`** (resolves the prior `juddges.com` vs `juddges.app` inconsistency).

## What's included

- **`lib/site.ts`** — single source of truth for `SITE_URL` / `metadataBase` (env precedence → fallback)
- **`app/robots.ts`** — allows `/`, disallows API/admin/auth + app sections, points to the sitemap
- **`app/sitemap.ts`** — public routes only
- **`app/opengraph-image.tsx`** + **`app/twitter-image.tsx`** — dynamic 1200×630 OG image via `next/og` (Editorial Jurisprudence palette, no binary asset)
- **`components/JsonLd.tsx`** + **`lib/structured-data.ts`** — Organization + WebSite + SoftwareApplication `@graph`, rendered site-wide
- **`app/layout.tsx`** — title template (`%s · Juddges`), keywords, canonical, Open Graph, Twitter cards, robots directives; `metadataBase` now sourced from `lib/site`
- **`lib/supabase/middleware.ts`** — allow-list `/opengraph-image` + `/twitter-image` so crawlers receive the image instead of a 307 to login (these routes have no file extension, so the matcher otherwise auth-gates them)
- normalized 6 page titles to bare form so the template doesn't double-brand; aligned the changelog RSS feed to `SITE_URL`
- **`docs/reference/seo-metadata.md`** + `.env.example` `NEXT_PUBLIC_SITE_URL`

> `/search` and its APIs intentionally stay auth-gated — not added to the public allow-list.

## Verification

Production build + served locally:

| Endpoint | Result |
|---|---|
| `/robots.txt` | 200 (Host + Sitemap + disallows) |
| `/sitemap.xml` | 200 (`/`, `/about`, `/ecosystem`) |
| `/opengraph-image` | 200 `image/png` (~43 KB) |
| `/twitter-image` | 200 `image/png` |
| home `<head>` | title, description, keywords, canonical, `og:*`, `twitter:*`, JSON-LD all present |
| `/search` | 307 (auth gate intact) |

`npm run build`, `tsc --noEmit`, ESLint on changed files: all clean.

## Deploy note

Set `NEXT_PUBLIC_SITE_URL=https://juddges.augustyniak.ai` in the production environment so canonical/OG/sitemap URLs resolve correctly.