### PR TITLE
security(extraction): migrate auth from X-User-ID to Supabase Bearer JWT (fixes #233)

### DIFF
--- a/backend/app/extraction.py
+++ b/backend/app/extraction.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from app.extraction_domain import jobs_router, prompts_router, results_router
-from app.extraction_domain.shared import get_current_user, simplify_job_status
+from app.extraction_domain.shared import simplify_job_status
 
 router = APIRouter(tags=["extraction"])
 
@@ -15,7 +15,6 @@ router.include_router(prompts_router, prefix="/extractions")
 router.include_router(results_router, prefix="/extractions")
 
 __all__ = [
-    "get_current_user",
     "jobs_router",
     "prompts_router",
     "results_router",

--- a/backend/app/extraction_domain/jobs_router.py
+++ b/backend/app/extraction_domain/jobs_router.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, status
 from loguru import logger
 from supabase import PostgrestAPIError, StorageException
 
+from app.core.auth_jwt import AuthenticatedUser, get_current_user
 from app.extraction_domain.shared import (
     _check_supabase_available,
     _convert_simplified_schema,
@@ -18,7 +19,6 @@ from app.extraction_domain.shared import (
     _validate_collection_id,
     _validate_documents,
     _validate_schema_id_required,
-    get_current_user,
     is_uuid,
     simplify_job_status,
     supabase,
@@ -833,7 +833,7 @@ async def list_extraction_jobs(
         None,
         description="Filter by job status (IN_PROGRESS, COMPLETED, PARTIALLY_COMPLETED, FAILED, CANCELLED)",
     ),
-    user_id: str = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(get_current_user),
 ) -> ListExtractionJobsResponse:
     """
     List extraction jobs for the current user.
@@ -855,6 +855,7 @@ async def list_extraction_jobs(
     Performance may vary based on the number of stored tasks.
     For production use with many tasks, consider implementing a dedicated job tracking database.
     """
+    user_id = user.id
     try:
         logger.info(
             f"Listing extraction jobs for user {user_id}, page={page}, page_size={page_size}, status={status}"
@@ -984,7 +985,7 @@ async def list_extraction_jobs(
 )
 async def cancel_or_delete_extraction_job(
     job_id: str = Path(..., description="Extraction job ID to cancel"),
-    user_id: str = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(get_current_user),
 ) -> CancelJobResponse:
     """
     Cancel a running extraction job.
@@ -995,7 +996,7 @@ async def cancel_or_delete_extraction_job(
     - **job_id**: The ID of the extraction job to cancel
 
     **Authorization:**
-    - Requires X-User-ID header
+    - Requires Authorization: Bearer <JWT>
     - Only the job owner can cancel (verified through collection ownership)
 
     **Response:**
@@ -1010,6 +1011,7 @@ async def cancel_or_delete_extraction_job(
     **Note:** This implementation uses Celery's revoke() method with terminate=True.
     The task will be terminated if it's currently running.
     """
+    user_id = user.id
     try:
         logger.info(f"User {user_id} requesting cancellation of job {job_id}")
 
@@ -1065,7 +1067,7 @@ async def cancel_or_delete_extraction_job(
 )
 async def delete_extraction_job(
     job_id: str = Path(..., description="Extraction job ID to delete"),
-    user_id: str = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(get_current_user),
 ) -> CancelJobResponse:
     """
     Permanently delete an extraction job from Supabase.
@@ -1076,13 +1078,14 @@ async def delete_extraction_job(
     - **job_id**: The ID of the extraction job to delete
 
     **Authorization:**
-    - Requires X-User-ID header
+    - Requires Authorization: Bearer <JWT>
     - Only the job owner can delete (verified through user_id)
 
     **Response:**
     - **status**: "deleted" or "not_found"
     - **message**: Human-readable status message
     """
+    user_id = user.id
     try:
         logger.info(f"User {user_id} requesting deletion of job {job_id}")
 

--- a/backend/app/extraction_domain/results_router.py
+++ b/backend/app/extraction_domain/results_router.py
@@ -9,8 +9,9 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from juddges_search.info_extraction import BaseSchemaExtractor
 from loguru import logger
 
+from app.core.auth_jwt import AuthenticatedUser, get_current_user
 from app.extraction_domain.base_schema_promote import promote_to_typed_columns
-from app.extraction_domain.shared import get_current_user, supabase
+from app.extraction_domain.shared import supabase
 from app.models import (
     BaseSchemaDefinitionResponse,
     BaseSchemaExtractionRequest,
@@ -34,7 +35,7 @@ router = APIRouter()
 async def export_extraction_results(
     job_id: str = Path(..., description="Extraction job ID"),
     format: str = Query("xlsx", description="Export format: 'xlsx' or 'csv'"),
-    user_id: str = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(get_current_user),
 ):
     """
     Export extraction results to CSV or Excel format.
@@ -46,7 +47,7 @@ async def export_extraction_results(
     - **format**: Export format ('xlsx' or 'csv', default: 'xlsx')
 
     **Authorization:**
-    - Requires X-User-ID header
+    - Requires Authorization: Bearer <JWT>
     - Only the job owner can export results
 
     **Returns:**
@@ -54,6 +55,7 @@ async def export_extraction_results(
     - Each row represents a document
     - Columns are flattened schema fields
     """
+    user_id = user.id
     from io import BytesIO
 
     import pandas as pd

--- a/backend/app/extraction_domain/shared.py
+++ b/backend/app/extraction_domain/shared.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import json
 import re
-import uuid
 from datetime import UTC, datetime
 from pathlib import Path as FilePath
 from typing import Any
 
 import jinja2
 from celery import exceptions as celery_exceptions
-from fastapi import Header, HTTPException, status
+from fastapi import HTTPException, status
 from loguru import logger
 
 from app.core.supabase import supabase_client as supabase
@@ -613,36 +612,3 @@ def archive_prompt(prompt_id: str) -> None:
     except Exception as e:
         logger.error(f"Error archiving prompt {prompt_id}: {e!s}")
         raise ValueError(f"Error archiving prompt: {e!s}")
-
-
-def get_current_user(x_user_id: str = Header(..., alias="X-User-ID")) -> str:
-    """
-    Extract and validate user ID from request header.
-
-    NOTE: This is an internal-only dependency intended for use behind API key
-    authentication middleware. The X-User-ID header is trusted only because the
-    calling service has already been authenticated via API key. Do NOT expose
-    endpoints using this dependency without upstream API key validation.
-
-    Args:
-        x_user_id: User ID from X-User-ID header (must be valid UUID format)
-
-    Returns:
-        Validated user ID string
-
-    Raises:
-        HTTPException: If user ID header is missing, empty, or not a valid UUID
-    """
-    if not x_user_id:
-        raise HTTPException(status_code=401, detail="User ID header is required")
-
-    # Validate UUID format to prevent injection of arbitrary user identifiers
-    try:
-        uuid.UUID(x_user_id)
-    except (ValueError, AttributeError):
-        raise HTTPException(
-            status_code=422,
-            detail="X-User-ID must be a valid UUID format",
-        )
-
-    return x_user_id

--- a/backend/tests/app/test_extraction_bearer_auth.py
+++ b/backend/tests/app/test_extraction_bearer_auth.py
@@ -1,0 +1,235 @@
+"""
+Tests pinning the Bearer-JWT auth contract on extraction endpoints.
+
+These tests document the migration from header-trusted ``X-User-ID`` to
+Supabase Bearer JWT for the extraction domain (issue #233). They mirror the
+pattern established by ``test_collections_bearer_auth.py`` and are written to:
+
+- FAIL if X-User-ID alone can still authenticate extraction endpoints.
+- PASS once all extraction routers consume ``app.core.auth_jwt.get_current_user``.
+
+Endpoints exercised:
+- ``GET  /extractions``          — list_extraction_jobs (requires Bearer)
+- ``DELETE /extractions/{id}``   — cancel_or_delete_extraction_job (requires Bearer)
+- ``GET  /extractions/{id}/export`` — export_extraction_results (requires Bearer)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.core.auth_jwt import AuthenticatedUser
+from app.core.auth_jwt import get_current_user as jwt_get_current_user
+from app.server import app
+
+pytestmark = [pytest.mark.anyio, pytest.mark.unit]
+
+_FAKE_USER_ID = "00000000-0000-4000-a000-000000000abc"
+_VALID_API_KEY = "test-api-key-12345"
+
+
+@pytest.fixture
+def valid_api_headers() -> dict[str, str]:
+    return {"X-API-Key": _VALID_API_KEY}
+
+
+@pytest.fixture
+def fake_user() -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_data={
+            "id": _FAKE_USER_ID,
+            "email": "extraction-bearer-user@example.com",
+            "role": "authenticated",
+        },
+        access_token="fake-jwt-token",
+    )
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.fixture
+def override_jwt_user(fake_user: AuthenticatedUser):
+    """Override the JWT dependency to return a stable test user for extraction."""
+
+    async def _resolver() -> AuthenticatedUser:
+        return fake_user
+
+    app.dependency_overrides[jwt_get_current_user] = _resolver
+    try:
+        yield fake_user
+    finally:
+        app.dependency_overrides.pop(jwt_get_current_user, None)
+
+
+# =============================================================================
+# GET /extractions — list endpoint
+# =============================================================================
+
+
+async def test_extraction_list_rejects_x_user_id_without_bearer(
+    client: AsyncClient, valid_api_headers: dict[str, str]
+) -> None:
+    """X-User-ID alone must no longer authenticate GET /extractions."""
+    headers = {**valid_api_headers, "X-User-ID": _FAKE_USER_ID}
+
+    response = await client.get("/extractions", headers=headers)
+
+    assert response.status_code in (401, 403), (
+        f"Expected 401/403 when only X-User-ID is supplied to /extractions; "
+        f"got {response.status_code}. Bearer JWT is now required."
+    )
+
+
+async def test_extraction_list_missing_all_auth_returns_unauthorized(
+    client: AsyncClient, valid_api_headers: dict[str, str]
+) -> None:
+    """API key alone (no Bearer, no X-User-ID) must be rejected on /extractions."""
+    response = await client.get("/extractions", headers=valid_api_headers)
+
+    assert response.status_code in (401, 403), (
+        f"Expected 401/403 when no user credential is supplied to /extractions; "
+        f"got {response.status_code}."
+    )
+
+
+async def test_extraction_list_accepts_bearer_jwt(
+    client: AsyncClient,
+    valid_api_headers: dict[str, str],
+    override_jwt_user: AuthenticatedUser,
+) -> None:
+    """A Bearer-authenticated request reaches the list handler (not 401/403/422)."""
+    mock_celery_app = MagicMock()
+    mock_inspect = MagicMock()
+    mock_inspect.active.return_value = {}
+    mock_inspect.scheduled.return_value = {}
+    mock_inspect.reserved.return_value = {}
+    mock_celery_app.control.inspect.return_value = mock_inspect
+
+    headers = {**valid_api_headers, "Authorization": "Bearer fake-jwt-token"}
+
+    with patch("app.extraction_domain.jobs_router.celery_app", mock_celery_app):
+        response = await client.get("/extractions", headers=headers)
+
+    assert response.status_code not in (401, 403, 422), (
+        f"Bearer auth path returned {response.status_code}; "
+        f"expected the handler to be reached (auth passed). "
+        f"Body: {response.text[:300]}"
+    )
+
+
+# =============================================================================
+# DELETE /extractions/{job_id} — cancel endpoint
+# =============================================================================
+
+
+async def test_extraction_cancel_rejects_x_user_id_without_bearer(
+    client: AsyncClient, valid_api_headers: dict[str, str]
+) -> None:
+    """X-User-ID alone must not authenticate DELETE /extractions/{job_id}."""
+    headers = {**valid_api_headers, "X-User-ID": _FAKE_USER_ID}
+
+    response = await client.delete("/extractions/job-123", headers=headers)
+
+    assert response.status_code in (401, 403), (
+        f"Expected 401/403 when only X-User-ID is supplied to DELETE /extractions/{{id}}; "
+        f"got {response.status_code}. Bearer JWT is now required."
+    )
+
+
+async def test_extraction_cancel_accepts_bearer_jwt(
+    client: AsyncClient,
+    valid_api_headers: dict[str, str],
+    override_jwt_user: AuthenticatedUser,
+) -> None:
+    """A Bearer-authenticated cancel request reaches the handler (not 401/403/422)."""
+    mock_result = MagicMock()
+    mock_result.state = "PENDING"
+    mock_result.info = None
+
+    headers = {**valid_api_headers, "Authorization": "Bearer fake-jwt-token"}
+
+    with patch(
+        "app.extraction_domain.jobs_router.AsyncResult",
+        return_value=mock_result,
+    ):
+        response = await client.delete("/extractions/job-123", headers=headers)
+
+    assert response.status_code not in (401, 403, 422), (
+        f"Bearer auth path returned {response.status_code}; "
+        f"expected the handler to be reached (auth passed). "
+        f"Body: {response.text[:300]}"
+    )
+
+
+# =============================================================================
+# GET /extractions/{job_id}/export — export endpoint
+# =============================================================================
+
+
+async def test_extraction_export_rejects_x_user_id_without_bearer(
+    client: AsyncClient, valid_api_headers: dict[str, str]
+) -> None:
+    """X-User-ID alone must not authenticate GET /extractions/{job_id}/export."""
+    headers = {**valid_api_headers, "X-User-ID": _FAKE_USER_ID}
+
+    response = await client.get(
+        "/extractions/job-123/export?format=csv", headers=headers
+    )
+
+    assert response.status_code in (401, 403), (
+        f"Expected 401/403 when only X-User-ID is supplied to /extractions/export; "
+        f"got {response.status_code}. Bearer JWT is now required."
+    )
+
+
+async def test_extraction_export_missing_all_auth_returns_unauthorized(
+    client: AsyncClient, valid_api_headers: dict[str, str]
+) -> None:
+    """API key alone (no Bearer) must be rejected on the export endpoint."""
+    response = await client.get(
+        "/extractions/job-123/export?format=csv", headers=valid_api_headers
+    )
+
+    assert response.status_code in (401, 403), (
+        f"Expected 401/403 when no user credential is supplied to /extractions/export; "
+        f"got {response.status_code}."
+    )
+
+
+async def test_extraction_export_accepts_bearer_jwt(
+    client: AsyncClient,
+    valid_api_headers: dict[str, str],
+    override_jwt_user: AuthenticatedUser,
+) -> None:
+    """A Bearer-authenticated export request reaches the handler (not 401/403/422).
+
+    The handler itself will return 400 (invalid format for 'pdf') — that's fine.
+    We are only verifying that the auth layer is passed, not the business logic.
+    """
+    headers = {**valid_api_headers, "Authorization": "Bearer fake-jwt-token"}
+
+    # Use an invalid format so the handler immediately returns 400 without
+    # hitting supabase — this is the cheapest way to confirm the auth layer
+    # was passed while keeping the test fully unit-scoped.
+    response = await client.get(
+        "/extractions/job-123/export?format=pdf", headers=headers
+    )
+
+    assert response.status_code not in (401, 403, 422), (
+        f"Bearer auth path returned {response.status_code}; "
+        f"expected the handler to be reached (auth passed). "
+        f"Body: {response.text[:300]}"
+    )
+    # Confirm the handler ran by checking the auth-unrelated 400 response
+    assert response.status_code == 400, (
+        f"Expected 400 (invalid format) after auth passes, got {response.status_code}. "
+        f"Body: {response.text[:300]}"
+    )

--- a/backend/tests/app/test_extraction_jobs_router.py
+++ b/backend/tests/app/test_extraction_jobs_router.py
@@ -2,6 +2,11 @@
 
 Tests cover: helper functions (pure logic), endpoint happy paths,
 error handling, and authorization via mocked dependencies.
+
+Auth note: jobs_router was migrated from X-User-ID header auth to Supabase
+Bearer JWT (issue #233). Endpoint tests that require user identity install the
+JWT override via _install_jwt_user_override() from conftest and send
+``Authorization: Bearer <token>`` instead of ``X-User-ID``.
 """
 
 from __future__ import annotations
@@ -24,6 +29,7 @@ from app.extraction_domain.jobs_router import (
     _worker_unavailable_error,
 )
 from app.models import DocumentExtractionResponse
+from tests.app.conftest import _install_jwt_user_override
 
 # =============================================================================
 # Pure helper functions
@@ -250,6 +256,10 @@ class TestBuildResubmitRequestFromJob:
 # Endpoint integration tests (via ASGI transport)
 # =============================================================================
 
+_USER_001 = "00000000-0000-4000-a000-000000000001"
+_USER_099 = "00000000-0000-4000-a000-000000000099"
+_BEARER_HEADERS = {"Authorization": "Bearer fake-jwt-token"}
+
 
 class TestCreateExtractionJobEndpoint:
     """Tests for POST /extractions endpoint."""
@@ -376,6 +386,7 @@ class TestCancelExtractionJobEndpoint:
     @pytest.mark.unit
     async def test_cancel_running_job(self, client, valid_api_headers) -> None:
         """Test cancelling a running job."""
+        _install_jwt_user_override(_USER_001)
         mock_result = MagicMock()
         mock_result.state = "STARTED"
         mock_result.info = {"some": "info"}
@@ -390,10 +401,7 @@ class TestCancelExtractionJobEndpoint:
         ):
             response = await client.delete(
                 "/extractions/job-789",
-                headers={
-                    **valid_api_headers,
-                    "X-User-ID": "00000000-0000-4000-a000-000000000001",
-                },
+                headers={**valid_api_headers, **_BEARER_HEADERS},
             )
             assert response.status_code == 200
             data = response.json()
@@ -403,6 +411,7 @@ class TestCancelExtractionJobEndpoint:
     @pytest.mark.unit
     async def test_cancel_completed_job(self, client, valid_api_headers) -> None:
         """Test cancelling an already completed job."""
+        _install_jwt_user_override(_USER_001)
         mock_result = MagicMock()
         mock_result.state = "SUCCESS"
         mock_result.info = {"data": "results"}
@@ -414,10 +423,7 @@ class TestCancelExtractionJobEndpoint:
         ):
             response = await client.delete(
                 "/extractions/job-done",
-                headers={
-                    **valid_api_headers,
-                    "X-User-ID": "00000000-0000-4000-a000-000000000001",
-                },
+                headers={**valid_api_headers, **_BEARER_HEADERS},
             )
             assert response.status_code == 200
             data = response.json()
@@ -426,6 +432,7 @@ class TestCancelExtractionJobEndpoint:
     @pytest.mark.unit
     async def test_cancel_not_found_job(self, client, valid_api_headers) -> None:
         """Test cancelling a job that doesn't exist."""
+        _install_jwt_user_override(_USER_001)
         mock_result = MagicMock()
         mock_result.state = "PENDING"
         mock_result.info = None
@@ -436,10 +443,7 @@ class TestCancelExtractionJobEndpoint:
         ):
             response = await client.delete(
                 "/extractions/job-missing",
-                headers={
-                    **valid_api_headers,
-                    "X-User-ID": "00000000-0000-4000-a000-000000000001",
-                },
+                headers={**valid_api_headers, **_BEARER_HEADERS},
             )
             assert response.status_code == 200
             data = response.json()
@@ -452,8 +456,9 @@ class TestDeleteExtractionJobEndpoint:
     @pytest.mark.unit
     async def test_delete_own_job(self, client, valid_api_headers) -> None:
         """Test deleting a job owned by the user."""
+        _install_jwt_user_override(_USER_001)
         mock_job_response = MagicMock()
-        mock_job_response.data = {"user_id": "00000000-0000-4000-a000-000000000001"}
+        mock_job_response.data = {"user_id": _USER_001}
 
         mock_delete_response = MagicMock()
         mock_delete_response.data = [{"job_id": "job-1"}]
@@ -465,10 +470,7 @@ class TestDeleteExtractionJobEndpoint:
         with patch("app.extraction_domain.jobs_router.supabase", mock_supabase):
             response = await client.delete(
                 "/extractions/job-1/delete",
-                headers={
-                    **valid_api_headers,
-                    "X-User-ID": "00000000-0000-4000-a000-000000000001",
-                },
+                headers={**valid_api_headers, **_BEARER_HEADERS},
             )
             assert response.status_code == 200
             data = response.json()
@@ -478,7 +480,13 @@ class TestDeleteExtractionJobEndpoint:
     async def test_delete_other_users_job_returns_403(
         self, client, valid_api_headers
     ) -> None:
-        """Test that deleting another user's job returns 403."""
+        """Test that deleting another user's job returns 403.
+
+        User 099 (the attacker) is authenticated as themselves via JWT.
+        The job in the DB belongs to user 001. The handler must deny access.
+        """
+        # Attacker is authenticated as _USER_099, job belongs to a different user
+        _install_jwt_user_override(_USER_099)
         mock_job_response = MagicMock()
         mock_job_response.data = {"user_id": "other-user"}
 
@@ -488,23 +496,18 @@ class TestDeleteExtractionJobEndpoint:
         with patch("app.extraction_domain.jobs_router.supabase", mock_supabase):
             response = await client.delete(
                 "/extractions/job-1/delete",
-                headers={
-                    **valid_api_headers,
-                    "X-User-ID": "00000000-0000-4000-a000-000000000099",
-                },
+                headers={**valid_api_headers, **_BEARER_HEADERS},
             )
             assert response.status_code == 403
 
     @pytest.mark.unit
     async def test_delete_supabase_unavailable(self, client, valid_api_headers) -> None:
         """Test that unavailable Supabase returns 503."""
+        _install_jwt_user_override(_USER_001)
         with patch("app.extraction_domain.jobs_router.supabase", None):
             response = await client.delete(
                 "/extractions/job-1/delete",
-                headers={
-                    **valid_api_headers,
-                    "X-User-ID": "00000000-0000-4000-a000-000000000001",
-                },
+                headers={**valid_api_headers, **_BEARER_HEADERS},
             )
             assert response.status_code == 503
 
@@ -515,16 +518,14 @@ class TestListExtractionJobsEndpoint:
     @pytest.mark.unit
     async def test_list_jobs_no_workers(self, client, valid_api_headers) -> None:
         """Test listing jobs when no workers are available returns 500 (generic handler)."""
+        _install_jwt_user_override(_USER_001)
         mock_celery_app = MagicMock()
         mock_celery_app.control.inspect.return_value = None
 
         with patch("app.extraction_domain.jobs_router.celery_app", mock_celery_app):
             response = await client.get(
                 "/extractions",
-                headers={
-                    **valid_api_headers,
-                    "X-User-ID": "00000000-0000-4000-a000-000000000001",
-                },
+                headers={**valid_api_headers, **_BEARER_HEADERS},
             )
             # The inner 503 HTTPException is caught by the outer `except Exception`
             # and re-wrapped as a 500 error
@@ -533,6 +534,7 @@ class TestListExtractionJobsEndpoint:
     @pytest.mark.unit
     async def test_list_jobs_empty(self, client, valid_api_headers) -> None:
         """Test listing jobs when no extraction jobs are running."""
+        _install_jwt_user_override(_USER_001)
         mock_inspect = MagicMock()
         mock_inspect.active.return_value = {}
         mock_inspect.scheduled.return_value = {}
@@ -544,10 +546,7 @@ class TestListExtractionJobsEndpoint:
         with patch("app.extraction_domain.jobs_router.celery_app", mock_celery_app):
             response = await client.get(
                 "/extractions",
-                headers={
-                    **valid_api_headers,
-                    "X-User-ID": "00000000-0000-4000-a000-000000000001",
-                },
+                headers={**valid_api_headers, **_BEARER_HEADERS},
             )
             assert response.status_code == 200
             data = response.json()

--- a/backend/tests/app/test_extraction_results_router.py
+++ b/backend/tests/app/test_extraction_results_router.py
@@ -2,6 +2,11 @@
 
 Tests cover: export endpoint (format validation, authorization, data flow),
 base schema extraction, filter, facets, definition, and filter-options endpoints.
+
+Auth note: results_router was migrated from X-User-ID header auth to Supabase
+Bearer JWT (issue #233). Endpoint tests that require user identity install the
+JWT override via _install_jwt_user_override() from conftest and send
+``Authorization: Bearer <token>`` instead of ``X-User-ID``.
 """
 
 from __future__ import annotations
@@ -9,6 +14,13 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+from tests.app.conftest import _install_jwt_user_override
+
+_USER_001 = "00000000-0000-4000-a000-000000000001"
+_USER_099 = "00000000-0000-4000-a000-000000000099"
+_BEARER_HEADERS = {"Authorization": "Bearer fake-jwt-token"}
+
 
 # =============================================================================
 # GET /extractions/{job_id}/export
@@ -18,12 +30,10 @@ import pytest
 class TestExportExtractionResults:
     @pytest.mark.unit
     async def test_invalid_format_returns_400(self, client, valid_api_headers) -> None:
+        _install_jwt_user_override(_USER_001)
         response = await client.get(
             "/extractions/job-1/export?format=pdf",
-            headers={
-                **valid_api_headers,
-                "X-User-ID": "00000000-0000-4000-a000-000000000001",
-            },
+            headers={**valid_api_headers, **_BEARER_HEADERS},
         )
         assert response.status_code == 400
 
@@ -31,18 +41,17 @@ class TestExportExtractionResults:
     async def test_supabase_unavailable_returns_503(
         self, client, valid_api_headers
     ) -> None:
+        _install_jwt_user_override(_USER_001)
         with patch("app.extraction_domain.results_router.supabase", None):
             response = await client.get(
                 "/extractions/job-1/export?format=csv",
-                headers={
-                    **valid_api_headers,
-                    "X-User-ID": "00000000-0000-4000-a000-000000000001",
-                },
+                headers={**valid_api_headers, **_BEARER_HEADERS},
             )
             assert response.status_code == 503
 
     @pytest.mark.unit
     async def test_job_not_found_returns_404(self, client, valid_api_headers) -> None:
+        _install_jwt_user_override(_USER_001)
         mock_response = MagicMock()
         mock_response.data = None
 
@@ -52,15 +61,18 @@ class TestExportExtractionResults:
         with patch("app.extraction_domain.results_router.supabase", mock_supabase):
             response = await client.get(
                 "/extractions/job-missing/export?format=csv",
-                headers={
-                    **valid_api_headers,
-                    "X-User-ID": "00000000-0000-4000-a000-000000000001",
-                },
+                headers={**valid_api_headers, **_BEARER_HEADERS},
             )
             assert response.status_code == 404
 
     @pytest.mark.unit
     async def test_access_denied_returns_403(self, client, valid_api_headers) -> None:
+        """User 099 (attacker) tries to export a job that belongs to other-user.
+
+        The attacker authenticates as _USER_099 via JWT; the job in the DB has
+        a different user_id. The handler must deny access with 403.
+        """
+        _install_jwt_user_override(_USER_099)
         mock_response = MagicMock()
         mock_response.data = {
             "job_id": "job-1",
@@ -77,19 +89,17 @@ class TestExportExtractionResults:
         with patch("app.extraction_domain.results_router.supabase", mock_supabase):
             response = await client.get(
                 "/extractions/job-1/export?format=csv",
-                headers={
-                    **valid_api_headers,
-                    "X-User-ID": "00000000-0000-4000-a000-000000000099",
-                },
+                headers={**valid_api_headers, **_BEARER_HEADERS},
             )
             assert response.status_code == 403
 
     @pytest.mark.unit
     async def test_no_results_returns_400(self, client, valid_api_headers) -> None:
+        _install_jwt_user_override(_USER_001)
         mock_response = MagicMock()
         mock_response.data = {
             "job_id": "job-1",
-            "user_id": "00000000-0000-4000-a000-000000000001",
+            "user_id": _USER_001,
             "collection_id": "col-1",
             "schema_id": None,
             "results": [],
@@ -102,20 +112,18 @@ class TestExportExtractionResults:
         with patch("app.extraction_domain.results_router.supabase", mock_supabase):
             response = await client.get(
                 "/extractions/job-1/export?format=csv",
-                headers={
-                    **valid_api_headers,
-                    "X-User-ID": "00000000-0000-4000-a000-000000000001",
-                },
+                headers={**valid_api_headers, **_BEARER_HEADERS},
             )
             assert response.status_code == 400
 
     @pytest.mark.unit
     async def test_export_csv_success(self, client, valid_api_headers) -> None:
         """Test successful CSV export with completed results."""
+        _install_jwt_user_override(_USER_001)
         mock_job_response = MagicMock()
         mock_job_response.data = {
             "job_id": "job-1",
-            "user_id": "00000000-0000-4000-a000-000000000001",
+            "user_id": _USER_001,
             "collection_id": "col-1",
             "schema_id": "schema-1",
             "results": [
@@ -146,10 +154,7 @@ class TestExportExtractionResults:
         with patch("app.extraction_domain.results_router.supabase", mock_supabase):
             response = await client.get(
                 "/extractions/job-1/export?format=csv",
-                headers={
-                    **valid_api_headers,
-                    "X-User-ID": "00000000-0000-4000-a000-000000000001",
-                },
+                headers={**valid_api_headers, **_BEARER_HEADERS},
             )
             assert response.status_code == 200
             assert "text/csv" in response.headers["content-type"]

--- a/backend/tests/app/test_extraction_shared.py
+++ b/backend/tests/app/test_extraction_shared.py
@@ -30,7 +30,6 @@ from app.extraction_domain.shared import (
     create_backup,
     get_archived_metadata_path,
     get_archived_prompt_path,
-    get_current_user,
     get_metadata_file_path,
     get_prompt_file_path,
     is_system_prompt,
@@ -727,44 +726,7 @@ class TestArchivePrompt:
             assert not metadata_file.exists()
 
 
-# =============================================================================
-# get_current_user dependency
-# =============================================================================
-
-
-class TestGetCurrentUser:
-    @pytest.mark.unit
-    def test_valid_uuid_user_id(self) -> None:
-        """A valid UUID should be accepted and returned."""
-        valid_uuid = "550e8400-e29b-41d4-a716-446655440000"
-        result = get_current_user(x_user_id=valid_uuid)
-        assert result == valid_uuid
-
-    @pytest.mark.unit
-    def test_empty_user_id_raises(self) -> None:
-        with pytest.raises(HTTPException) as exc_info:
-            get_current_user(x_user_id="")
-        assert exc_info.value.status_code == 401
-
-    @pytest.mark.unit
-    def test_non_uuid_user_id_raises_422(self) -> None:
-        """BUG-15 regression: arbitrary strings like 'user-123' must be rejected
-        to prevent user impersonation via crafted X-User-ID headers."""
-        with pytest.raises(HTTPException) as exc_info:
-            get_current_user(x_user_id="user-123")
-        assert exc_info.value.status_code == 422
-        assert "UUID" in exc_info.value.detail
-
-    @pytest.mark.unit
-    def test_sql_injection_attempt_rejected(self) -> None:
-        """BUG-15 regression: injection payloads must not pass validation."""
-        with pytest.raises(HTTPException) as exc_info:
-            get_current_user(x_user_id="'; DROP TABLE users; --")
-        assert exc_info.value.status_code == 422
-
-    @pytest.mark.unit
-    def test_uppercase_uuid_accepted(self) -> None:
-        """UUIDs should be accepted regardless of case."""
-        upper_uuid = "550E8400-E29B-41D4-A716-446655440000"
-        result = get_current_user(x_user_id=upper_uuid)
-        assert result == upper_uuid
+# NOTE: The X-User-ID-based get_current_user dependency was removed from
+# app.extraction_domain.shared in the migration to Supabase Bearer JWT auth
+# (issue #233). Tests for the old dep have been deleted; auth-contract tests
+# for the new Bearer JWT dep live in test_extraction_bearer_auth.py.

--- a/backend/tests/app/test_rate_limiting.py
+++ b/backend/tests/app/test_rate_limiting.py
@@ -170,24 +170,26 @@ class TestRateLimitBypass:
     async def test_authenticated_users_higher_limits(
         self, client: AsyncClient, valid_api_headers: dict[str, str]
     ):
-        """Test that authenticated users may have higher rate limits."""
-        # Authenticated requests with user ID
-        auth_headers = {**valid_api_headers, "X-User-ID": "premium-user-123"}
+        """Test that authenticated users may have higher rate limits.
 
-        # Make many requests
-        auth_responses = []
+        Note: X-User-ID no longer authenticates users (Bearer JWT required).
+        This test exercises the rate limiter under repeated API-key-only load,
+        which is still a valid load pattern for observing rate-limit behaviour.
+        """
+        # Make many requests with the API key (no Bearer token — rate-limit load test)
+        api_key_responses = []
         for _i in range(100):
-            response = await client.get("/documents", headers=auth_headers)
-            auth_responses.append(response)
+            response = await client.get("/documents", headers=valid_api_headers)
+            api_key_responses.append(response)
 
-        # Compare to unauthenticated requests
+        # Compare to requests with no API key at all
         unauth_responses = []
         for _i in range(100):
             response = await client.get("/documents", headers=valid_api_headers)
             unauth_responses.append(response)
 
-        # Document whether authenticated users get higher limits
-        any(r.status_code == 429 for r in auth_responses)
+        # Document whether rate limits differ by key presence
+        any(r.status_code == 429 for r in api_key_responses)
         any(r.status_code == 429 for r in unauth_responses)
 
     async def test_health_endpoints_not_rate_limited(self, client: AsyncClient):
@@ -232,13 +234,15 @@ class TestRateLimitSecurity:
     async def test_rate_limit_prevents_enumeration(
         self, client: AsyncClient, valid_api_headers: dict[str, str]
     ):
-        """Test that rate limiting helps prevent user enumeration."""
-        # Simulate user enumeration attempt
-        user_ids = [f"user-{i}" for i in range(100)]
+        """Test that rate limiting helps prevent rapid enumeration attempts.
 
-        for user_id in user_ids:
-            headers = {**valid_api_headers, "X-User-ID": user_id}
-            response = await client.get("/collections", headers=headers)
+        Note: X-User-ID no longer authenticates users (Bearer JWT required).
+        Sending it without a Bearer token will be rejected as 401/403 by
+        /collections, but the rate-limiter still counts those requests, which
+        is the behaviour this test documents.
+        """
+        for _i in range(100):
+            response = await client.get("/collections", headers=valid_api_headers)
 
             # Rate limiting should prevent rapid enumeration
             if response.status_code == 429:

--- a/frontend/__tests__/api/extractions/base-schema/route.test.ts
+++ b/frontend/__tests__/api/extractions/base-schema/route.test.ts
@@ -43,6 +43,10 @@ describe('POST /api/extractions/base-schema', () => {
           data: { user },
           error,
         }),
+        getSession: jest.fn().mockResolvedValue({
+          data: { session: user ? { access_token: 'test-access-token' } : null },
+          error: null,
+        }),
       },
     });
   };
@@ -84,7 +88,7 @@ describe('POST /api/extractions/base-schema', () => {
         method: 'POST',
         headers: expect.objectContaining({
           'X-API-Key': 'test-api-key',
-          'X-User-ID': 'user-1',
+          'Authorization': 'Bearer test-access-token',
         }),
         body: JSON.stringify({
           document_ids: ['doc-1'],

--- a/frontend/__tests__/app/api/extractions/route.test.ts
+++ b/frontend/__tests__/app/api/extractions/route.test.ts
@@ -59,6 +59,10 @@ function mockSupabaseAuth(userId: string | null) {
         data: { user: userId ? { id: userId } : null },
         error: userId ? null : new Error("not authed"),
       }),
+      getSession: jest.fn().mockResolvedValue({
+        data: { session: userId ? { access_token: "test-access-token" } : null },
+        error: null,
+      }),
     },
     from: fromMock,
   };
@@ -485,7 +489,7 @@ describe("DELETE /api/extractions", () => {
         method: "DELETE",
         headers: expect.objectContaining({
           "X-API-Key": "test-api-key",
-          "X-User-ID": USER_ID,
+          "Authorization": "Bearer test-access-token",
         }),
       })
     );

--- a/frontend/app/api/extractions/[id]/export/route.ts
+++ b/frontend/app/api/extractions/[id]/export/route.ts
@@ -35,6 +35,16 @@ export async function GET(
       );
     }
 
+    const { data: sessionData } = await supabase.auth.getSession();
+    const accessToken = sessionData.session?.access_token;
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
     // Call the backend export endpoint
     const backendUrl = `${API_BASE_URL}/extractions/${jobId}/export?format=${format}`;
 
@@ -46,7 +56,7 @@ export async function GET(
     const response = await fetch(backendUrl, {
       headers: {
         'X-API-Key': API_KEY,
-        'X-User-ID': userData.user.id,
+        'Authorization': `Bearer ${accessToken}`,
       },
     });
 

--- a/frontend/app/api/extractions/base-schema/definition/route.ts
+++ b/frontend/app/api/extractions/base-schema/definition/route.ts
@@ -29,13 +29,20 @@ export async function GET(): Promise<NextResponse> {
       throw new UnauthorizedError("Please log in to view base schema definition");
     }
 
+    const { data: sessionData } = await supabase.auth.getSession();
+    const accessToken = sessionData.session?.access_token;
+
+    if (!accessToken) {
+      throw new UnauthorizedError("Please log in to view base schema definition");
+    }
+
     const response = await fetch(
       `${API_BASE_URL}/extractions/base-schema/definition`,
       {
         method: "GET",
         headers: {
           "X-API-Key": API_KEY,
-          "X-User-ID": userData.user.id,
+          "Authorization": `Bearer ${accessToken}`,
         },
       }
     );

--- a/frontend/app/api/extractions/base-schema/facets/[field]/route.ts
+++ b/frontend/app/api/extractions/base-schema/facets/[field]/route.ts
@@ -34,6 +34,13 @@ export async function GET(
       throw new UnauthorizedError("Please log in to get facet counts");
     }
 
+    const { data: sessionData } = await supabase.auth.getSession();
+    const accessToken = sessionData.session?.access_token;
+
+    if (!accessToken) {
+      throw new UnauthorizedError("Please log in to get facet counts");
+    }
+
     // Forward request to backend
     const response = await fetch(
       `${API_BASE_URL}/extractions/base-schema/facets/${encodeURIComponent(field)}`,
@@ -41,7 +48,7 @@ export async function GET(
         method: 'GET',
         headers: {
           'X-API-Key': API_KEY,
-          'X-User-ID': userData.user.id,
+          'Authorization': `Bearer ${accessToken}`,
         },
       }
     );

--- a/frontend/app/api/extractions/base-schema/filter-options/route.ts
+++ b/frontend/app/api/extractions/base-schema/filter-options/route.ts
@@ -30,6 +30,13 @@ export async function GET(request: NextRequest) {
       throw new UnauthorizedError("Please log in to get filter options");
     }
 
+    const { data: sessionData } = await supabase.auth.getSession();
+    const accessToken = sessionData.session?.access_token;
+
+    if (!accessToken) {
+      throw new UnauthorizedError("Please log in to get filter options");
+    }
+
     // Forward request to backend
     const response = await fetch(
       `${API_BASE_URL}/extractions/base-schema/filter-options`,
@@ -37,7 +44,7 @@ export async function GET(request: NextRequest) {
         method: 'GET',
         headers: {
           'X-API-Key': API_KEY,
-          'X-User-ID': userData.user.id,
+          'Authorization': `Bearer ${accessToken}`,
         },
       }
     );

--- a/frontend/app/api/extractions/base-schema/filter/route.ts
+++ b/frontend/app/api/extractions/base-schema/filter/route.ts
@@ -30,6 +30,13 @@ export async function POST(request: NextRequest) {
       throw new UnauthorizedError("Please log in to filter documents");
     }
 
+    const { data: sessionData } = await supabase.auth.getSession();
+    const accessToken = sessionData.session?.access_token;
+
+    if (!accessToken) {
+      throw new UnauthorizedError("Please log in to filter documents");
+    }
+
     // Parse request body
     const body = await request.json();
     const { filters, text_query, limit = 50, offset = 0 } = body;
@@ -40,7 +47,7 @@ export async function POST(request: NextRequest) {
       headers: {
         'Content-Type': 'application/json',
         'X-API-Key': API_KEY,
-        'X-User-ID': userData.user.id,
+        'Authorization': `Bearer ${accessToken}`,
       },
       body: JSON.stringify({
         filters: filters || {},

--- a/frontend/app/api/extractions/base-schema/route.ts
+++ b/frontend/app/api/extractions/base-schema/route.ts
@@ -30,6 +30,13 @@ export async function POST(request: NextRequest) {
       throw new UnauthorizedError("Please log in to extract data");
     }
 
+    const { data: sessionData } = await supabase.auth.getSession();
+    const accessToken = sessionData.session?.access_token;
+
+    if (!accessToken) {
+      throw new UnauthorizedError("Please log in to extract data");
+    }
+
     // Parse request body
     const body = await request.json();
     const {
@@ -70,7 +77,7 @@ export async function POST(request: NextRequest) {
       headers: {
         'Content-Type': 'application/json',
         'X-API-Key': API_KEY,
-        'X-User-ID': userData.user.id,
+        'Authorization': `Bearer ${accessToken}`,
       },
       body: JSON.stringify({
         document_ids: normalizedDocumentIds,

--- a/frontend/app/api/extractions/bulk/route.ts
+++ b/frontend/app/api/extractions/bulk/route.ts
@@ -51,6 +51,13 @@ export async function POST(request: NextRequest) {
       throw new UnauthorizedError("Please log in to start a bulk extraction");
     }
 
+    const { data: sessionData } = await supabase.auth.getSession();
+    const accessToken = sessionData.session?.access_token;
+
+    if (!accessToken) {
+      throw new UnauthorizedError("Please log in to start a bulk extraction");
+    }
+
     // Resolve document IDs if not provided
     let resolvedDocumentIds: string[] = document_ids || [];
 
@@ -59,7 +66,7 @@ export async function POST(request: NextRequest) {
         const response = await fetch(`${API_BASE_URL}/collections/${collection_id}/documents`, {
           headers: {
             'X-API-Key': API_KEY,
-            'X-User-ID': userData.user.id,
+            'Authorization': `Bearer ${accessToken}`,
           } as HeadersInit,
         });
 
@@ -101,6 +108,7 @@ export async function POST(request: NextRequest) {
       headers: {
         'Content-Type': 'application/json',
         'X-API-Key': API_KEY,
+        'Authorization': `Bearer ${accessToken}`,
       },
       body: JSON.stringify(backendPayload),
     });

--- a/frontend/app/api/extractions/delete/route.ts
+++ b/frontend/app/api/extractions/delete/route.ts
@@ -56,6 +56,13 @@ export async function DELETE(request: NextRequest): Promise<NextResponse> {
       throw new UnauthorizedError("Please log in to delete an extraction job");
     }
 
+    const { data: sessionData } = await supabase.auth.getSession();
+    const accessToken = sessionData.session?.access_token;
+
+    if (!accessToken) {
+      throw new UnauthorizedError("Please log in to delete an extraction job");
+    }
+
     // Call the backend API to delete the job with timeout
     const backendUrl = `${API_BASE_URL}/extractions/${job_id}/delete`;
     apiLogger.info('Calling backend DELETE endpoint', { requestId, job_id, backendUrl });
@@ -71,7 +78,7 @@ export async function DELETE(request: NextRequest): Promise<NextResponse> {
           method: 'DELETE',
           headers: {
             'X-API-Key': API_KEY,
-            'X-User-ID': userData.user.id
+            'Authorization': `Bearer ${accessToken}`,
           },
           signal: controller.signal
         }

--- a/frontend/app/api/extractions/route.ts
+++ b/frontend/app/api/extractions/route.ts
@@ -86,6 +86,13 @@ export async function POST(request: NextRequest) {
       throw new UnauthorizedError("Please log in to start an extraction");
     }
 
+    const { data: sessionData } = await supabase.auth.getSession();
+    const accessToken = sessionData.session?.access_token;
+
+    if (!accessToken) {
+      throw new UnauthorizedError("Please log in to start an extraction");
+    }
+
     // Use provided document_ids or get all documents from the collection
     // document_ids from frontend are document IDs (backend returns them directly)
     let documentIds: string[];
@@ -104,7 +111,7 @@ export async function POST(request: NextRequest) {
         const response = await fetch(`${API_BASE_URL}/collections/${collection_id}/documents`, {
           headers: {
             'X-API-Key': API_KEY,
-            'X-User-ID': userData.user.id,
+            'Authorization': `Bearer ${accessToken}`,
           } as HeadersInit,
         });
 
@@ -171,7 +178,8 @@ export async function POST(request: NextRequest) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'X-API-Key': API_KEY
+        'X-API-Key': API_KEY,
+        'Authorization': `Bearer ${accessToken}`,
       },
       body: JSON.stringify(backendPayload)
     });
@@ -331,12 +339,23 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    const { data: sessionData } = await supabase.auth.getSession();
+    const accessToken = sessionData.session?.access_token;
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
     // Call the backend API to get extraction status and results
     const response = await fetch(
       `${API_BASE_URL}/extractions/${job_id}`,
       {
         headers: {
-          'X-API-Key': API_KEY
+          'X-API-Key': API_KEY,
+          'Authorization': `Bearer ${accessToken}`,
         }
       }
     );
@@ -524,6 +543,13 @@ export async function DELETE(request: NextRequest) {
       throw new UnauthorizedError("Please log in to cancel an extraction job");
     }
 
+    const { data: deleteSessionData } = await supabase.auth.getSession();
+    const deleteAccessToken = deleteSessionData.session?.access_token;
+
+    if (!deleteAccessToken) {
+      throw new UnauthorizedError("Please log in to cancel an extraction job");
+    }
+
     // Call the backend API to cancel the job with timeout
     const backendUrl = `${API_BASE_URL}/extractions/${job_id}`;
     apiLogger.info('Calling backend DELETE endpoint', { requestId, job_id, backendUrl });
@@ -539,7 +565,7 @@ export async function DELETE(request: NextRequest) {
           method: 'DELETE',
           headers: {
             'X-API-Key': API_KEY,
-            'X-User-ID': userData.user.id
+            'Authorization': `Bearer ${deleteAccessToken}`,
           },
           signal: controller.signal
         }

--- a/frontend/lib/api/generated/openapi.ts
+++ b/frontend/lib/api/generated/openapi.ts
@@ -2051,7 +2051,7 @@ export interface paths {
         put?: never;
         /**
          * Add Documents Batch
-         * @description Add multiple documents to a collection at once.
+         * @description Add multiple documents to a collection at once (max 100 per request).
          */
         post: operations["add_documents_batch_collections__collection_id__documents_batch_post"];
         delete?: never;
@@ -5211,11 +5211,12 @@ export interface paths {
          *
          *     This endpoint provides a chat-based interface for creating and refining
          *     extraction schemas. It maintains conversation state across requests using
-         *     session IDs.
+         *     session IDs scoped to the authenticated user.
          *
          *     Args:
          *         params: Chat request with message and context
          *         request: FastAPI request object
+         *         user: Authenticated user (from Bearer JWT)
          *
          *     Returns:
          *         Chat response with AI message and schema state
@@ -5257,6 +5258,7 @@ export interface paths {
          *     Args:
          *         params: Schema generation request with user's description
          *         request: FastAPI request object
+         *         user: Authenticated user (from Bearer JWT)
          *
          *     Returns:
          *         Generated schema with metadata
@@ -5297,6 +5299,7 @@ export interface paths {
          *     Args:
          *         params: Test request with schema and document IDs
          *         request: FastAPI request object
+         *         user: Authenticated user (from Bearer JWT)
          *
          *     Returns:
          *         Test results with success/failure statistics
@@ -6150,7 +6153,7 @@ export interface components {
         AddDocumentsRequest: {
             /**
              * Document Ids
-             * @description List of document IDs to add
+             * @description List of document IDs to add (max 100 per request)
              */
             document_ids: string[];
         };
@@ -19134,9 +19137,7 @@ export interface operations {
                 /** @description Filter by job status (IN_PROGRESS, COMPLETED, PARTIALLY_COMPLETED, FAILED, CANCELLED) */
                 status?: string | null;
             };
-            header: {
-                "X-User-ID": string;
-            };
+            header?: never;
             path?: never;
             cookie?: never;
         };
@@ -19610,9 +19611,7 @@ export interface operations {
     cancel_or_delete_extraction_job_extractions__job_id__delete: {
         parameters: {
             query?: never;
-            header: {
-                "X-User-ID": string;
-            };
+            header?: never;
             path: {
                 /** @description Extraction job ID to cancel */
                 job_id: string;
@@ -19644,9 +19643,7 @@ export interface operations {
     delete_extraction_job_extractions__job_id__delete_delete: {
         parameters: {
             query?: never;
-            header: {
-                "X-User-ID": string;
-            };
+            header?: never;
             path: {
                 /** @description Extraction job ID to delete */
                 job_id: string;
@@ -19681,9 +19678,7 @@ export interface operations {
                 /** @description Export format: 'xlsx' or 'csv' */
                 format?: string;
             };
-            header: {
-                "X-User-ID": string;
-            };
+            header?: never;
             path: {
                 /** @description Extraction job ID */
                 job_id: string;

--- a/scripts/openapi-snapshot.json
+++ b/scripts/openapi-snapshot.json
@@ -260,10 +260,11 @@
         "description": "Request model for adding multiple documents to a collection.",
         "properties": {
           "document_ids": {
-            "description": "List of document IDs to add",
+            "description": "List of document IDs to add (max 100 per request)",
             "items": {
               "type": "string"
             },
+            "maxItems": 100,
             "minItems": 1,
             "title": "Document Ids",
             "type": "array"
@@ -22450,7 +22451,7 @@
     },
     "/collections/{collection_id}/documents/batch": {
       "post": {
-        "description": "Add multiple documents to a collection at once.",
+        "description": "Add multiple documents to a collection at once (max 100 per request).",
         "operationId": "add_documents_batch_collections__collection_id__documents_batch_post",
         "parameters": [
           {
@@ -25567,15 +25568,6 @@
               "description": "Filter by job status (IN_PROGRESS, COMPLETED, PARTIALLY_COMPLETED, FAILED, CANCELLED)",
               "title": "Status"
             }
-          },
-          {
-            "in": "header",
-            "name": "X-User-ID",
-            "required": true,
-            "schema": {
-              "title": "X-User-Id",
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -25603,6 +25595,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "HTTPBearer": []
           }
         ],
         "summary": "List extraction jobs",
@@ -26254,15 +26249,6 @@
               "title": "Job Id",
               "type": "string"
             }
-          },
-          {
-            "in": "header",
-            "name": "X-User-ID",
-            "required": true,
-            "schema": {
-              "title": "X-User-Id",
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -26290,6 +26276,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "HTTPBearer": []
           }
         ],
         "summary": "Cancel or delete extraction job",
@@ -26361,15 +26350,6 @@
               "title": "Job Id",
               "type": "string"
             }
-          },
-          {
-            "in": "header",
-            "name": "X-User-ID",
-            "required": true,
-            "schema": {
-              "title": "X-User-Id",
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -26397,6 +26377,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "HTTPBearer": []
           }
         ],
         "summary": "Delete extraction job",
@@ -26432,15 +26415,6 @@
               "title": "Format",
               "type": "string"
             }
-          },
-          {
-            "in": "header",
-            "name": "X-User-ID",
-            "required": true,
-            "schema": {
-              "title": "X-User-Id",
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -26466,6 +26440,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "HTTPBearer": []
           }
         ],
         "summary": "Export extraction results",
@@ -31188,7 +31165,7 @@
     },
     "/schema-generator/chat": {
       "post": {
-        "description": "Process conversational messages for schema generation.\n\nThis endpoint provides a chat-based interface for creating and refining\nextraction schemas. It maintains conversation state across requests using\nsession IDs.\n\nArgs:\n    params: Chat request with message and context\n    request: FastAPI request object\n\nReturns:\n    Chat response with AI message and schema state\n\nExample:\n    ```\n    POST /api/schema-generator/chat\n    {\n        \"message\": \"I need to extract drug information from court documents\",\n        \"collection_id\": \"drug-cases\",\n        \"document_type\": \"judgment\",\n        \"mode\": \"rabbit\"\n    }\n    ```",
+        "description": "Process conversational messages for schema generation.\n\nThis endpoint provides a chat-based interface for creating and refining\nextraction schemas. It maintains conversation state across requests using\nsession IDs scoped to the authenticated user.\n\nArgs:\n    params: Chat request with message and context\n    request: FastAPI request object\n    user: Authenticated user (from Bearer JWT)\n\nReturns:\n    Chat response with AI message and schema state\n\nExample:\n    ```\n    POST /api/schema-generator/chat\n    {\n        \"message\": \"I need to extract drug information from court documents\",\n        \"collection_id\": \"drug-cases\",\n        \"document_type\": \"judgment\",\n        \"mode\": \"rabbit\"\n    }\n    ```",
         "operationId": "schema_chat_schema_generator_chat_post",
         "requestBody": {
           "content": {
@@ -31225,6 +31202,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "HTTPBearer": []
           }
         ],
         "summary": "Schema Chat",
@@ -31235,7 +31215,7 @@
     },
     "/schema-generator/simple": {
       "post": {
-        "description": "Generate a JSON Schema from a natural language description.\n\nThis endpoint provides a simple, single-shot approach to schema generation\nwithout the complexity of multi-turn conversations or agent systems.\n\nArgs:\n    params: Schema generation request with user's description\n    request: FastAPI request object\n\nReturns:\n    Generated schema with metadata\n\nExample:\n    ```\n    POST /api/schema-generator/simple\n    {\n        \"message\": \"Extract party names, contract dates, and monetary amounts\",\n        \"schema_name\": \"ContractExtraction\",\n        \"extraction_instructions\": \"These are Polish legal contracts from 2020-2024\"\n    }\n    ```",
+        "description": "Generate a JSON Schema from a natural language description.\n\nThis endpoint provides a simple, single-shot approach to schema generation\nwithout the complexity of multi-turn conversations or agent systems.\n\nArgs:\n    params: Schema generation request with user's description\n    request: FastAPI request object\n    user: Authenticated user (from Bearer JWT)\n\nReturns:\n    Generated schema with metadata\n\nExample:\n    ```\n    POST /api/schema-generator/simple\n    {\n        \"message\": \"Extract party names, contract dates, and monetary amounts\",\n        \"schema_name\": \"ContractExtraction\",\n        \"extraction_instructions\": \"These are Polish legal contracts from 2020-2024\"\n    }\n    ```",
         "operationId": "generate_schema_simple_schema_generator_simple_post",
         "requestBody": {
           "content": {
@@ -31272,6 +31252,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "HTTPBearer": []
           }
         ],
         "summary": "Generate Schema Simple",
@@ -31282,7 +31265,7 @@
     },
     "/schema-generator/test": {
       "post": {
-        "description": "Test a schema against sample documents.\n\nThis endpoint runs the schema on specified documents and returns\nextraction results and statistics.\n\nArgs:\n    params: Test request with schema and document IDs\n    request: FastAPI request object\n\nReturns:\n    Test results with success/failure statistics\n\nExample:\n    ```\n    POST /api/schema-generator/test\n    {\n        \"schema\": {...},\n        \"collection_id\": \"drug-cases\",\n        \"document_ids\": [\"doc1\", \"doc2\", \"doc3\"]\n    }\n    ```",
+        "description": "Test a schema against sample documents.\n\nThis endpoint runs the schema on specified documents and returns\nextraction results and statistics.\n\nArgs:\n    params: Test request with schema and document IDs\n    request: FastAPI request object\n    user: Authenticated user (from Bearer JWT)\n\nReturns:\n    Test results with success/failure statistics\n\nExample:\n    ```\n    POST /api/schema-generator/test\n    {\n        \"schema\": {...},\n        \"collection_id\": \"drug-cases\",\n        \"document_ids\": [\"doc1\", \"doc2\", \"doc3\"]\n    }\n    ```",
         "operationId": "test_schema_schema_generator_test_post",
         "requestBody": {
           "content": {
@@ -31319,6 +31302,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "HTTPBearer": []
           }
         ],
         "summary": "Test Schema",


### PR DESCRIPTION
## Summary

The extraction routers (jobs **list/cancel/delete** and results **export**) authenticated via an `X-User-ID` header validated only for UUID *shape*. Anyone holding `BACKEND_API_KEY` could therefore read, stop, or delete **another user's** extraction jobs — and incur their per-job LLM cost. This is the follow-up to the collections-only Bearer migration in #209, applied to the most cost-exposed surface.

Mirrors the #209 pattern: extraction now consumes `app.core.auth_jwt.get_current_user` (Supabase Bearer JWT → `AuthenticatedUser`).

## Changes

**Backend**
- Delete the local `get_current_user(x_user_id)` dependency from `extraction_domain/shared.py` (plus now-unused `Header`/`uuid` imports).
- `jobs_router.py` (list/cancel/delete) and `results_router.py` (export) now depend on `app.core.auth_jwt.get_current_user`; `user.id` replaces the trusted header. Auth docstrings updated.
- Remove the stale `get_current_user` re-export from `extraction.py`.

**Frontend**
- All 9 proxies under `app/api/extractions/**` forward `Authorization: Bearer <access_token>` (via `supabase.auth.getSession()`) instead of `X-User-ID`.
- Incidental fix: the POST handler in `extractions/route.ts` was calling the already-migrated `/collections/{id}/documents` endpoint with `X-User-ID` (broken since #209) — now sends Bearer.

**Tests**
- New `test_extraction_bearer_auth.py` pins the contract: `X-User-ID` alone is now **rejected** (401/403); Bearer reaches the handler.
- `test_extraction_jobs_router.py` / `test_extraction_results_router.py` migrated to JWT override + Bearer; **cross-user impersonation tests preserved** (attacker authenticated as a different user → still 403).
- `test_extraction_shared.py`: removed the deleted-dependency unit tests.
- `test_rate_limiting.py`: dropped the now-meaningless `X-User-ID` auth simulation.

## Test plan

- `cd backend && poetry run pytest tests/app/test_extraction_bearer_auth.py tests/app/test_extraction_jobs_router.py tests/app/test_extraction_results_router.py tests/app/test_extraction_shared.py tests/app/test_rate_limiting.py` → **159 passed**
- `ruff check` + `ruff format --check` on changed files → clean
- `cd frontend && npm run validate` → passes (document-types + eslint)

## Out of scope / follow-ups
- The `/extract` submission endpoints don't use this dependency and are tracked separately for rate limiting (#167).
- Sibling header-trust gaps: publications (#231), playground (#232).

Fixes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)