### PR TITLE
fix(collections): cap batch add at 100 docs + single bulk upsert (fixes #166)

### DIFF
--- a/backend/app/collections.py
+++ b/backend/app/collections.py
@@ -199,7 +199,9 @@ class AddDocumentsRequest(BaseModel):
     """Request model for adding multiple documents to a collection."""
 
     document_ids: list[str] = Field(
-        description="List of document IDs to add", min_length=1
+        description="List of document IDs to add (max 100 per request)",
+        min_length=1,
+        max_length=100,
     )
 
     @field_validator("document_ids")
@@ -218,7 +220,7 @@ async def add_documents_batch(
     db=Depends(get_collections_db),
     user: AuthenticatedUser = Depends(get_current_user),
 ):
-    """Add multiple documents to a collection at once."""
+    """Add multiple documents to a collection at once (max 100 per request)."""
     # Validate collection_id
     try:
         collection_id = validate_id_format(collection_id, "collection_id")
@@ -226,16 +228,9 @@ async def add_documents_batch(
         logger.warning(f"Invalid collection_id format: {collection_id}")
         raise HTTPException(status_code=400, detail=str(e))
 
-    added = []
-    failed = []
-
-    for document_id in request.document_ids:
-        try:
-            await db.add_document(collection_id, document_id, user.id)
-            added.append(document_id)
-        except Exception as e:
-            logger.warning(f"Failed to add document {document_id}: {e}")
-            failed.append({"document_id": document_id, "error": str(e)})
+    result = await db.bulk_add_documents(collection_id, request.document_ids, user.id)
+    added = result["added"]
+    failed = result["failed"]
 
     return {
         "message": f"Added {len(added)} documents, {len(failed)} failed",

--- a/backend/packages/juddges_search/juddges_search/db/collections_db.py
+++ b/backend/packages/juddges_search/juddges_search/db/collections_db.py
@@ -248,6 +248,43 @@ class CollectionsDB(SupabaseClientMixin):
             logger.exception(f"Error adding judgment to collection: {e}")
             raise HTTPException(status_code=500, detail=f"Failed to add judgment: {str(e)}")
 
+    async def bulk_add_documents(self, collection_id: str, judgment_ids: List[str], user_id: str) -> Dict[str, Any]:
+        """Add multiple judgments to a collection in a single upsert.
+
+        Verifies collection ownership once (not per document), then performs
+        a multi-row upsert against ``collection_judgments`` with duplicate
+        rows silently ignored.
+
+        Returns a dict with keys ``added`` (list[str]) and ``failed``
+        (list[dict] with ``document_id`` and ``error`` keys).
+        """
+        # Ownership check — done once for the whole batch.
+        collection = await self.find_collection(collection_id, user_id)
+        if not collection:
+            raise HTTPException(status_code=404, detail="Collection not found")
+
+        if not judgment_ids:
+            return {"added": [], "failed": []}
+
+        rows = [{"collection_id": collection_id, "judgment_id": jid} for jid in judgment_ids]
+
+        try:
+            self.client.table("collection_judgments").upsert(
+                rows,
+                on_conflict="collection_id,judgment_id",
+                ignore_duplicates=True,
+            ).execute()
+
+            logger.info(f"Bulk-added {len(judgment_ids)} judgments to collection {collection_id}")
+            return {"added": list(judgment_ids), "failed": []}
+
+        except (PostgrestAPIError, StorageException) as e:
+            logger.exception(f"Bulk upsert failed for collection {collection_id}: {e}")
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to bulk-add judgments: {str(e)}",
+            )
+
     async def remove_document(self, collection_id: str, judgment_id: str, user_id: str) -> bool:
         collection = await self.find_collection(collection_id, user_id)
         if not collection:

--- a/backend/tests/app/test_collections_batch_cap.py
+++ b/backend/tests/app/test_collections_batch_cap.py
@@ -1,0 +1,179 @@
+"""
+Unit tests for the batch-add cap (issue #166).
+
+Exercises the ``POST /{collection_id}/documents/batch`` endpoint at the
+schema-validation and handler layers without hitting a real Supabase instance.
+The DB dependency is replaced by ``_StubCollectionsDb``, which mirrors the
+real ``bulk_add_documents`` return contract.
+"""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from juddges_search.db.supabase_db import get_collections_db
+
+from app.core.auth_jwt import AuthenticatedUser
+from app.core.auth_jwt import get_current_user as jwt_get_current_user
+from app.server import app
+
+pytestmark = [pytest.mark.anyio, pytest.mark.unit, pytest.mark.collections]
+
+_VALID_COLLECTION_ID = "00000000-0000-4000-a000-000000000001"
+_VALID_DOC_ID = "00000000-0000-4000-a000-000000000002"
+_VALID_API_HEADERS = {"X-API-Key": "test-api-key-12345"}
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class _StubCollectionsDb:
+    """Minimal stub: returns a canned bulk_add_documents result."""
+
+    async def find_collection(self, collection_id: str, user_id: str, **_kwargs):
+        # Return a minimal collection dict so ownership check passes.
+        return {"id": collection_id, "user_id": user_id}
+
+    async def bulk_add_documents(
+        self, collection_id: str, judgment_ids: list[str], user_id: str
+    ) -> dict:
+        return {"added": list(judgment_ids), "failed": []}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_user() -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_data={
+            "id": "00000000-0000-4000-a000-000000000abc",
+            "email": "batch-test@example.com",
+            "role": "authenticated",
+        },
+        access_token="fake-jwt-token",
+    )
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.fixture
+def override_deps(fake_user: AuthenticatedUser):
+    """Install both the JWT user stub and the DB stub, then clean up."""
+
+    async def _jwt_resolver() -> AuthenticatedUser:
+        return fake_user
+
+    async def _db_resolver() -> _StubCollectionsDb:
+        return _StubCollectionsDb()
+
+    app.dependency_overrides[jwt_get_current_user] = _jwt_resolver
+    app.dependency_overrides[get_collections_db] = _db_resolver
+    try:
+        yield fake_user
+    finally:
+        app.dependency_overrides.pop(jwt_get_current_user, None)
+        app.dependency_overrides.pop(get_collections_db, None)
+
+
+def _batch_url(collection_id: str = _VALID_COLLECTION_ID) -> str:
+    return f"/collections/{collection_id}/documents/batch"
+
+
+# ---------------------------------------------------------------------------
+# Tests — schema validation (no db interaction needed)
+# ---------------------------------------------------------------------------
+
+
+async def test_batch_rejects_empty_list(
+    client: AsyncClient, override_deps: AuthenticatedUser
+) -> None:
+    """Pydantic min_length=1 must reject an empty document_ids list."""
+    response = await client.post(
+        _batch_url(),
+        json={"document_ids": []},
+        headers=_VALID_API_HEADERS,
+    )
+    assert response.status_code == 422, (
+        f"Expected 422 for empty list; got {response.status_code}. Body: {response.text[:300]}"
+    )
+
+
+async def test_batch_accepts_single_document(
+    client: AsyncClient, override_deps: AuthenticatedUser
+) -> None:
+    """A list of 1 document must be accepted (min_length=1)."""
+    response = await client.post(
+        _batch_url(),
+        json={"document_ids": [_VALID_DOC_ID]},
+        headers=_VALID_API_HEADERS,
+    )
+    assert response.status_code == 200, (
+        f"Expected 200 for single document; got {response.status_code}. Body: {response.text[:300]}"
+    )
+    data = response.json()
+    assert data["total_requested"] == 1
+    assert len(data["added"]) == 1
+    assert data["failed"] == []
+
+
+async def test_batch_accepts_exactly_100_documents(
+    client: AsyncClient, override_deps: AuthenticatedUser
+) -> None:
+    """A list of exactly 100 documents must be accepted (max_length=100)."""
+    doc_ids = [f"00000000-0000-4000-a000-{i:012x}" for i in range(100)]
+    response = await client.post(
+        _batch_url(),
+        json={"document_ids": doc_ids},
+        headers=_VALID_API_HEADERS,
+    )
+    assert response.status_code == 200, (
+        f"Expected 200 for 100 documents; got {response.status_code}. Body: {response.text[:300]}"
+    )
+    data = response.json()
+    assert data["total_requested"] == 100
+    assert len(data["added"]) == 100
+    assert data["failed"] == []
+
+
+async def test_batch_rejects_101_documents(
+    client: AsyncClient, override_deps: AuthenticatedUser
+) -> None:
+    """Pydantic max_length=100 must reject a list of 101 document IDs with 422."""
+    doc_ids = [f"00000000-0000-4000-a000-{i:012x}" for i in range(101)]
+    response = await client.post(
+        _batch_url(),
+        json={"document_ids": doc_ids},
+        headers=_VALID_API_HEADERS,
+    )
+    assert response.status_code == 422, (
+        f"Expected 422 for 101 documents (over cap); got {response.status_code}. "
+        f"Body: {response.text[:300]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests — response shape
+# ---------------------------------------------------------------------------
+
+
+async def test_batch_response_contains_expected_keys(
+    client: AsyncClient, override_deps: AuthenticatedUser
+) -> None:
+    """Successful batch response must carry message/added/failed/total_requested."""
+    response = await client.post(
+        _batch_url(),
+        json={"document_ids": [_VALID_DOC_ID]},
+        headers=_VALID_API_HEADERS,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    for key in ("message", "added", "failed", "total_requested"):
+        assert key in data, f"Missing key '{key}' in response: {data}"


### PR DESCRIPTION
## Summary

- `AddDocumentsRequest.document_ids` now enforces `max_length=100` via Pydantic `Field`; payloads of 101+ document IDs are rejected with HTTP 422 before any DB interaction.
- Replaced the sequential `await db.add_document()` loop in `POST /{collection_id}/documents/batch` with a single `db.bulk_add_documents()` call — eliminates N round-trips to Supabase.
- Added `CollectionsDB.bulk_add_documents()`: verifies collection ownership **once** (not per row), then inserts all rows in a single multi-row upsert against `collection_judgments` (`collection_id` + `judgment_id` columns) with `ignore_duplicates=True` so re-adding existing judgments is a silent no-op.
- Response shape (`added`/`failed`/`message`/`total_requested`) is **unchanged** — no frontend changes required.

## Files changed

- `backend/app/collections.py` — `max_length=100` on `AddDocumentsRequest.document_ids`; endpoint now calls `bulk_add_documents`.
- `backend/packages/juddges_search/juddges_search/db/collections_db.py` — new `bulk_add_documents()` method.
- `backend/tests/app/test_collections_batch_cap.py` — five new unit tests (all pass, no real DB needed).

## Table / column names used

Table: `collection_judgments` · Columns: `collection_id`, `judgment_id`  
Conflict key for upsert: `collection_id,judgment_id`

## Test plan

- [x] `poetry run pytest tests/app/test_collections_batch_cap.py -q` → 5/5 pass
- [x] `poetry run pytest tests/app/test_collections_bearer_auth.py -q` → 3/3 pass (no regression)
- [x] `poetry run ruff check` + `ruff format` → clean on all changed files
- [ ] Integration: `POST /{id}/documents/batch` with 100 IDs → single Supabase upsert in DB logs
- [ ] Integration: `POST /{id}/documents/batch` with 101 IDs → HTTP 422

Fixes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)