### PR TITLE
chore(deps): clear remaining moderate npm audit advisories

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12179,15 +12179,6 @@
         "node": ">=8.3.0"
       }
     },
-    "node_modules/exceljs/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -17461,52 +17452,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -18375,7 +18320,6 @@
       "version": "8.5.12",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
       "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -18404,7 +18348,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -21383,9 +21326,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.1.tgz",
-      "integrity": "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -181,7 +181,9 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "ws": "^8.20.1",
-    "markdown-it": "^14.2.0"
+    "markdown-it": "^14.2.0",
+    "postcss": "^8.5.10",
+    "uuid": "^13.0.1"
   },
   "optionalDependencies": {
     "lightningcss-linux-arm64-musl": "^1.30.1",


### PR DESCRIPTION
Follow-on to #239 (which cleared the two HIGH advisories). Brings the **production** `npm audit` to **0 vulnerabilities** (was 4 moderate).

## Changes (`frontend/package.json` overrides)
Following the existing `ws` / `markdown-it` override pattern:

- **`postcss: ^8.5.10`** — patches the XSS-via-CSS-stringify advisory (GHSA-qx2v-qp2m-jg93) bundled inside `next`. Safe patch within next's supported postcss 8.x → resolves to 8.5.12.
- **`uuid: ^13.0.1`** — forces `exceljs`'s nested `uuid 8.3.2` (flagged by GHSA-w5hq-g745-h8pq) up to the version the app **already uses directly**, deduping to a single uuid 13. exceljs imports `const {v4} = require('uuid')` (modern named export, stable v8→v13).

## Why this is safe
- exceljs uses the modern named-export uuid API (not deep `uuid/v4` imports that broke in v7), so the v8→v13 bump is API-compatible.
- Runtime smoke test: `new ExcelJS.Workbook(); … xlsx.writeBuffer()` → succeeds with uuid 13.
- `next` is already at 15.5.19 (latest 15.x) from #239 — no further next bump needed.

## Verification
- `npm audit --omit=dev` → **found 0 vulnerabilities**
- `npx tsc --noEmit` → clean
- `npm run build` → success
- exceljs xlsx export smoke test → passes

Remaining audit noise (37 moderate) is **dev-only tooling**, outside the production tree; the CI gate (`npm audit --production --audit-level=high`) is satisfied.