### PR TITLE
security(research-agent): enforce session ownership on read/stop/stream (fixes #211)

### DIFF
--- a/backend/app/api/research_agent.py
+++ b/backend/app/api/research_agent.py
@@ -20,7 +20,7 @@ from fastapi.responses import StreamingResponse
 from loguru import logger
 from pydantic import BaseModel, Field
 
-from app.core.auth_jwt import AuthenticatedUser, get_optional_user
+from app.core.auth_jwt import AuthenticatedUser, get_current_user
 from app.core.supabase import get_supabase_client
 from app.models import validate_id_format
 
@@ -241,12 +241,12 @@ def _now_iso() -> str:
 )
 async def start_session(
     request: StartSessionRequest,
-    current_user: AuthenticatedUser | None = Depends(get_optional_user),
+    current_user: AuthenticatedUser = Depends(get_current_user),
 ) -> StartSessionResponse:
     """Create a research session and launch the agent in the background."""
     from research_agent.persistence import ResearchMode, ResearchSession
 
-    user_id = current_user.id if current_user else "anonymous"
+    user_id = current_user.id
     session_id = str(uuid.uuid4())
 
     session_store, _ = _get_persistence()
@@ -279,7 +279,7 @@ async def start_session(
 )
 async def get_session(
     session_id: str,
-    current_user: AuthenticatedUser | None = Depends(get_optional_user),
+    current_user: AuthenticatedUser = Depends(get_current_user),
 ) -> SessionResponse:
     """Read a research session by ID."""
     try:
@@ -290,6 +290,10 @@ async def get_session(
     session_store, _ = _get_persistence()
     session = await session_store.get_session(session_id)
     if session is None:
+        raise HTTPException(status_code=404, detail="Session not found.")
+
+    # Return 404 (not 403) to avoid disclosing that the session exists to other users.
+    if session.user_id != current_user.id:
         raise HTTPException(status_code=404, detail="Session not found.")
 
     return SessionResponse(
@@ -314,7 +318,7 @@ async def get_session(
 )
 async def stream_session(
     session_id: str,
-    current_user: AuthenticatedUser | None = Depends(get_optional_user),
+    current_user: AuthenticatedUser = Depends(get_current_user),
 ):
     """Return an SSE stream that emits progress events for the given session."""
     try:
@@ -322,8 +326,17 @@ async def stream_session(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-    queue: asyncio.Queue = asyncio.Queue(maxsize=256)
-    _session_event_queues.setdefault(session_id, []).append(queue)
+    # Verify ownership BEFORE registering any SSE queue to avoid existence disclosure.
+    session_store, _ = _get_persistence()
+    session = await session_store.get_session(session_id)
+    if session is None or session.user_id != current_user.id:
+        raise HTTPException(status_code=404, detail="Session not found.")
+
+    queue: asyncio.Queue = asyncio.Queue(maxsize=100)
+    queues = _session_event_queues.setdefault(session_id, [])
+    # Evict stale full queues before appending to avoid unbounded growth.
+    _session_event_queues[session_id] = [q for q in queues if not q.full()]
+    _session_event_queues[session_id].append(queue)
 
     async def _event_generator():
         try:
@@ -364,13 +377,18 @@ async def stream_session(
 async def send_message(
     session_id: str,
     request: SendMessageRequest,
-    current_user: AuthenticatedUser | None = Depends(get_optional_user),
+    current_user: AuthenticatedUser = Depends(get_current_user),
 ) -> dict[str, str]:
     """Placeholder for interrupt-resume: accepts user input at a decision point."""
     try:
         validate_id_format(session_id, "session_id")
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+    session_store, _ = _get_persistence()
+    session = await session_store.get_session(session_id)
+    if session is None or session.user_id != current_user.id:
+        raise HTTPException(status_code=404, detail="Session not found.")
 
     logger.info(
         "Received user message for session {}: {}",
@@ -386,13 +404,19 @@ async def send_message(
 )
 async def stop_session(
     session_id: str,
-    current_user: AuthenticatedUser | None = Depends(get_optional_user),
+    current_user: AuthenticatedUser = Depends(get_current_user),
 ) -> dict[str, str]:
     """Cancel the running agent task and mark the session as stopped."""
     try:
         validate_id_format(session_id, "session_id")
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+    # Verify ownership before revealing whether the session/task exists.
+    session_store, _ = _get_persistence()
+    session = await session_store.get_session(session_id)
+    if session is None or session.user_id != current_user.id:
+        raise HTTPException(status_code=404, detail="Session not found.")
 
     task = _running_sessions.get(session_id)
     if task is None:
@@ -417,12 +441,12 @@ async def stop_session(
     summary="List user's research sessions",
 )
 async def list_sessions(
-    current_user: AuthenticatedUser | None = Depends(get_optional_user),
+    current_user: AuthenticatedUser = Depends(get_current_user),
     limit: int = Query(20, ge=1, le=100, description="Max sessions to return"),
     offset: int = Query(0, ge=0, description="Pagination offset"),
 ) -> list[SessionResponse]:
     """List research sessions for the current user."""
-    user_id = current_user.id if current_user else "anonymous"
+    user_id = current_user.id
 
     session_store, _ = _get_persistence()
     sessions = await session_store.list_sessions(user_id, limit=limit, offset=offset)

--- a/backend/tests/app/test_research_agent.py
+++ b/backend/tests/app/test_research_agent.py
@@ -1,0 +1,246 @@
+"""
+Unit tests for IDOR security fixes on /research-agent endpoints (fixes #211).
+
+Verifies:
+- All session-scoped endpoints require authentication (401/403 when no token).
+- User B gets 404 (not 403) when accessing User A's session, to avoid
+  existence disclosure.
+- start_session requires authentication (anonymous sessions disabled).
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.auth import verify_api_key
+from app.core.auth_jwt import AuthenticatedUser
+from app.core.auth_jwt import get_current_user as jwt_get_current_user
+from app.server import app
+
+pytestmark = [pytest.mark.anyio, pytest.mark.unit, pytest.mark.security]
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_TEST_API_KEY = "test-api-key-12345"
+_USER_A_ID = "aaaaaaaa-0000-4000-a000-000000000001"
+_USER_B_ID = "bbbbbbbb-0000-4000-b000-000000000002"
+_VALID_SESSION_ID = str(uuid.uuid4())
+
+# ---------------------------------------------------------------------------
+# Helpers / stubs
+# ---------------------------------------------------------------------------
+
+
+def _make_user(user_id: str) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_data={
+            "id": user_id,
+            "email": f"{user_id[:8]}@example.com",
+            "role": "authenticated",
+        },
+        access_token="fake-test-token",
+    )
+
+
+def _make_session_stub(owner_id: str):
+    """Return a minimal session-like object owned by *owner_id*."""
+    session = MagicMock()
+    session.id = _VALID_SESSION_ID
+    session.user_id = owner_id
+    session.mode = "guided"
+    session.initial_query = "test query"
+    session.status = "planning"
+    session.findings = []
+    session.decision_points = []
+    session.report = None
+    created = MagicMock()
+    created.isoformat.return_value = "2026-06-19T00:00:00+00:00"
+    session.created_at = created
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.fixture
+def api_key_headers() -> dict[str, str]:
+    """Headers containing a valid API key (bypassed via override)."""
+    return {"X-API-Key": _TEST_API_KEY}
+
+
+@pytest.fixture
+def override_api_key():
+    """Override verify_api_key so API key auth is bypassed."""
+
+    async def _pass():
+        return _TEST_API_KEY
+
+    app.dependency_overrides[verify_api_key] = _pass
+    yield
+    app.dependency_overrides.pop(verify_api_key, None)
+
+
+@pytest.fixture
+def install_user_b(override_api_key):
+    """Override JWT dep to authenticate as User B (also bypasses API key check)."""
+
+    async def _resolver() -> AuthenticatedUser:
+        return _make_user(_USER_B_ID)
+
+    app.dependency_overrides[jwt_get_current_user] = _resolver
+    yield
+    app.dependency_overrides.pop(jwt_get_current_user, None)
+
+
+# ---------------------------------------------------------------------------
+# 401/403 Tests — unauthenticated requests must be rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method, path",
+    [
+        ("POST", "/research-agent/sessions"),
+        ("GET", f"/research-agent/sessions/{_VALID_SESSION_ID}"),
+        ("GET", f"/research-agent/sessions/{_VALID_SESSION_ID}/stream"),
+        ("POST", f"/research-agent/sessions/{_VALID_SESSION_ID}/message"),
+        ("POST", f"/research-agent/sessions/{_VALID_SESSION_ID}/stop"),
+        ("GET", "/research-agent/sessions"),
+    ],
+)
+async def test_unauthenticated_returns_401_or_403(
+    client: AsyncClient,
+    override_api_key,
+    method: str,
+    path: str,
+) -> None:
+    """Every session endpoint must return 401/403 when no Bearer token is supplied.
+
+    The API key is bypassed via override so we're testing only the JWT layer.
+    FastAPI's HTTPBearer returns 403 (Forbidden) when credentials are absent;
+    either 401 or 403 is acceptable as an "unauthenticated" rejection.
+    """
+    kwargs: dict = {}
+    if method == "POST" and path == "/research-agent/sessions":
+        kwargs["json"] = {"query": "test query for auth check"}
+    elif method == "POST" and path.endswith("/message"):
+        kwargs["json"] = {"message": "hello"}
+
+    response = await client.request(method, path, **kwargs)
+
+    assert response.status_code in (401, 403), (
+        f"{method} {path} should reject unauthenticated requests; "
+        f"got {response.status_code}: {response.text}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 404 Tests — User B accessing User A's session must get 404, not 200/403
+# ---------------------------------------------------------------------------
+
+
+async def test_get_session_wrong_user_returns_404(
+    client: AsyncClient,
+    install_user_b,
+) -> None:
+    """GET /sessions/{id}: User B gets 404 on User A's session (no existence disclosure)."""
+    session_owned_by_a = _make_session_stub(owner_id=_USER_A_ID)
+
+    with _patch_persistence(get_session_return=session_owned_by_a):
+        response = await client.get(f"/research-agent/sessions/{_VALID_SESSION_ID}")
+
+    assert response.status_code == 404, (
+        f"Expected 404 for wrong-user access, got {response.status_code}: {response.text}"
+    )
+
+
+async def test_stream_session_wrong_user_returns_404(
+    client: AsyncClient,
+    install_user_b,
+) -> None:
+    """GET /sessions/{id}/stream: User B gets 404 on User A's session."""
+    session_owned_by_a = _make_session_stub(owner_id=_USER_A_ID)
+
+    with _patch_persistence(get_session_return=session_owned_by_a):
+        response = await client.get(
+            f"/research-agent/sessions/{_VALID_SESSION_ID}/stream"
+        )
+
+    assert response.status_code == 404, (
+        f"Expected 404 for wrong-user SSE stream, got {response.status_code}: {response.text}"
+    )
+
+
+async def test_send_message_wrong_user_returns_404(
+    client: AsyncClient,
+    install_user_b,
+) -> None:
+    """POST /sessions/{id}/message: User B gets 404 on User A's session."""
+    session_owned_by_a = _make_session_stub(owner_id=_USER_A_ID)
+
+    with _patch_persistence(get_session_return=session_owned_by_a):
+        response = await client.post(
+            f"/research-agent/sessions/{_VALID_SESSION_ID}/message",
+            json={"message": "inject!"},
+        )
+
+    assert response.status_code == 404, (
+        f"Expected 404 for wrong-user message, got {response.status_code}: {response.text}"
+    )
+
+
+async def test_stop_session_wrong_user_returns_404(
+    client: AsyncClient,
+    install_user_b,
+) -> None:
+    """POST /sessions/{id}/stop: User B gets 404 on User A's session."""
+    session_owned_by_a = _make_session_stub(owner_id=_USER_A_ID)
+
+    with _patch_persistence(get_session_return=session_owned_by_a):
+        response = await client.post(
+            f"/research-agent/sessions/{_VALID_SESSION_ID}/stop"
+        )
+
+    assert response.status_code == 404, (
+        f"Expected 404 for wrong-user stop, got {response.status_code}: {response.text}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _patch_persistence(get_session_return=None, list_sessions_return=None):
+    """Context manager that stubs _get_persistence() in the router."""
+    import contextlib
+
+    store = AsyncMock()
+    store.get_session.return_value = get_session_return
+    store.list_sessions.return_value = list_sessions_return or []
+    store.create_session.return_value = None
+
+    @contextlib.contextmanager
+    def _ctx():
+        with patch(
+            "app.api.research_agent._get_persistence",
+            return_value=(store, AsyncMock()),
+        ):
+            yield store
+
+    return _ctx()


### PR DESCRIPTION
## Summary

- Replace `get_optional_user` with `get_current_user` on all session-scoped endpoints (`GET /sessions/{id}`, `POST /sessions/{id}/message`, `POST /sessions/{id}/stop`, `GET /sessions/{id}/stream`, `GET /sessions`, `POST /sessions`)
- Add session ownership check returning **404** (not 403) before serving any session data or registering SSE event queues — 404 avoids telling an attacker whether a session exists
- Require authentication on `start_session` to prevent anonymous LLM cost abuse (unbounded background tasks with no owner)
- Cap `asyncio.Queue` to `maxsize=100` and evict stale full queues before appending new SSE subscribers

## Security design decisions

**404 vs 403 on wrong-user access:** returning 403 discloses that the session exists. 404 is the correct response to avoid IDOR existence disclosure — an attacker learns nothing about sessions they don't own.

**Anonymous start_session disabled:** the previous code silently assigned `user_id = "anonymous"` for unauthenticated callers. This allowed any internet client to launch unbounded LLM agent tasks at service cost with no accountability. All session creation now requires a valid Bearer JWT.

**SSE ownership check before queue registration:** the ownership guard is placed _before_ `_session_event_queues.setdefault(...)` so a rejected request never registers a dangling queue.

## Test plan

- [x] `test_unauthenticated_returns_401_or_403` — parametrized across all 6 endpoints, verifies no Bearer token → 401/403
- [x] `test_get_session_wrong_user_returns_404` — User B → 404 on User A's session
- [x] `test_stream_session_wrong_user_returns_404` — User B → 404 on SSE stream
- [x] `test_send_message_wrong_user_returns_404` — User B → 404 on message endpoint
- [x] `test_stop_session_wrong_user_returns_404` — User B → 404 on stop endpoint
- [x] All 10 tests pass (`poetry run pytest tests/app/test_research_agent.py -v`)
- [x] `ruff check` + `ruff format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)