### PR TITLE
security(playground): migrate auth from X-User-ID to Supabase Bearer JWT (fixes #232)

### DIFF
--- a/backend/app/playground.py
+++ b/backend/app/playground.py
@@ -10,13 +10,14 @@ import time
 from datetime import UTC, datetime
 from typing import Any, Literal
 
-from fastapi import APIRouter, Header, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from juddges_search.info_extraction.extractor import InformationExtractor
 from juddges_search.info_extraction.schema_utils import prepare_schema_from_db
 from juddges_search.llms import get_llm
 from loguru import logger
 from pydantic import BaseModel, Field
 
+from app.core.auth_jwt import AuthenticatedUser, get_current_user
 from app.core.supabase import get_supabase_client
 from app.utils.judgment_fetcher import get_documents_by_id
 
@@ -241,7 +242,7 @@ def _save_playground_run(
 )
 async def playground_extract(
     request: PlaygroundExtractionRequest,
-    x_user_id: str = Header(..., alias="X-User-ID"),
+    user: AuthenticatedUser = Depends(get_current_user),
 ) -> PlaygroundExtractionResponse:
     """
     Run synchronous extraction for playground testing.
@@ -267,12 +268,13 @@ async def playground_extract(
     - timing: Detailed timing breakdown
     - schema info and document metadata
     """
+    user_id = user.id
     start_time = time.time()
     started_at = datetime.now(UTC).isoformat()
 
     logger.info(
         f"Playground extraction started: schema={request.schema_id}, "
-        f"doc={request.document_id}, user={x_user_id}"
+        f"doc={request.document_id}, user={user_id}"
     )
 
     try:
@@ -358,7 +360,7 @@ async def playground_extract(
             schema_id=request.schema_id,
             schema_version_id=version_id or request.schema_version_id,
             document_id=request.document_id,
-            user_id=x_user_id,
+            user_id=user_id,
             extraction_result=extracted_data or {},
             execution_time_ms=int(total_ms),
             status="completed",
@@ -409,7 +411,7 @@ async def playground_extract(
             schema_id=request.schema_id,
             schema_version_id=request.schema_version_id,
             document_id=request.document_id,
-            user_id=x_user_id,
+            user_id=user_id,
             extraction_result={},
             execution_time_ms=int(total_ms),
             status="failed",
@@ -457,7 +459,7 @@ async def playground_extract(
 async def list_playground_runs(
     schema_id: str,
     limit: int = 20,
-    x_user_id: str = Header(..., alias="X-User-ID"),
+    user: AuthenticatedUser = Depends(get_current_user),
 ) -> list[PlaygroundTestRun]:
     """
     List recent playground test runs for a schema.
@@ -465,6 +467,7 @@ async def list_playground_runs(
     Returns the most recent test runs for the specified schema,
     useful for reviewing extraction history and comparing results.
     """
+    user_id = user.id
     if not supabase:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -478,7 +481,7 @@ async def list_playground_runs(
                 "id, schema_id, schema_version_id, document_id, status, execution_time_ms, created_at"
             )
             .eq("schema_id", schema_id)
-            .eq("user_id", x_user_id)
+            .eq("user_id", user_id)
             .order("created_at", desc=True)
             .limit(limit)
             .execute()
@@ -514,13 +517,14 @@ async def list_playground_runs(
 )
 async def get_playground_run(
     run_id: str,
-    x_user_id: str = Header(..., alias="X-User-ID"),
+    user: AuthenticatedUser = Depends(get_current_user),
 ) -> dict[str, Any]:
     """
     Get full details of a specific playground test run.
 
     Returns the complete extraction result and metadata for a test run.
     """
+    user_id = user.id
     if not supabase:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -536,7 +540,7 @@ async def get_playground_run(
                 "schema_name, schema_version, document_title, created_at"
             )
             .eq("id", run_id)
-            .eq("user_id", x_user_id)
+            .eq("user_id", user_id)
             .single()
             .execute()
         )

--- a/backend/tests/app/conftest.py
+++ b/backend/tests/app/conftest.py
@@ -29,12 +29,12 @@ from app.server import app
 
 
 def _install_jwt_user_override(user_id: str) -> None:
-    """Override the Supabase Bearer dep so /collections tests can keep using
-    the legacy X-User-ID-style fixtures (which never carried a real JWT).
+    """Override the Supabase Bearer dep so JWT-migrated routers can be tested
+    without a real Supabase token.
 
-    Publications, playground, and extraction routers still consume X-User-ID
-    via their own ``get_current_user`` deps, so this override does not affect
-    them.
+    Covers /collections (PR #209) and /playground (PR #232). Publications and
+    extraction routers still consume X-User-ID via their own deps, so this
+    override does not affect them.
     """
 
     async def _resolver() -> AuthenticatedUser:
@@ -99,9 +99,9 @@ async def authenticated_client(
     """
     Create an authenticated async HTTP client with valid API key and user header.
 
-    Installs the Bearer-JWT override for /collections (the router migrated to
-    Supabase JWT in PR-for-#209) while keeping X-User-ID for legacy routers
-    (publications, playground, extraction).
+    Installs the Bearer-JWT override for /collections (#209) and /playground
+    (#232) while keeping X-User-ID for legacy routers (publications,
+    extraction).
     """
     headers = {**valid_api_headers, "X-User-ID": mock_user["id"]}
 

--- a/backend/tests/app/test_playground_bearer_auth.py
+++ b/backend/tests/app/test_playground_bearer_auth.py
@@ -1,0 +1,289 @@
+"""
+Tests pinning the Bearer-JWT auth contract on /playground endpoints.
+
+These tests document the migration from header-trusted ``X-User-ID`` to
+Supabase Bearer JWT (issue #232). They are written to fail against the legacy
+``x_user_id: str = Header(...)`` parameter and pass once each handler consumes
+``app.core.auth_jwt.get_current_user`` via ``Depends``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.core.auth_jwt import AuthenticatedUser
+from app.core.auth_jwt import get_current_user as jwt_get_current_user
+from app.server import app
+
+pytestmark = [pytest.mark.anyio, pytest.mark.unit, pytest.mark.security]
+
+
+@pytest.fixture
+def valid_api_headers() -> dict[str, str]:
+    return {"X-API-Key": "test-api-key-12345"}
+
+
+@pytest.fixture
+def fake_user() -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_data={
+            "id": "00000000-0000-4000-a000-000000000abc",
+            "email": "bearer-user@example.com",
+            "role": "authenticated",
+        },
+        access_token="fake-jwt-token",
+    )
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.fixture
+def override_jwt_user(fake_user: AuthenticatedUser):
+    """Override the JWT dependency to return a stable test user."""
+
+    async def _resolver() -> AuthenticatedUser:
+        return fake_user
+
+    app.dependency_overrides[jwt_get_current_user] = _resolver
+    try:
+        yield fake_user
+    finally:
+        app.dependency_overrides.pop(jwt_get_current_user, None)
+
+
+# ---------------------------------------------------------------------------
+# POST /playground/extract — prompt run endpoint
+# ---------------------------------------------------------------------------
+
+
+async def test_playground_extract_rejects_x_user_id_without_bearer(
+    client: AsyncClient, valid_api_headers: dict[str, str]
+) -> None:
+    """X-User-ID alone must no longer authenticate POST /playground/extract."""
+    headers = {**valid_api_headers, "X-User-ID": "00000000-0000-4000-a000-000000000abc"}
+
+    response = await client.post(
+        "/playground/extract",
+        headers=headers,
+        json={
+            "schema_id": "schema-uuid-1",
+            "document_id": "doc-1",
+        },
+    )
+
+    assert response.status_code in (401, 403), (
+        f"Expected 401/403 when only X-User-ID is supplied; got {response.status_code}. "
+        "Bearer JWT is now required."
+    )
+
+
+async def test_playground_extract_missing_all_auth_returns_unauthorized(
+    client: AsyncClient, valid_api_headers: dict[str, str]
+) -> None:
+    """API key alone (no Bearer, no X-User-ID) must be rejected."""
+    response = await client.post(
+        "/playground/extract",
+        headers=valid_api_headers,
+        json={
+            "schema_id": "schema-uuid-1",
+            "document_id": "doc-1",
+        },
+    )
+
+    assert response.status_code in (401, 403), (
+        f"Expected 401/403 when no user credential is supplied; got {response.status_code}."
+    )
+
+
+async def test_playground_extract_accepts_bearer_jwt(
+    client: AsyncClient,
+    valid_api_headers: dict[str, str],
+    override_jwt_user: AuthenticatedUser,
+) -> None:
+    """A Bearer-authenticated request reaches the handler (not rejected at auth layer)."""
+    headers = {
+        **valid_api_headers,
+        "Authorization": "Bearer fake-jwt-token",
+    }
+
+    # Patch both supabase and the document/extractor so the handler doesn't
+    # need real services — we only care that the auth layer admits the request.
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value.data = {
+        "name": "TestSchema",
+        "description": "desc",
+        "text": {"field1": "string"},
+        "schema_version": 1,
+    }
+
+    with (
+        patch("app.playground.supabase", mock_supabase),
+        patch(
+            "app.playground.get_documents_by_id",
+            return_value=[],
+        ),
+    ):
+        response = await client.post(
+            "/playground/extract",
+            headers=headers,
+            json={
+                "schema_id": "schema-uuid-1",
+                "document_id": "doc-1",
+            },
+        )
+
+    # Auth passed; document-not-found 404 is fine — it means we got past the
+    # auth layer and into the handler.
+    assert response.status_code != 401, (
+        f"Bearer auth path returned 401; expected handler-level response. "
+        f"Body: {response.text[:300]}"
+    )
+    assert response.status_code != 403, (
+        f"Bearer auth path returned 403; expected handler-level response. "
+        f"Body: {response.text[:300]}"
+    )
+    assert response.status_code != 422, (
+        f"Bearer auth path returned 422 (schema validation error). "
+        f"Body: {response.text[:300]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /playground/runs — list history endpoint
+# ---------------------------------------------------------------------------
+
+
+async def test_playground_runs_rejects_x_user_id_without_bearer(
+    client: AsyncClient, valid_api_headers: dict[str, str]
+) -> None:
+    """X-User-ID alone must no longer authenticate GET /playground/runs."""
+    headers = {**valid_api_headers, "X-User-ID": "00000000-0000-4000-a000-000000000abc"}
+
+    response = await client.get(
+        "/playground/runs",
+        headers=headers,
+        params={"schema_id": "schema-uuid-1"},
+    )
+
+    assert response.status_code in (401, 403), (
+        f"Expected 401/403 when only X-User-ID is supplied; got {response.status_code}."
+    )
+
+
+async def test_playground_runs_missing_all_auth_returns_unauthorized(
+    client: AsyncClient, valid_api_headers: dict[str, str]
+) -> None:
+    """API key alone (no Bearer, no X-User-ID) must be rejected."""
+    response = await client.get(
+        "/playground/runs",
+        headers=valid_api_headers,
+        params={"schema_id": "schema-uuid-1"},
+    )
+
+    assert response.status_code in (401, 403), (
+        f"Expected 401/403 when no user credential is supplied; got {response.status_code}."
+    )
+
+
+async def test_playground_runs_accepts_bearer_jwt(
+    client: AsyncClient,
+    valid_api_headers: dict[str, str],
+    override_jwt_user: AuthenticatedUser,
+) -> None:
+    """A Bearer-authenticated request reaches the handler for GET /playground/runs."""
+    headers = {
+        **valid_api_headers,
+        "Authorization": "Bearer fake-jwt-token",
+    }
+
+    mock_supabase = MagicMock()
+    mock_resp = MagicMock()
+    mock_resp.data = []
+    (
+        mock_supabase.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value
+    ) = mock_resp
+
+    with patch("app.playground.supabase", mock_supabase):
+        response = await client.get(
+            "/playground/runs",
+            headers=headers,
+            params={"schema_id": "schema-uuid-1"},
+        )
+
+    assert response.status_code == 200, (
+        f"Bearer auth path returned {response.status_code}; expected 200. "
+        f"Body: {response.text[:300]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /playground/runs/{run_id} — get run detail endpoint
+# ---------------------------------------------------------------------------
+
+
+async def test_playground_run_detail_rejects_x_user_id_without_bearer(
+    client: AsyncClient, valid_api_headers: dict[str, str]
+) -> None:
+    """X-User-ID alone must no longer authenticate GET /playground/runs/{run_id}."""
+    headers = {**valid_api_headers, "X-User-ID": "00000000-0000-4000-a000-000000000abc"}
+
+    response = await client.get(
+        "/playground/runs/some-run-id",
+        headers=headers,
+    )
+
+    assert response.status_code in (401, 403), (
+        f"Expected 401/403 when only X-User-ID is supplied; got {response.status_code}."
+    )
+
+
+async def test_playground_run_detail_missing_all_auth_returns_unauthorized(
+    client: AsyncClient, valid_api_headers: dict[str, str]
+) -> None:
+    """API key alone (no Bearer, no X-User-ID) must be rejected."""
+    response = await client.get(
+        "/playground/runs/some-run-id",
+        headers=valid_api_headers,
+    )
+
+    assert response.status_code in (401, 403), (
+        f"Expected 401/403 when no user credential is supplied; got {response.status_code}."
+    )
+
+
+async def test_playground_run_detail_accepts_bearer_jwt(
+    client: AsyncClient,
+    valid_api_headers: dict[str, str],
+    override_jwt_user: AuthenticatedUser,
+) -> None:
+    """A Bearer-authenticated request reaches the handler for GET /playground/runs/{run_id}."""
+    headers = {
+        **valid_api_headers,
+        "Authorization": "Bearer fake-jwt-token",
+    }
+
+    mock_supabase = MagicMock()
+    mock_resp = MagicMock()
+    mock_resp.data = None
+    (
+        mock_supabase.table.return_value.select.return_value.eq.return_value.eq.return_value.single.return_value.execute.return_value
+    ) = mock_resp
+
+    with patch("app.playground.supabase", mock_supabase):
+        response = await client.get(
+            "/playground/runs/some-run-id",
+            headers=headers,
+        )
+
+    # 404 (run not found with stubbed DB) means auth was accepted and the
+    # handler ran — which is what we're testing.
+    assert response.status_code not in (401, 403, 422), (
+        f"Bearer auth path returned {response.status_code}; expected handler-level response. "
+        f"Body: {response.text[:300]}"
+    )


### PR DESCRIPTION
## Summary

- **`backend/app/playground.py`**: replaced the three `x_user_id: str = Header(..., alias="X-User-ID")` parameters on `playground_extract`, `list_playground_runs`, and `get_playground_run` with `user: AuthenticatedUser = Depends(get_current_user)`. Added `user_id = user.id` as the first statement of each handler body so all downstream `user_id` references remain unchanged. Removed the now-unused `Header` import and added the `Depends` + `auth_jwt` imports.
- **`backend/tests/app/test_playground_bearer_auth.py`** (new): 9 unit tests pinning the Bearer-JWT contract for all three endpoints — X-User-ID alone → 401/403, no auth → 401/403, Bearer → handler-level response. Mirrors `test_collections_bearer_auth.py`.
- **`backend/tests/app/conftest.py`**: updated stale docstrings in `_install_jwt_user_override` and `authenticated_client` to reflect that playground is now also migrated.
- **Frontend**: no frontend playground proxy routes exist under `frontend/app/api/playground/`; no changes required.

## Test plan

- [ ] `poetry run pytest tests/app/test_playground_bearer_auth.py tests/app/test_playground.py -q` — all 27 tests pass
- [ ] `poetry run ruff check app/playground.py tests/app/test_playground_bearer_auth.py` — clean
- [ ] `poetry run ruff format` — no changes
- [ ] Pre-commit hooks (ruff, ruff-format, trailing whitespace, large files, private key detection) — all passed on commit

Fixes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)