### PR TITLE
security(extraction): enforce ownership on GET /extractions/{job_id} (IDOR)

### DIFF
--- a/backend/app/extraction_domain/jobs_router.py
+++ b/backend/app/extraction_domain/jobs_router.py
@@ -704,6 +704,41 @@ async def create_bulk_extraction(
         )
 
 
+def _verify_job_ownership(job_id: str, user_id: str) -> None:
+    """Enforce per-user ownership on extraction job reads.
+
+    Raises 403 if the job has a database record owned by a different user.
+    Enforced only when the job is recorded and the database is reachable:
+    unknown ids carry no user data to leak, and transient DB/lookup errors
+    degrade to the prior behaviour rather than blocking status polling.
+    """
+    if supabase is None:
+        return
+    try:
+        owner = (
+            supabase.table("extraction_jobs")
+            .select("user_id")
+            .eq("job_id", job_id)
+            .single()
+            .execute()
+        )
+    except Exception as lookup_error:
+        # Never block status polling on transient DB/lookup errors; degrade to
+        # the prior behaviour rather than failing the request.
+        logger.warning(f"Ownership check skipped for job {job_id}: {lookup_error}")
+        return
+
+    owner_id = (owner.data or {}).get("user_id") if owner.data else None
+    if owner_id is not None and owner_id != user_id:
+        logger.warning(
+            f"User {user_id} attempted to read job {job_id} owned by another user"
+        )
+        raise HTTPException(
+            status_code=403,
+            detail="You do not have permission to view this job",
+        )
+
+
 @router.get(
     "/{job_id}",
     response_model=BatchExtractionResponse,
@@ -712,6 +747,7 @@ async def create_bulk_extraction(
 )
 async def get_extraction_job(
     job_id: str = Path(..., description="Extraction job ID (task ID)"),
+    user: AuthenticatedUser = Depends(get_current_user),
 ) -> BatchExtractionResponse:
     """
     Get extraction job status and results.
@@ -727,6 +763,7 @@ async def get_extraction_job(
     - **CANCELLED**: Job was cancelled
     """
     try:
+        _verify_job_ownership(job_id, user.id)
         task_result = AsyncResult(id=job_id, app=celery_app)
         task_state = _safe_get_task_state(task_result, job_id)
         if task_state is None:

--- a/backend/tests/app/test_extraction_jobs_router.py
+++ b/backend/tests/app/test_extraction_jobs_router.py
@@ -335,7 +335,8 @@ class TestGetExtractionJobEndpoint:
 
     @pytest.mark.unit
     async def test_pending_job(self, client, valid_api_headers) -> None:
-        """Test retrieving a pending job."""
+        """Test retrieving a pending job (ownership check degrades when DB is down)."""
+        _install_jwt_user_override(_USER_001)
         mock_result = MagicMock()
         mock_result.state = "PENDING"
         mock_result.info = None
@@ -348,7 +349,8 @@ class TestGetExtractionJobEndpoint:
             patch("app.extraction_domain.jobs_router.supabase", None),
         ):
             response = await client.get(
-                "/extractions/job-123", headers=valid_api_headers
+                "/extractions/job-123",
+                headers={**valid_api_headers, **_BEARER_HEADERS},
             )
             assert response.status_code == 200
             data = response.json()
@@ -356,11 +358,17 @@ class TestGetExtractionJobEndpoint:
 
     @pytest.mark.unit
     async def test_in_progress_job(self, client, valid_api_headers) -> None:
-        """Test retrieving an in-progress job."""
+        """Test retrieving an in-progress job owned by the caller."""
+        _install_jwt_user_override(_USER_001)
         mock_result = MagicMock()
         mock_result.state = "STARTED"
         mock_result.ready.return_value = False
         mock_result.info = {"completed_documents": 5}
+
+        owner_row = MagicMock()
+        owner_row.data = {"user_id": _USER_001}
+        mock_supabase = MagicMock()
+        mock_supabase.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = owner_row
 
         with (
             patch(
@@ -371,13 +379,38 @@ class TestGetExtractionJobEndpoint:
                 "app.extraction_domain.jobs_router.update_job_status_in_supabase",
                 return_value=True,
             ),
+            patch("app.extraction_domain.jobs_router.supabase", mock_supabase),
         ):
             response = await client.get(
-                "/extractions/job-456", headers=valid_api_headers
+                "/extractions/job-456",
+                headers={**valid_api_headers, **_BEARER_HEADERS},
             )
             assert response.status_code == 200
             data = response.json()
             assert data["status"] == "IN_PROGRESS"
+
+    @pytest.mark.unit
+    async def test_get_job_owned_by_another_user_is_forbidden(
+        self, client, valid_api_headers
+    ) -> None:
+        """A user must not read another user's extraction job (IDOR, #233 follow-up)."""
+        _install_jwt_user_override(_USER_001)
+        owner_row = MagicMock()
+        owner_row.data = {"user_id": _USER_099}
+        mock_supabase = MagicMock()
+        mock_supabase.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = owner_row
+
+        with (
+            patch("app.extraction_domain.jobs_router.supabase", mock_supabase),
+            patch("app.extraction_domain.jobs_router.AsyncResult") as mock_async,
+        ):
+            response = await client.get(
+                "/extractions/job-belongs-to-other",
+                headers={**valid_api_headers, **_BEARER_HEADERS},
+            )
+            assert response.status_code == 403
+            # Ownership is rejected before any Celery result is fetched.
+            mock_async.assert_not_called()
 
 
 class TestCancelExtractionJobEndpoint:

--- a/scripts/openapi-snapshot.json
+++ b/scripts/openapi-snapshot.json
@@ -26327,6 +26327,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "HTTPBearer": []
           }
         ],
         "summary": "Get extraction job status and results",


### PR DESCRIPTION
Follow-up to #238. A security review of the extraction auth migration found that the **read path was missed**: `GET /extractions/{job_id}` returned any user's extraction job status/results with no ownership check (delete/export were correctly scoped). An authenticated user could read another user's extracted document data by `job_id`.

## Fix
- `get_extraction_job` now requires a Bearer JWT (`Depends(get_current_user)`) and verifies the job's recorded `user_id` matches the caller — **403** on mismatch — mirroring the existing `delete_extraction_job` / `export_extraction_results` ownership pattern.
- Ownership is enforced **only when the job is recorded and the DB is reachable**: unknown ids carry no user data to leak, and transient DB/lookup errors degrade to the prior behaviour rather than blocking status polling (a hot endpoint).
- The frontend BFF GET route already forwards `Authorization: Bearer`, so no frontend change is needed.
- Regenerated the OpenAPI snapshot (adds `HTTPBearer` to the endpoint).

## Tests
- New cross-user regression test: caller `_USER_001` requesting `_USER_099`'s job → 403, and Celery is never queried.
- Updated existing GET tests for the new Bearer dependency. Full `test_extraction_jobs_router.py` (46) + results/shared/bearer/rate-limit suites (114) green; ruff clean.

## Known related follow-ups (not in this PR)
Surfaced by the same review, left as separate tracked work (more behavioural / higher regression risk):
- **`list_extraction_jobs`** enumerates Celery's global inspect API and returns all users' in-flight jobs (despite the docstring); should list from the `extraction_jobs` table filtered by `user_id`.
- **`cancel_or_delete_extraction_job`** (cancel path) authenticates but does not verify ownership before revoking the Celery task.