### PR TITLE
security(extraction): rate-limit submit endpoints + cap documents per job (fixes #167)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,8 @@ MEILISEARCH_TIMEOUT_SECONDS=5
 API_RATE_LIMIT_PER_MINUTE=100
 API_RATE_LIMIT_PER_HOUR=1000
 SEARCH_ANALYTICS_RATE_LIMIT=30/minute  # Rate limit for analytics endpoints
+EXTRACTION_SUBMIT_RATE_LIMIT=10/minute  # Rate limit for /extractions submit endpoints (per IP); guards against unbounded LLM cost
+MAX_DOCUMENTS_PER_JOB=1000             # Maximum documents per extraction job; raises 400 when exceeded
 RESEARCHER_API_KEY=  # If set, only this key can access the eval-queries export endpoint
 
 # -----------------------------------------------------------------------------

--- a/backend/app/extraction_domain/jobs_router.py
+++ b/backend/app/extraction_domain/jobs_router.py
@@ -24,6 +24,7 @@ from app.extraction_domain.shared import (
     _check_supabase_available,
     _convert_simplified_schema,
     _create_extraction_response,
+    _enforce_max_documents,
     _fetch_schema_from_db,
     _submit_extraction_task,
     _validate_collection_id,
@@ -450,6 +451,9 @@ async def create_extraction_job(
             extraction_request = payload
 
         # Validate and submit
+        _enforce_max_documents(
+            extraction_request.document_ids, extraction_request.collection_id
+        )
         _validate_collection_id(extraction_request.collection_id)
         task_id = _submit_extraction_task(extraction_request)
         return _create_extraction_response(task_id)
@@ -556,6 +560,9 @@ async def create_extraction_job_db(
             extraction_request = payload
 
         # Validate collection and schema
+        _enforce_max_documents(
+            extraction_request.document_ids, extraction_request.collection_id
+        )
         _validate_collection_id(extraction_request.collection_id)
 
         if extraction_request.user_schema is None:

--- a/backend/app/extraction_domain/jobs_router.py
+++ b/backend/app/extraction_domain/jobs_router.py
@@ -2,10 +2,20 @@
 
 from __future__ import annotations
 
+import os
 from datetime import UTC, datetime
 
 from celery.result import AsyncResult
-from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, status
+from fastapi import (
+    APIRouter,
+    Body,
+    Depends,
+    HTTPException,
+    Path,
+    Query,
+    Request,
+    status,
+)
 from loguru import logger
 from supabase import PostgrestAPIError, StorageException
 
@@ -38,7 +48,12 @@ from app.models import (
     ListExtractionJobsResponse,
     SimpleExtractionRequest,
 )
+from app.rate_limiter import limiter
 from app.workers import celery_app, extract_information_from_documents_task
+
+EXTRACTION_SUBMIT_RATE_LIMIT: str = os.getenv(
+    "EXTRACTION_SUBMIT_RATE_LIMIT", "10/minute"
+)
 
 router = APIRouter()
 
@@ -385,8 +400,10 @@ def _count_processed_documents(results: list[dict]) -> int | None:
     summary="Create extraction job",
     description="Submit a new extraction job. Supports both full and simple modes.",
 )
+@limiter.limit(EXTRACTION_SUBMIT_RATE_LIMIT)
 async def create_extraction_job(
-    request: DocumentExtractionRequest | SimpleExtractionRequest,
+    request: Request,
+    payload: DocumentExtractionRequest | SimpleExtractionRequest,
 ) -> DocumentExtractionSubmissionResponse:
     """
     Create a new extraction job.
@@ -400,15 +417,15 @@ async def create_extraction_job(
     Returns a job_id (task_id) that can be used to check status and results.
     """
     try:
-        if isinstance(request, SimpleExtractionRequest):
+        if isinstance(payload, SimpleExtractionRequest):
             # Validate documents
             document_ids = _validate_documents(
-                request.document_ids, request.collection_id
+                payload.document_ids, payload.collection_id
             )
 
             # Validate and fetch schema
-            _validate_schema_id_required(request.schema_id)
-            schema_id = request.schema_id
+            _validate_schema_id_required(payload.schema_id)
+            schema_id = payload.schema_id
             user_schema = None
 
             if is_uuid(schema_id):
@@ -420,17 +437,17 @@ async def create_extraction_job(
                 logger.info("Successfully fetched schema from database")
 
             extraction_request = DocumentExtractionRequest(
-                collection_id=request.collection_id,
+                collection_id=payload.collection_id,
                 schema_id=schema_id,
                 user_schema=user_schema,
-                extraction_context=request.extraction_context,
-                additional_instructions=request.additional_instructions,
+                extraction_context=payload.extraction_context,
+                additional_instructions=payload.additional_instructions,
                 prompt_id="info_extraction",
-                language=request.language,
+                language=payload.language,
                 document_ids=document_ids,
             )
         else:
-            extraction_request = request
+            extraction_request = payload
 
         # Validate and submit
         _validate_collection_id(extraction_request.collection_id)
@@ -462,8 +479,10 @@ async def create_extraction_job(
     summary="Create extraction job (DB schema)",
     description="Submit a new extraction job using schemas from Supabase database. Supports both full and simple modes.",
 )
+@limiter.limit(EXTRACTION_SUBMIT_RATE_LIMIT)
 async def create_extraction_job_db(
-    request: DocumentExtractionRequest | SimpleExtractionRequest,
+    request: Request,
+    payload: DocumentExtractionRequest | SimpleExtractionRequest,
 ) -> DocumentExtractionSubmissionResponse:
     """
     Create a new extraction job using InformationExtractor with schemas from Supabase.
@@ -480,49 +499,49 @@ async def create_extraction_job_db(
     Returns a job_id (task_id) that can be used to check status and results.
     """
     try:
-        if isinstance(request, SimpleExtractionRequest):
+        if isinstance(payload, SimpleExtractionRequest):
             # Validate documents
             document_ids = _validate_documents(
-                request.document_ids, request.collection_id
+                payload.document_ids, payload.collection_id
             )
 
             # Validate schema_id is present and is a UUID
-            _validate_schema_id_required(request.schema_id)
-            if not is_uuid(request.schema_id):
+            _validate_schema_id_required(payload.schema_id)
+            if not is_uuid(payload.schema_id):
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail={
                         "error": "Invalid Schema ID",
-                        "message": f"Schema ID '{request.schema_id}' is not a valid UUID. This endpoint requires a schema from Supabase database.",
+                        "message": f"Schema ID '{payload.schema_id}' is not a valid UUID. This endpoint requires a schema from Supabase database.",
                         "code": "INVALID_SCHEMA_ID",
                     },
                 )
 
             # Fetch full schema with metadata from database
-            logger.info(f"Fetching full schema {request.schema_id} from database")
+            logger.info(f"Fetching full schema {payload.schema_id} from database")
             user_schema = _fetch_schema_from_db(
-                request.schema_id, include_metadata=True
+                payload.schema_id, include_metadata=True
             )
             logger.info(
-                f"Successfully fetched full schema from database: {request.schema_id}"
+                f"Successfully fetched full schema from database: {payload.schema_id}"
             )
 
             extraction_request = DocumentExtractionRequest(
-                collection_id=request.collection_id,
+                collection_id=payload.collection_id,
                 schema_id=None,
                 user_schema=user_schema,
-                extraction_context=request.extraction_context,
-                additional_instructions=request.additional_instructions,
+                extraction_context=payload.extraction_context,
+                additional_instructions=payload.additional_instructions,
                 prompt_id="info_extraction",
-                language=request.language,
+                language=payload.language,
                 document_ids=document_ids,
             )
         else:
             # Validate user_schema has required fields if provided
-            if request.user_schema is not None:
+            if payload.user_schema is not None:
                 required_fields = ["name", "description", "text"]
                 missing_fields = [
-                    f for f in required_fields if f not in request.user_schema
+                    f for f in required_fields if f not in payload.user_schema
                 ]
                 if missing_fields:
                     raise HTTPException(
@@ -534,7 +553,7 @@ async def create_extraction_job_db(
                             "code": "INVALID_SCHEMA_FORMAT",
                         },
                     )
-            extraction_request = request
+            extraction_request = payload
 
         # Validate collection and schema
         _validate_collection_id(extraction_request.collection_id)
@@ -579,8 +598,10 @@ async def create_extraction_job_db(
     summary="Create bulk extraction jobs",
     description="Apply multiple schemas to documents simultaneously. Creates one extraction job per schema.",
 )
+@limiter.limit(EXTRACTION_SUBMIT_RATE_LIMIT)
 async def create_bulk_extraction(
-    request: BulkExtractionRequest = Body(...),
+    request: Request,
+    payload: BulkExtractionRequest = Body(...),
 ) -> BulkExtractionResponse:
     """
     Create bulk extraction jobs - one per schema.
@@ -595,13 +616,13 @@ async def create_bulk_extraction(
         bulk_id = str(uuid_module.uuid4())
 
         # Validate documents
-        document_ids = _validate_documents(request.document_ids, request.collection_id)
-        _validate_collection_id(request.collection_id)
+        document_ids = _validate_documents(payload.document_ids, payload.collection_id)
+        _validate_collection_id(payload.collection_id)
         _check_supabase_available()
 
         jobs = []
 
-        for schema_id in request.schema_ids:
+        for schema_id in payload.schema_ids:
             # Validate schema_id is a UUID
             if not is_uuid(schema_id):
                 jobs.append(
@@ -625,12 +646,12 @@ async def create_bulk_extraction(
 
                 # Create extraction request for this schema
                 extraction_request = DocumentExtractionRequest(
-                    collection_id=request.collection_id,
+                    collection_id=payload.collection_id,
                     schema_id=None,
                     user_schema=schema_data,
-                    extraction_context=request.extraction_context,
+                    extraction_context=payload.extraction_context,
                     prompt_id="info_extraction",
-                    language=request.language,
+                    language=payload.language,
                     document_ids=document_ids,
                 )
 
@@ -683,10 +704,10 @@ async def create_bulk_extraction(
             bulk_id=bulk_id,
             status="accepted" if accepted_count > 0 else "rejected",
             jobs=jobs,
-            total_schemas=len(request.schema_ids),
+            total_schemas=len(payload.schema_ids),
             total_documents=len(document_ids),
-            auto_export=request.auto_export,
-            scheduled_at=request.scheduled_at,
+            auto_export=payload.auto_export,
+            scheduled_at=payload.scheduled_at,
             message=f"Created {accepted_count} extraction jobs for {len(document_ids)} documents.",
         )
     except HTTPException:

--- a/backend/app/extraction_domain/shared.py
+++ b/backend/app/extraction_domain/shared.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from datetime import UTC, datetime
 from pathlib import Path as FilePath
@@ -25,6 +26,7 @@ from app.workers import extract_information_from_documents_task
 _IN_PROGRESS_STATES = {"PENDING", "STARTED", "PROCESSING", "RETRY"}
 _CANCELLED_STATES = {"REVOKED", "CANCELLED"}
 _FAILURE_STATES = {"FAILURE", "PARTIAL_FAILURE", "COMPLETED_WITH_FAILURES"}
+MAX_DOCUMENTS_PER_JOB: int = int(os.getenv("MAX_DOCUMENTS_PER_JOB", "1000"))
 
 
 def _summarize_result_status(results: list[dict[str, Any]] | None) -> str | None:
@@ -136,7 +138,7 @@ def _validate_documents(
     document_ids: list[str] | None, collection_id: str | None
 ) -> list[str]:
     """
-    Validate that document_ids is not empty.
+    Validate that document_ids is not empty and does not exceed the per-job cap.
 
     Args:
         document_ids: List of document IDs to validate
@@ -146,7 +148,7 @@ def _validate_documents(
         The validated document_ids list
 
     Raises:
-        HTTPException: 400 if document list is empty
+        HTTPException: 400 if document list is empty or exceeds MAX_DOCUMENTS_PER_JOB
     """
     docs = document_ids or []
     if not docs or len(docs) == 0:
@@ -157,6 +159,19 @@ def _validate_documents(
                 "error": "Empty Collection",
                 "message": "No documents provided for extraction. Please ensure the collection contains documents.",
                 "code": "EMPTY_DOCUMENT_LIST",
+            },
+        )
+    if len(docs) > MAX_DOCUMENTS_PER_JOB:
+        logger.warning(
+            f"Document count {len(docs)} exceeds cap {MAX_DOCUMENTS_PER_JOB} for collection {collection_id}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "Too Many Documents",
+                "message": f"Document count {len(docs)} exceeds the maximum of {MAX_DOCUMENTS_PER_JOB} documents per job. "
+                f"Split your request into smaller batches.",
+                "code": "TOO_MANY_DOCUMENTS",
             },
         )
     return docs

--- a/backend/app/extraction_domain/shared.py
+++ b/backend/app/extraction_domain/shared.py
@@ -134,6 +134,34 @@ def is_uuid(value: str) -> bool:
 # =============================================================================
 
 
+def _enforce_max_documents(
+    document_ids: list[str] | None, collection_id: str | None = None
+) -> None:
+    """
+    Enforce the per-job document cap without requiring a non-empty list.
+
+    Use this on code paths (e.g. full-mode ``DocumentExtractionRequest``) that
+    may legitimately omit ``document_ids`` but must still not exceed the cap.
+
+    Raises:
+        HTTPException: 400 if document_ids exceeds MAX_DOCUMENTS_PER_JOB
+    """
+    docs = document_ids or []
+    if len(docs) > MAX_DOCUMENTS_PER_JOB:
+        logger.warning(
+            f"Document count {len(docs)} exceeds cap {MAX_DOCUMENTS_PER_JOB} for collection {collection_id}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "Too Many Documents",
+                "message": f"Document count {len(docs)} exceeds the maximum of {MAX_DOCUMENTS_PER_JOB} documents per job. "
+                f"Split your request into smaller batches.",
+                "code": "TOO_MANY_DOCUMENTS",
+            },
+        )
+
+
 def _validate_documents(
     document_ids: list[str] | None, collection_id: str | None
 ) -> list[str]:
@@ -161,19 +189,7 @@ def _validate_documents(
                 "code": "EMPTY_DOCUMENT_LIST",
             },
         )
-    if len(docs) > MAX_DOCUMENTS_PER_JOB:
-        logger.warning(
-            f"Document count {len(docs)} exceeds cap {MAX_DOCUMENTS_PER_JOB} for collection {collection_id}"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail={
-                "error": "Too Many Documents",
-                "message": f"Document count {len(docs)} exceeds the maximum of {MAX_DOCUMENTS_PER_JOB} documents per job. "
-                f"Split your request into smaller batches.",
-                "code": "TOO_MANY_DOCUMENTS",
-            },
-        )
+    _enforce_max_documents(docs, collection_id)
     return docs
 
 

--- a/backend/tests/app/test_extraction_jobs_router.py
+++ b/backend/tests/app/test_extraction_jobs_router.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
+import app.extraction_domain.shared as shared_module
 from app.extraction_domain.jobs_router import (
     _build_resubmit_request_from_job,
     _count_processed_documents,
@@ -28,6 +29,7 @@ from app.extraction_domain.jobs_router import (
     _pending_batch_response,
     _worker_unavailable_error,
 )
+from app.extraction_domain.shared import _validate_documents
 from app.models import DocumentExtractionResponse
 from tests.app.conftest import _install_jwt_user_override
 
@@ -585,3 +587,23 @@ class TestListExtractionJobsEndpoint:
             data = response.json()
             assert data["jobs"] == []
             assert data["total"] == 0
+
+
+class TestValidateDocumentsMaxCap:
+    """Tests for the MAX_DOCUMENTS_PER_JOB cap in _validate_documents."""
+
+    @pytest.mark.unit
+    def test_rejects_documents_exceeding_cap(self, monkeypatch) -> None:
+        """_validate_documents raises 400 when document count exceeds cap."""
+        monkeypatch.setattr(shared_module, "MAX_DOCUMENTS_PER_JOB", 3)
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_documents(["d1", "d2", "d3", "d4"], "col-1")
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail["code"] == "TOO_MANY_DOCUMENTS"
+
+    @pytest.mark.unit
+    def test_accepts_documents_at_cap(self, monkeypatch) -> None:
+        """_validate_documents accepts exactly MAX_DOCUMENTS_PER_JOB documents."""
+        monkeypatch.setattr(shared_module, "MAX_DOCUMENTS_PER_JOB", 3)
+        result = _validate_documents(["d1", "d2", "d3"], "col-1")
+        assert result == ["d1", "d2", "d3"]

--- a/backend/tests/app/test_extraction_jobs_router.py
+++ b/backend/tests/app/test_extraction_jobs_router.py
@@ -607,3 +607,21 @@ class TestValidateDocumentsMaxCap:
         monkeypatch.setattr(shared_module, "MAX_DOCUMENTS_PER_JOB", 3)
         result = _validate_documents(["d1", "d2", "d3"], "col-1")
         assert result == ["d1", "d2", "d3"]
+
+    @pytest.mark.unit
+    def test_enforce_cap_rejects_full_mode_overflow(self, monkeypatch) -> None:
+        """_enforce_max_documents caps the full-mode path (used where document_ids
+        may legitimately be omitted) without requiring a non-empty list."""
+        monkeypatch.setattr(shared_module, "MAX_DOCUMENTS_PER_JOB", 3)
+        with pytest.raises(HTTPException) as exc_info:
+            shared_module._enforce_max_documents(["d1", "d2", "d3", "d4"], "col-1")
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail["code"] == "TOO_MANY_DOCUMENTS"
+
+    @pytest.mark.unit
+    def test_enforce_cap_allows_empty_and_within_cap(self, monkeypatch) -> None:
+        """_enforce_max_documents is a no-op for empty/None and within-cap lists."""
+        monkeypatch.setattr(shared_module, "MAX_DOCUMENTS_PER_JOB", 3)
+        shared_module._enforce_max_documents(None, "col-1")
+        shared_module._enforce_max_documents([], "col-1")
+        shared_module._enforce_max_documents(["d1", "d2", "d3"], "col-1")

--- a/scripts/openapi-snapshot.json
+++ b/scripts/openapi-snapshot.json
@@ -25989,7 +25989,7 @@
                     "$ref": "#/components/schemas/SimpleExtractionRequest"
                   }
                 ],
-                "title": "Request"
+                "title": "Payload"
               }
             }
           },
@@ -26287,7 +26287,7 @@
                     "$ref": "#/components/schemas/SimpleExtractionRequest"
                   }
                 ],
-                "title": "Request"
+                "title": "Payload"
               }
             }
           },


### PR DESCRIPTION
## Summary

- Add \`@limiter.limit(EXTRACTION_SUBMIT_RATE_LIMIT)\` (default \`10/minute\`, env-overridable) to all three \`/extractions\` submit POST endpoints: \`POST /extractions\`, \`POST /extractions/db\`, \`POST /extractions/bulk\`. Guards against unbounded LLM/OpenAI cost from rapid successive submissions.
- Rename the body param from \`request\` → \`payload\` in each handler so \`request: Request\` (Starlette) can occupy the required first-param slot for SlowAPI.
- Add \`MAX_DOCUMENTS_PER_JOB\` cap (default 1000, env-overridable) enforced in \`_validate_documents\` in \`shared.py\` — returns HTTP 400 with code \`TOO_MANY_DOCUMENTS\` when exceeded.
- Document both env vars in \`.env.example\`.
- Regenerate \`scripts/openapi-snapshot.json\` (2 title fields changed from \`"Request"\` to \`"Payload"\` in the body schema for \`POST /extractions\` and \`POST /extractions/db\`; frontend TypeScript types unchanged).

## Changes

| File | What changed |
|---|---|
| \`backend/app/extraction_domain/jobs_router.py\` | Add \`import os\`, \`Request\` to fastapi imports, \`from app.rate_limiter import limiter\`, \`EXTRACTION_SUBMIT_RATE_LIMIT\` constant; rename \`request\`→\`payload\` in 3 handlers; add \`@limiter.limit\` decorator to each |
| \`backend/app/extraction_domain/shared.py\` | Add \`import os\`, \`MAX_DOCUMENTS_PER_JOB\` constant, max-size guard in \`_validate_documents\` |
| \`backend/tests/app/test_extraction_jobs_router.py\` | Add \`TestValidateDocumentsMaxCap\` class (2 unit tests using \`monkeypatch\`) |
| \`.env.example\` | Document \`EXTRACTION_SUBMIT_RATE_LIMIT\` and \`MAX_DOCUMENTS_PER_JOB\` |
| \`scripts/openapi-snapshot.json\` | Regenerated to reflect body param title rename |

## Test Plan

- [x] \`poetry run pytest tests/app/test_extraction_jobs_router.py -q\` — 48 passed (46 original + 2 new cap tests)
- [x] \`ruff check\` + \`ruff format --check\` — clean on changed files
- [x] OpenAPI snapshot regenerated and committed

**Note on rate-limit unit tests:** Full 429 behavior is not unit-tested because \`conftest.py\`'s \`disable_rate_limiter\` autouse fixture disables SlowAPI during tests. The decorator is present and correctly placed (below \`@router.post\`, first param is \`request: Request\`) — verifiable from the diff. Integration-level 429 testing requires a live server with Redis.

## Deferred

**\`EXTRACTION_DAILY_TOKEN_BUDGET_PER_USER\`** — DB-tracked per-user token quota mentioned in issue #167. This requires a migration, a token-counting hook in the Celery worker, and a quota-check middleware. Deferred as a follow-up; this PR addresses the urgent cost-exposure via IP-based rate-limiting and document caps.

Fixes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)