### PR TITLE
chore(ci): add OpenAPI regen step to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,5 +35,6 @@ Longer contributing guidance: docs/contributing/CONTRIBUTING.md
 - [ ] Branched from `develop` (not `main`)
 - [ ] Commit messages follow Conventional Commits
 - [ ] Tests pass locally (`npm run validate` and/or `poetry run poe check-all`)
+- [ ] If backend endpoints, params, or auth deps changed: ran `scripts/regen_openapi_types.sh` and committed `scripts/openapi-snapshot.json` + `frontend/lib/api/generated/openapi.ts` (keeps the **OpenAPI Type Drift** check green)
 - [ ] Docs updated if behavior, API, or architecture changed (`docs/`, Diátaxis-organized)
 - [ ] No Claude / co-author footers in commits (per project policy)


### PR DESCRIPTION
## Summary
- Backend PRs that change endpoints/params/auth deps have been merging without regenerating the OpenAPI snapshot, leaving the **OpenAPI Type Drift** check perpetually red on `main`.

## Changes
- Add a checklist item to `.github/PULL_REQUEST_TEMPLATE.md` reminding contributors to run `scripts/regen_openapi_types.sh` and commit `scripts/openapi-snapshot.json` + `frontend/lib/api/generated/openapi.ts` when backend endpoints/params/auth change.

## Type
- [x] CI

## Testing
- Docs/template-only change; no code paths affected.