### PR TITLE
security(dashboard): auth-gate /health and require admin on /refresh-stats (fixes #170, fixes #216)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,8 @@ API_RATE_LIMIT_PER_MINUTE=100
 API_RATE_LIMIT_PER_HOUR=1000
 SEARCH_ANALYTICS_RATE_LIMIT=30/minute  # Rate limit for analytics endpoints
 EXTRACTION_SUBMIT_RATE_LIMIT=10/minute  # Rate limit for /extractions submit endpoints (per IP); guards against unbounded LLM cost
+DASHBOARD_HEALTH_RATE_LIMIT=30/minute  # Rate limit for GET /dashboard/health (requires API key after #170)
+DASHBOARD_REFRESH_RATE_LIMIT=2/hour   # Rate limit for POST /dashboard/refresh-stats (admin-only after #216)
 MAX_DOCUMENTS_PER_JOB=1000             # Maximum documents per extraction job; raises 400 when exceeded
 RESEARCHER_API_KEY=  # If set, only this key can access the eval-queries export endpoint
 

--- a/backend/app/dashboard.py
+++ b/backend/app/dashboard.py
@@ -14,6 +14,7 @@ from supabase import Client, PostgrestAPIError, StorageException, create_client
 from supabase.client import ClientOptions
 
 from app.auth import verify_api_key
+from app.core.auth_jwt import AuthenticatedUser, require_admin
 from app.rate_limiter import limiter
 
 # Redis client setup (optional, falls back to in-memory cache)
@@ -41,7 +42,8 @@ except Exception as e:
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
 
 DASHBOARD_READ_RATE_LIMIT = os.getenv("DASHBOARD_READ_RATE_LIMIT", "100/minute")
-DASHBOARD_REFRESH_RATE_LIMIT = os.getenv("DASHBOARD_REFRESH_RATE_LIMIT", "20/minute")
+DASHBOARD_HEALTH_RATE_LIMIT = os.getenv("DASHBOARD_HEALTH_RATE_LIMIT", "30/minute")
+DASHBOARD_REFRESH_RATE_LIMIT = os.getenv("DASHBOARD_REFRESH_RATE_LIMIT", "2/hour")
 
 
 def _get_required_env(name: str) -> str:
@@ -333,7 +335,9 @@ async def get_dashboard_stats(
 @router.post("/refresh-stats")
 @limiter.limit(DASHBOARD_REFRESH_RATE_LIMIT)
 async def refresh_dashboard_stats(
-    request: Request, api_key: str = Depends(verify_api_key)
+    request: Request,
+    api_key: str = Depends(verify_api_key),
+    admin: AuthenticatedUser = Depends(require_admin),
 ):
     """
     Trigger a refresh of precomputed dashboard statistics.
@@ -370,7 +374,11 @@ async def refresh_dashboard_stats(
 
 
 @router.get("/health")
-async def dashboard_health():
+@limiter.limit(DASHBOARD_HEALTH_RATE_LIMIT)
+async def dashboard_health(
+    request: Request,
+    api_key: str = Depends(verify_api_key),
+):
     """Check dashboard data availability."""
     try:
         stats = (

--- a/backend/tests/app/test_dashboard_hardening.py
+++ b/backend/tests/app/test_dashboard_hardening.py
@@ -79,3 +79,47 @@ async def test_dashboard_trending_topics_enforces_route_rate_limit(
     finally:
         if previous_enabled is not None:
             limiter.enabled = previous_enabled
+
+
+@pytest.mark.anyio
+@pytest.mark.api
+async def test_dashboard_health_requires_api_key(client: AsyncClient):
+    """GET /dashboard/health must reject requests without X-API-Key (fixes #170)."""
+    response = await client.get("/dashboard/health")
+    assert response.status_code in (401, 403)
+
+
+@pytest.mark.anyio
+@pytest.mark.api
+async def test_dashboard_refresh_stats_requires_admin(
+    valid_api_headers: dict,
+):
+    """POST /dashboard/refresh-stats must reject non-admin authenticated users with 403 (fixes #216)."""
+    from httpx import ASGITransport, AsyncClient
+
+    from app.core.auth_jwt import AuthenticatedUser
+    from app.core.auth_jwt import get_current_user as jwt_get_current_user
+    from app.server import app
+
+    async def non_admin_user() -> AuthenticatedUser:
+        return AuthenticatedUser(
+            user_data={
+                "id": "non-admin-user",
+                "email": "user@example.com",
+                "role": "authenticated",
+                "app_metadata": {},
+            },
+            access_token="test-token",
+        )
+
+    app.dependency_overrides[jwt_get_current_user] = non_admin_user
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            headers=valid_api_headers,
+        ) as ac:
+            response = await ac.post("/dashboard/refresh-stats")
+        assert response.status_code == 403
+    finally:
+        app.dependency_overrides.pop(jwt_get_current_user, None)

--- a/backend/tests/app/test_dashboard_integration.py
+++ b/backend/tests/app/test_dashboard_integration.py
@@ -44,12 +44,9 @@ async def test_dashboard_refresh_stats_requires_auth(client: AsyncClient):
 @pytest.mark.anyio
 @pytest.mark.api
 async def test_dashboard_refresh_stats_with_auth(authenticated_client: AsyncClient):
-    """Refresh stats should work with valid auth."""
+    """Refresh stats with non-admin auth returns 403 after admin gate added in #216."""
     response = await authenticated_client.post("/dashboard/refresh-stats")
-    assert response.status_code in [200, 500]
-    if response.status_code == 200:
-        data = response.json()
-        assert "status" in data
+    assert response.status_code == 403
 
 
 @pytest.mark.anyio
@@ -130,3 +127,19 @@ async def test_dashboard_test_document_counts_requires_auth(client: AsyncClient)
     """Test document counts should reject unauthenticated requests."""
     response = await client.get("/dashboard/test-document-counts")
     assert response.status_code in [401, 403]
+
+
+@pytest.mark.anyio
+@pytest.mark.api
+async def test_dashboard_health_requires_auth(client: AsyncClient):
+    """Health check should reject unauthenticated requests after #170 fix."""
+    response = await client.get("/dashboard/health")
+    assert response.status_code in [401, 403]
+
+
+@pytest.mark.anyio
+@pytest.mark.api
+async def test_dashboard_health_with_api_key(authenticated_client: AsyncClient):
+    """Health check should not return 401/403 with valid API key (DB may be unavailable)."""
+    response = await authenticated_client.get("/dashboard/health")
+    assert response.status_code not in [401, 403]

--- a/scripts/openapi-snapshot.json
+++ b/scripts/openapi-snapshot.json
@@ -22991,6 +22991,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "HTTPBearer": []
           }
         ],
         "summary": "Refresh Dashboard Stats",


### PR DESCRIPTION
## Summary

- **#170 — `GET /dashboard/health`**: was unauthenticated and ran `count="exact"` on `judgments`. Now requires `X-API-Key` (same as all other dashboard endpoints) and `@limiter.limit(DASHBOARD_HEALTH_RATE_LIMIT)` (default 30/minute). The `count="exact"` is retained to preserve the `total_judgments_in_db` response field; auth+rate-limit prevents unauthenticated DB abuse.
- **#216 — `POST /dashboard/refresh-stats`**: was gated only by `verify_api_key` at 20/minute. Now also requires `Depends(require_admin)` (service_role or `app_metadata.is_admin=true`) and the rate limit default is lowered to `2/hour` to throttle expensive `refresh_dashboard_stats` RPC calls.

## Files changed

- `backend/app/dashboard.py` — new constants, new deps on two endpoints
- `backend/tests/app/test_dashboard_hardening.py` — unit tests for auth gates
- `backend/tests/app/test_dashboard_integration.py` — integration tests + updated existing refresh-stats test
- `.env.example` — documents two new rate-limit env vars
- `scripts/openapi-snapshot.json` — regen: added HTTPBearer security on POST /refresh-stats

## Frontend audit

- `frontend/app/api/dashboard/health/route.ts` **already forwards** `X-API-Key: process.env.BACKEND_API_KEY` — no change needed.
- No frontend proxy exists for `POST /dashboard/refresh-stats` — the endpoint is admin-only and is not called from the frontend UI.

## Test plan

- [ ] `poetry run pytest backend/tests/app/test_dashboard_hardening.py backend/tests/app/test_dashboard_integration.py -q` — all pass
- [ ] `GET /dashboard/health` without `X-API-Key` → 401 or 403
- [ ] `GET /dashboard/health` with valid `X-API-Key` → not 401/403
- [ ] `POST /dashboard/refresh-stats` with non-admin JWT + API key → 403
- [ ] `POST /dashboard/refresh-stats` with admin JWT + API key → 200

Fixes #170
Fixes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)