### PR TITLE
fix(admin): surface fatal errors as 5xx instead of 200 with partial data (fixes #220)

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -11,7 +11,7 @@ Date: 2026-02-23
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from loguru import logger
 from pydantic import BaseModel, Field
 
@@ -311,11 +311,16 @@ async def list_users(
 
         return UserListResponse(users=users, page=page, per_page=per_page)
 
+    except HTTPException:
+        raise
     except Exception as e:
         # Broad catch: gotrue-py list_users raises arbitrary exceptions across
         # versions; no stable base exception class is exposed publicly.
-        logger.error(f"Admin list_users failed: {e}")
-        return UserListResponse(users=[], page=page, per_page=per_page)
+        logger.exception(f"Admin list_users failed: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to retrieve user list from auth provider.",
+        )
 
 
 @router.get("/activity", response_model=list[ActivityLogEntry])
@@ -360,9 +365,14 @@ async def get_recent_activity(
         logger.info(f"Admin activity fetched by {admin.email}: {len(entries)} entries")
         return entries
 
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.warning(f"Admin get_recent_activity failed: {e}")
-        return []
+        logger.exception(f"Admin get_recent_activity failed: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to retrieve activity log from database.",
+        )
 
 
 @router.get("/search-queries", response_model=SearchQueriesResponse)
@@ -424,9 +434,14 @@ async def get_search_queries(
             queries=entries, total=total, page=page, limit=limit
         )
 
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.warning(f"Admin get_search_queries failed: {e}")
-        return SearchQueriesResponse(queries=[], total=0, page=page, limit=limit)
+        logger.exception(f"Admin get_search_queries failed: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to retrieve search queries from database.",
+        )
 
 
 @router.get("/documents/stats", response_model=DocumentStats)
@@ -527,11 +542,17 @@ async def get_system_health(
 
     try:
         services_health = await check_all_services()
+    except HTTPException:
+        raise
     except Exception as e:
-        # Broad catch: check_all_services() probes multiple external systems
-        # (database, Redis, OpenAI) which may raise arbitrary exceptions.
-        logger.error(f"Admin system health check failed: {e}")
-        services_health = {}
+        # check_all_services() itself raising means the health-probe machinery
+        # is broken — we cannot report meaningful service status, so surface a
+        # 500 rather than a falsely-healthy empty response.
+        logger.exception(f"Admin system health check failed: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail="Health check probe failed; service status is unavailable.",
+        )
 
     services: dict[str, ServiceHealthEntry] = {}
     for name, health in services_health.items():

--- a/backend/tests/app/test_admin.py
+++ b/backend/tests/app/test_admin.py
@@ -274,7 +274,8 @@ class TestListUsers:
         assert response.status_code == 200
 
     @patch("app.api.admin.get_admin_supabase_client")
-    async def test_list_users_error_returns_empty(self, mock_get_client, admin_app):
+    async def test_list_users_error_returns_500(self, mock_get_client, admin_app):
+        """Fatal auth-provider failure must surface as 500, not 200 with empty list."""
         mock_client = MagicMock()
         mock_client.auth.admin.list_users.side_effect = Exception("auth error")
         mock_get_client.return_value = mock_client
@@ -286,9 +287,8 @@ class TestListUsers:
                 "/api/admin/users",
                 headers={"Authorization": "Bearer fake"},
             )
-        assert response.status_code == 200
-        data = response.json()
-        assert data["users"] == []
+        assert response.status_code == 500
+        assert "user list" in response.json()["detail"].lower()
 
 
 # ===== Activity endpoint tests =====
@@ -323,7 +323,8 @@ class TestGetRecentActivity:
         assert len(data) == 1
 
     @patch("app.api.admin.get_admin_supabase_client")
-    async def test_activity_error_returns_empty(self, mock_get_client, admin_app):
+    async def test_activity_error_returns_500(self, mock_get_client, admin_app):
+        """Fatal DB failure on the primary query must surface as 500, not 200 with empty list."""
         mock_client = MagicMock()
         mock_client.table.side_effect = Exception("db down")
         mock_get_client.return_value = mock_client
@@ -335,8 +336,8 @@ class TestGetRecentActivity:
                 "/api/admin/activity",
                 headers={"Authorization": "Bearer fake"},
             )
-        assert response.status_code == 200
-        assert response.json() == []
+        assert response.status_code == 500
+        assert "activity log" in response.json()["detail"].lower()
 
 
 # ===== Search queries endpoint tests =====
@@ -392,6 +393,91 @@ class TestGetSearchQueries:
         data = response.json()
         assert data["total"] == 1
         assert len(data["queries"]) == 1
+
+    @patch("app.api.admin.get_admin_supabase_client")
+    async def test_search_queries_primary_failure_returns_500(
+        self, mock_get_client, admin_app
+    ):
+        """Primary data query failing must surface as 500 (count failure alone stays 200)."""
+        mock_client = MagicMock()
+
+        call_idx = {"n": 0}
+
+        def table_side(name):
+            call_idx["n"] += 1
+            m = MagicMock()
+            if call_idx["n"] == 1:
+                # count query succeeds
+                count_resp = MagicMock()
+                count_resp.count = 5
+                m.select.return_value.execute.return_value = count_resp
+            else:
+                # primary data query fails
+                m.select.return_value.order.return_value.range.return_value.execute.side_effect = Exception(
+                    "db error"
+                )
+            return m
+
+        mock_client.table.side_effect = table_side
+        mock_get_client.return_value = mock_client
+
+        async with AsyncClient(
+            transport=ASGITransport(app=admin_app), base_url="http://test"
+        ) as client:
+            response = await client.get(
+                "/api/admin/search-queries",
+                headers={"Authorization": "Bearer fake"},
+            )
+        assert response.status_code == 500
+        assert "search queries" in response.json()["detail"].lower()
+
+    @patch("app.api.admin.get_admin_supabase_client")
+    async def test_search_queries_count_failure_stays_200(
+        self, mock_get_client, admin_app
+    ):
+        """Count sub-query failure is tolerable; primary data success → 200 with total=0."""
+        mock_client = MagicMock()
+
+        call_idx = {"n": 0}
+
+        def table_side(name):
+            call_idx["n"] += 1
+            m = MagicMock()
+            if call_idx["n"] == 1:
+                # count query fails
+                m.select.return_value.execute.side_effect = Exception("count error")
+            else:
+                # data query succeeds
+                data_resp = MagicMock()
+                data_resp.data = [
+                    {
+                        "id": "q1",
+                        "query": "test",
+                        "user_id": None,
+                        "session_id": None,
+                        "result_count": None,
+                        "filters": None,
+                        "duration_ms": None,
+                        "created_at": None,
+                    }
+                ]
+                m.select.return_value.order.return_value.range.return_value.execute.return_value = data_resp
+            return m
+
+        mock_client.table.side_effect = table_side
+        mock_get_client.return_value = mock_client
+
+        async with AsyncClient(
+            transport=ASGITransport(app=admin_app), base_url="http://test"
+        ) as client:
+            response = await client.get(
+                "/api/admin/search-queries",
+                headers={"Authorization": "Bearer fake"},
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 0  # count failed, defaults to 0
+        assert len(data["queries"]) == 1  # primary data succeeded
 
 
 # ===== Document stats endpoint tests =====
@@ -512,7 +598,8 @@ class TestGetSystemHealth:
         assert data["status"] == "unhealthy"
 
     @patch("app.health.checks.check_all_services")
-    async def test_health_check_exception(self, mock_check, admin_app):
+    async def test_health_check_exception_returns_500(self, mock_check, admin_app):
+        """check_all_services() raising must surface as 500, not a falsely-healthy 200."""
         mock_check.side_effect = Exception("health check failed")
 
         async with AsyncClient(
@@ -522,10 +609,8 @@ class TestGetSystemHealth:
                 "/api/admin/system/health",
                 headers={"Authorization": "Bearer fake"},
             )
-        assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "healthy"  # no services = healthy
-        assert data["services"] == {}
+        assert response.status_code == 500
+        assert "health check" in response.json()["detail"].lower()
 
 
 # ===== Content stats endpoint tests =====


### PR DESCRIPTION
## Summary

- **`list_users`**: auth-provider failure now returns 500 instead of `users=[]` 200 — the endpoint exists solely to serve this list; silence was misleading
- **`get_recent_activity`**: DB failure now returns 500 instead of `[]` 200 — single primary query with no fallback concept
- **`get_search_queries`**: primary data query failure → 500; the optional count sub-query stays 200 with `total=0` when it fails alone (genuinely independent)
- **`get_system_health`**: `check_all_services()` raising → 500 instead of silently returning `{}` which produced a falsely-healthy overall status

**Left unchanged (legitimate multi-rollup aggregators):**
- `get_platform_stats` — 5 independent sub-queries (users, docs, searches, sessions, recent additions); each independently contributing zeros is meaningful and expected under partial degradation
- `get_document_stats` — 5 independent dimension breakdowns; same rationale
- `get_content_stats` — 4 independent blog metric queries; same rationale

All changed handlers: add `except HTTPException: raise` guard before the broad except, switch `logger.error/warning` → `logger.exception` (preserves tracebacks), and `raise HTTPException(status_code=500, ...)` instead of returning partial data.

## Test plan

- [x] Existing test `test_list_users_error_returns_empty` → renamed and updated to assert `status_code == 500`
- [x] Existing test `test_activity_error_returns_empty` → updated to assert `status_code == 500`
- [x] Existing test `test_health_check_exception` → updated to assert `status_code == 500`
- [x] New `test_search_queries_primary_failure_returns_500` — count succeeds, data query fails → 500
- [x] New `test_search_queries_count_failure_stays_200` — count fails, data query succeeds → 200 with `total=0`
- [x] All 19 unit tests in `tests/app/test_admin.py` pass
- [x] Ruff lint + format pass; pre-commit hooks green
- [x] OpenAPI snapshot unchanged (status codes not reflected in response schema)

Fixes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)