### PR TITLE
fix(search): signal hybrid→keyword fallback via search_mode + ops log (fixes #221)

### DIFF
--- a/backend/app/api/search.py
+++ b/backend/app/api/search.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, Field
 from app.auth import verify_api_key
 from app.core.auth_jwt import AuthenticatedUser, get_current_user, get_optional_user
 from app.rate_limiter import limiter
-from app.services.search import MeiliSearchService, TopicHit
+from app.services.search import MeiliSearchService, SearchMode, TopicHit
 from app.services.search_analytics import (
     export_eval_queries,
     get_popular_queries,
@@ -62,13 +62,23 @@ class DocumentPagination(BaseModel):
 
 
 class DocumentSearchResponse(BaseModel):
-    """Paginated document search response (Meilisearch-backed text mode)."""
+    """Paginated document search response (Meilisearch-backed text mode).
+
+    ``search_mode`` indicates which ranking strategy was used:
+
+    - ``"keyword"`` — pure keyword search (``semantic_ratio == 0``).
+    - ``"hybrid"`` — hybrid semantic+keyword search ran successfully.
+    - ``"keyword_fallback"`` — hybrid was requested but Meilisearch returned
+      4xx (e.g. the ``bge-m3`` embedder is not registered); the response
+      contains keyword results only.  Ops should treat this as an ops alert.
+    """
 
     documents: list[dict[str, Any]] = Field(default_factory=list)
     query: str
     query_time_ms: int | None = None
     pagination: DocumentPagination
     total_count: int | None = None
+    search_mode: SearchMode = "keyword"
 
 
 class TopicClickEvent(BaseModel):
@@ -232,6 +242,7 @@ async def documents_search(
             next_offset=next_offset,
         ),
         total_count=estimated_total,
+        search_mode=result.get("search_mode", "keyword"),
     )
 
 

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -5,13 +5,20 @@ from __future__ import annotations
 import asyncio
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import urlparse, urlunparse
 
 import httpx
 from juddges_search.embeddings import embed_texts
 from loguru import logger
 from pydantic import BaseModel, Field
+
+# Sentinel key injected into the raw Meilisearch response dict when a hybrid
+# search degrades to keyword-only.  Consumers (e.g. ``documents_search``) read
+# and strip this key so it never leaks into the HTTP response body.
+_FALLBACK_SENTINEL = "_hybrid_fallback"
+
+SearchMode = Literal["hybrid", "keyword", "keyword_fallback"]
 
 
 class SearchServiceError(RuntimeError):
@@ -183,11 +190,29 @@ class MeiliSearchService:
                 if 400 <= response.status_code < 500 and (
                     "hybrid" in payload or "vector" in payload
                 ):
+                    meili_error = response.text[:300]
                     logger.warning(
-                        "Meilisearch rejected hybrid search "
-                        f"(status={response.status_code}): "
-                        f"{response.text[:300]} — retrying as keyword-only"
+                        "hybrid_search_degraded index={} status={} reason={!r} — "
+                        "retrying as keyword-only; semantic ranking is unavailable",
+                        self.index_name,
+                        response.status_code,
+                        meili_error,
                     )
+                    try:
+                        import sentry_sdk
+
+                        sentry_sdk.add_breadcrumb(
+                            category="search",
+                            message="Hybrid search degraded to keyword-only",
+                            data={
+                                "index": self.index_name,
+                                "status_code": response.status_code,
+                                "meili_error": meili_error,
+                            },
+                            level="warning",
+                        )
+                    except Exception:
+                        pass  # sentry_sdk absent or not initialised — structured log is enough
                     keyword_payload = {
                         k: v
                         for k, v in payload.items()
@@ -196,8 +221,12 @@ class MeiliSearchService:
                     response = await client.post(
                         url, json=keyword_payload, headers=self._search_headers()
                     )
-                response.raise_for_status()
-                data = response.json()
+                    response.raise_for_status()
+                    data = response.json()
+                    data[_FALLBACK_SENTINEL] = True
+                else:
+                    response.raise_for_status()
+                    data = response.json()
         except httpx.HTTPError as exc:
             raise SearchServiceError(str(exc)) from exc
 
@@ -396,6 +425,8 @@ class MeiliSearchService:
         if filters:
             payload["filter"] = filters
 
+        # Track whether we intended hybrid search so we can set search_mode.
+        hybrid_requested = False
         if semantic_ratio > 0 and query.strip():
             try:
                 query_vec = await asyncio.to_thread(embed_texts, query)
@@ -404,12 +435,25 @@ class MeiliSearchService:
                     "semanticRatio": semantic_ratio,
                 }
                 payload["vector"] = query_vec
+                hybrid_requested = True
             except Exception:
                 logger.opt(exception=True).warning(
                     "TEI embedding failed for documents_search — falling back to keyword"
                 )
 
-        return await self._search_post(payload)
+        raw = await self._search_post(payload)
+
+        # Determine and surface the effective search mode.
+        fallback = raw.pop(_FALLBACK_SENTINEL, False)
+        if fallback:
+            search_mode: SearchMode = "keyword_fallback"
+        elif hybrid_requested:
+            search_mode = "hybrid"
+        else:
+            search_mode = "keyword"
+
+        raw["search_mode"] = search_mode
+        return raw
 
     async def search(
         self,

--- a/backend/tests/app/test_meilisearch_service.py
+++ b/backend/tests/app/test_meilisearch_service.py
@@ -628,6 +628,36 @@ class TestDocumentsSearch:
         assert "hybrid" in calls[0] and "vector" in calls[0]
         assert "hybrid" not in calls[1] and "vector" not in calls[1]
         assert result["hits"][0]["id"] == "doc-after-retry"
+        # search_mode must signal the degradation
+        assert result["search_mode"] == "keyword_fallback"
+
+    @pytest.mark.asyncio
+    async def test_documents_search_pure_keyword_sets_search_mode(self, service):
+        """Pure keyword search (semantic_ratio=0) must return search_mode='keyword'."""
+
+        async def fake_post(self_, url, json, headers):
+            return _mock_response(200, {"hits": [], "estimatedTotalHits": 0})
+
+        with patch("httpx.AsyncClient.post", new=fake_post):
+            result = await service.documents_search("contract", semantic_ratio=0.0)
+
+        assert result["search_mode"] == "keyword"
+
+    @pytest.mark.asyncio
+    async def test_documents_search_hybrid_success_sets_search_mode(self, service):
+        """Successful hybrid search must return search_mode='hybrid'."""
+        fake_vec = [0.1] * 1024
+
+        async def fake_post(self_, url, json, headers):
+            return _mock_response(200, {"hits": [], "estimatedTotalHits": 0})
+
+        with (
+            patch("app.services.search.embed_texts", return_value=fake_vec),
+            patch("httpx.AsyncClient.post", new=fake_post),
+        ):
+            result = await service.documents_search("contract", semantic_ratio=0.5)
+
+        assert result["search_mode"] == "hybrid"
 
     @pytest.mark.asyncio
     async def test_keyword_400_does_not_retry(self, service):
@@ -664,3 +694,127 @@ class TestDocumentsSearch:
             pytest.raises(SearchServiceError),
         ):
             await service.documents_search("drugs", semantic_ratio=0.5)
+
+
+# ── search_mode / hybrid-fallback signal tests (issue #221) ──────────────
+
+
+class TestHybridFallbackSignal:
+    """Verify that a Meilisearch 400 on a hybrid request:
+
+    (a) still returns keyword results,
+    (b) sets search_mode == "keyword_fallback", and
+    (c) emits a structured warning log with enough context for ops.
+    """
+
+    @pytest.fixture
+    def svc(self):
+        return MeiliSearchService(
+            base_url="http://meili:7700",
+            api_key="search-key",
+            admin_key="admin-key",
+            index_name="judgments",
+            timeout_seconds=2.0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_fallback_returns_keyword_results_and_sets_mode(self, svc):
+        """(a) keyword results returned, (b) search_mode == 'keyword_fallback'."""
+        fake_vec = [0.5] * 1024
+        keyword_hits = [{"id": "j-001", "title": "Drug case"}, {"id": "j-002"}]
+
+        calls: list[dict] = []
+
+        async def fake_post(self_, url, json, headers):
+            calls.append(json)
+            if "hybrid" in json or "vector" in json:
+                # Simulate bge-m3 not registered
+                return httpx.Response(
+                    400,
+                    json={
+                        "message": "Cannot find embedder with name `bge-m3`.",
+                        "code": "invalid_search_embedder",
+                    },
+                    request=httpx.Request("POST", url),
+                )
+            # Keyword retry succeeds
+            return _mock_response(
+                200, {"hits": keyword_hits, "estimatedTotalHits": len(keyword_hits)}
+            )
+
+        with (
+            patch("app.services.search.embed_texts", return_value=fake_vec),
+            patch("httpx.AsyncClient.post", new=fake_post),
+        ):
+            result = await svc.documents_search("narkotyki", semantic_ratio=0.5)
+
+        # (a) keyword results are present
+        assert result["hits"] == keyword_hits
+        # (b) mode signals the degradation
+        assert result["search_mode"] == "keyword_fallback"
+        # two HTTP calls: first hybrid (400), then keyword retry (200)
+        assert len(calls) == 2
+        assert "hybrid" in calls[0]
+        assert "hybrid" not in calls[1]
+
+    @pytest.mark.asyncio
+    async def test_fallback_emits_warning_log(self, svc):
+        """(c) a structured warning log is emitted when hybrid degrades."""
+        from loguru import logger
+
+        fake_vec = [0.5] * 1024
+        logged_warnings: list[str] = []
+
+        def _capture_sink(message):
+            logged_warnings.append(str(message))
+
+        async def fake_post(self_, url, json, headers):
+            if "hybrid" in json or "vector" in json:
+                return httpx.Response(
+                    400,
+                    json={"message": "Cannot find embedder with name `bge-m3`."},
+                    request=httpx.Request("POST", url),
+                )
+            return _mock_response(200, {"hits": [], "estimatedTotalHits": 0})
+
+        sink_id = logger.add(_capture_sink, level="WARNING")
+        try:
+            with (
+                patch("app.services.search.embed_texts", return_value=fake_vec),
+                patch("httpx.AsyncClient.post", new=fake_post),
+            ):
+                await svc.documents_search("narkotyki", semantic_ratio=0.5)
+        finally:
+            logger.remove(sink_id)
+
+        assert logged_warnings, "Expected at least one warning to be emitted"
+        combined = " ".join(logged_warnings)
+        assert "hybrid_search_degraded" in combined or "hybrid" in combined.lower(), (
+            f"Expected hybrid degradation warning; got: {logged_warnings}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_sentinel_leaks_into_result(self, svc):
+        """The internal _FALLBACK_SENTINEL key must not appear in the returned dict."""
+        from app.services.search import _FALLBACK_SENTINEL
+
+        fake_vec = [0.5] * 1024
+
+        async def fake_post(self_, url, json, headers):
+            if "hybrid" in json:
+                return httpx.Response(
+                    400,
+                    json={"message": "bge-m3 not found"},
+                    request=httpx.Request("POST", url),
+                )
+            return _mock_response(200, {"hits": [], "estimatedTotalHits": 0})
+
+        with (
+            patch("app.services.search.embed_texts", return_value=fake_vec),
+            patch("httpx.AsyncClient.post", new=fake_post),
+        ):
+            result = await svc.documents_search("test", semantic_ratio=0.5)
+
+        assert _FALLBACK_SENTINEL not in result, (
+            "Internal sentinel key must be stripped before the result is returned"
+        )

--- a/frontend/lib/api/generated/openapi.ts
+++ b/frontend/lib/api/generated/openapi.ts
@@ -8586,6 +8586,14 @@ export interface components {
         /**
          * DocumentSearchResponse
          * @description Paginated document search response (Meilisearch-backed text mode).
+         *
+         *     ``search_mode`` indicates which ranking strategy was used:
+         *
+         *     - ``"keyword"`` — pure keyword search (``semantic_ratio == 0``).
+         *     - ``"hybrid"`` — hybrid semantic+keyword search ran successfully.
+         *     - ``"keyword_fallback"`` — hybrid was requested but Meilisearch returned
+         *       4xx (e.g. the ``bge-m3`` embedder is not registered); the response
+         *       contains keyword results only.  Ops should treat this as an ops alert.
          */
         DocumentSearchResponse: {
             /** Documents */
@@ -8597,6 +8605,12 @@ export interface components {
             query: string;
             /** Query Time Ms */
             query_time_ms?: number | null;
+            /**
+             * Search Mode
+             * @default keyword
+             * @enum {string}
+             */
+            search_mode: "hybrid" | "keyword" | "keyword_fallback";
             /** Total Count */
             total_count?: number | null;
         };

--- a/scripts/openapi-snapshot.json
+++ b/scripts/openapi-snapshot.json
@@ -5127,7 +5127,7 @@
         "type": "object"
       },
       "DocumentSearchResponse": {
-        "description": "Paginated document search response (Meilisearch-backed text mode).",
+        "description": "Paginated document search response (Meilisearch-backed text mode).\n\n``search_mode`` indicates which ranking strategy was used:\n\n- ``\"keyword\"`` \u2014 pure keyword search (``semantic_ratio == 0``).\n- ``\"hybrid\"`` \u2014 hybrid semantic+keyword search ran successfully.\n- ``\"keyword_fallback\"`` \u2014 hybrid was requested but Meilisearch returned\n  4xx (e.g. the ``bge-m3`` embedder is not registered); the response\n  contains keyword results only.  Ops should treat this as an ops alert.",
         "properties": {
           "documents": {
             "items": {
@@ -5154,6 +5154,16 @@
               }
             ],
             "title": "Query Time Ms"
+          },
+          "search_mode": {
+            "default": "keyword",
+            "enum": [
+              "hybrid",
+              "keyword",
+              "keyword_fallback"
+            ],
+            "title": "Search Mode",
+            "type": "string"
           },
           "total_count": {
             "anyOf": [


### PR DESCRIPTION
## Summary

- Adds `search_mode: "hybrid" | "keyword" | "keyword_fallback"` to `DocumentSearchResponse` (additive, backward-compatible — defaults to `"keyword"`).
- When Meilisearch returns 4xx on a hybrid request (e.g. `bge-m3` embedder not registered), `_search_post` now emits a structured `logger.warning("hybrid_search_degraded ...")` with the index name, HTTP status code, and Meilisearch error body; also adds a Sentry breadcrumb via `sentry_sdk.add_breadcrumb` (gracefully no-ops if `sentry-sdk` is absent or uninitialised).
- `documents_search` reads an internal sentinel key from the service result, strips it, and sets `search_mode` to `"keyword_fallback"` when a degradation occurred; `"hybrid"` on success; `"keyword"` for pure-keyword requests.
- Existing keyword results are returned unchanged on fallback — no behaviour regression.

## search_mode values

| Value | Meaning |
|---|---|
| `"keyword"` | `semantic_ratio == 0`; pure BM25 ranking |
| `"hybrid"` | Hybrid search ran successfully; semantic + keyword combined |
| `"keyword_fallback"` | Hybrid requested, Meilisearch returned 4xx; fell back to keyword; **ops signal** |

## Ops signal

On fallback, two signals fire:
1. `logger.warning("hybrid_search_degraded index=judgments status=400 reason=... — retrying as keyword-only; semantic ranking is unavailable")` — always.
2. `sentry_sdk.add_breadcrumb(category="search", level="warning", ...)` with structured metadata — when Sentry is initialised.

## Test plan

- [x] `test_hybrid_400_falls_back_to_keyword_retry` — updated to also assert `search_mode == "keyword_fallback"`
- [x] `test_documents_search_pure_keyword_sets_search_mode` — `search_mode == "keyword"`
- [x] `test_documents_search_hybrid_success_sets_search_mode` — `search_mode == "hybrid"`
- [x] `TestHybridFallbackSignal::test_fallback_returns_keyword_results_and_sets_mode` — (a) keyword hits returned, (b) `search_mode == "keyword_fallback"`
- [x] `TestHybridFallbackSignal::test_fallback_emits_warning_log` — (c) structured warning logged
- [x] `TestHybridFallbackSignal::test_no_fallback_sentinel_leaks_into_result` — internal sentinel stripped before return
- [x] All 45 existing + new tests pass
- [x] OpenAPI snapshot + `frontend/lib/api/generated/openapi.ts` regenerated and committed

Fixes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)