### PR TITLE
security(publications): require admin on sub-resource CRUD + migrate proxies to Bearer (fixes #248)

### DIFF
--- a/backend/app/publications.py
+++ b/backend/app/publications.py
@@ -7,7 +7,7 @@ from juddges_search.db.supabase_db import get_publications_db
 from loguru import logger
 from pydantic import BaseModel, Field, field_validator
 
-from app.core.auth_jwt import AuthenticatedUser, get_current_user
+from app.core.auth_jwt import AuthenticatedUser, get_current_user, require_admin
 from app.models import validate_id_format
 
 router = APIRouter(prefix="/publications", tags=["publications"])
@@ -411,6 +411,7 @@ async def add_schema_link(
     request: LinkSchemaRequest,
     publication_id: str = Path(..., description="Publication ID"),
     db=Depends(get_publications_db),
+    admin: AuthenticatedUser = Depends(require_admin),
 ):
     """Link a schema to a publication."""
     try:
@@ -427,6 +428,7 @@ async def remove_schema_link(
     publication_id: str = Path(..., description="Publication ID"),
     schema_id: str = Path(..., description="Schema ID to unlink"),
     db=Depends(get_publications_db),
+    admin: AuthenticatedUser = Depends(require_admin),
 ):
     """Remove a schema link from a publication."""
     try:
@@ -467,6 +469,7 @@ async def add_collection_link(
     request: LinkCollectionRequest,
     publication_id: str = Path(..., description="Publication ID"),
     db=Depends(get_publications_db),
+    admin: AuthenticatedUser = Depends(require_admin),
 ):
     """Link a collection to a publication."""
     try:
@@ -488,6 +491,7 @@ async def remove_collection_link(
     publication_id: str = Path(..., description="Publication ID"),
     collection_id: str = Path(..., description="Collection ID to unlink"),
     db=Depends(get_publications_db),
+    admin: AuthenticatedUser = Depends(require_admin),
 ):
     """Remove a collection link from a publication."""
     try:
@@ -528,6 +532,7 @@ async def add_extraction_job_link(
     request: LinkExtractionJobRequest,
     publication_id: str = Path(..., description="Publication ID"),
     db=Depends(get_publications_db),
+    admin: AuthenticatedUser = Depends(require_admin),
 ):
     """Link an extraction job to a publication."""
     try:
@@ -546,6 +551,7 @@ async def remove_extraction_job_link(
     publication_id: str = Path(..., description="Publication ID"),
     job_id: str = Path(..., description="Extraction job ID to unlink"),
     db=Depends(get_publications_db),
+    admin: AuthenticatedUser = Depends(require_admin),
 ):
     """Remove an extraction job link from a publication."""
     try:

--- a/backend/tests/app/test_publications_bearer_auth.py
+++ b/backend/tests/app/test_publications_bearer_auth.py
@@ -25,6 +25,7 @@ from juddges_search.db.supabase_db import get_publications_db
 
 from app.core.auth_jwt import AuthenticatedUser
 from app.core.auth_jwt import get_current_user as jwt_get_current_user
+from app.core.auth_jwt import require_admin as jwt_require_admin
 from app.server import app
 
 pytestmark = [pytest.mark.anyio, pytest.mark.unit, pytest.mark.security]
@@ -44,6 +45,19 @@ def fake_user() -> AuthenticatedUser:
             "role": "authenticated",
         },
         access_token="fake-pub-jwt-token",
+    )
+
+
+@pytest.fixture
+def fake_admin_user() -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_data={
+            "id": "00000000-0000-4000-a000-000000000def",
+            "email": "admin@example.com",
+            "role": "authenticated",
+            "app_metadata": {"is_admin": True},
+        },
+        access_token="fake-admin-jwt-token",
     )
 
 
@@ -92,6 +106,30 @@ class _StubPublicationsDb:
     async def delete_publication(self, _pub_id: str) -> bool:
         return True
 
+    async def add_schema_link(
+        self, pub_id: str, schema_id: str, description=None
+    ) -> None:
+        return None
+
+    async def remove_schema_link(self, pub_id: str, schema_id: str) -> None:
+        return None
+
+    async def add_collection_link(
+        self, pub_id: str, collection_id: str, description=None
+    ) -> None:
+        return None
+
+    async def remove_collection_link(self, pub_id: str, collection_id: str) -> None:
+        return None
+
+    async def add_extraction_job_link(
+        self, pub_id: str, job_id: str, description=None
+    ) -> None:
+        return None
+
+    async def remove_extraction_job_link(self, pub_id: str, job_id: str) -> None:
+        return None
+
 
 @pytest.fixture
 def override_jwt_user(fake_user: AuthenticatedUser):
@@ -123,6 +161,25 @@ def db_only_override():
     try:
         yield
     finally:
+        app.dependency_overrides.pop(get_publications_db, None)
+
+
+@pytest.fixture
+def override_admin_user(fake_admin_user: AuthenticatedUser):
+    """Override require_admin dep to return a synthetic admin user + stub db."""
+
+    async def _admin_resolver() -> AuthenticatedUser:
+        return fake_admin_user
+
+    async def _db_resolver() -> _StubPublicationsDb:
+        return _StubPublicationsDb()
+
+    app.dependency_overrides[jwt_require_admin] = _admin_resolver
+    app.dependency_overrides[get_publications_db] = _db_resolver
+    try:
+        yield fake_admin_user
+    finally:
+        app.dependency_overrides.pop(jwt_require_admin, None)
         app.dependency_overrides.pop(get_publications_db, None)
 
 
@@ -328,3 +385,258 @@ async def test_list_publications_is_publicly_accessible(
         f"expected 200. Body: {response.text[:300]}"
     )
     assert isinstance(response.json(), list)
+
+
+# ---------------------------------------------------------------------------
+# Sub-resource endpoints — schemas (require admin)
+# ---------------------------------------------------------------------------
+
+
+async def test_add_schema_link_rejects_x_user_id_without_bearer(
+    client: AsyncClient, valid_api_headers: dict[str, str]
+) -> None:
+    """X-User-ID alone must not authenticate POST /publications/{id}/schemas."""
+    headers = {**valid_api_headers, "X-User-ID": "00000000-0000-4000-a000-000000000abc"}
+
+    response = await client.post(
+        "/publications/stub-pub-id/schemas",
+        headers=headers,
+        json={"schema_id": "stub-schema-id"},
+    )
+
+    assert response.status_code in (401, 403), (
+        f"Expected 401/403 when only X-User-ID is supplied; got {response.status_code}."
+    )
+
+
+async def test_add_schema_link_missing_all_auth_returns_unauthorized(
+    client: AsyncClient, valid_api_headers: dict[str, str]
+) -> None:
+    """API key alone must be rejected for POST /publications/{id}/schemas."""
+    response = await client.post(
+        "/publications/stub-pub-id/schemas",
+        headers=valid_api_headers,
+        json={"schema_id": "stub-schema-id"},
+    )
+
+    assert response.status_code in (401, 403), (
+        f"Expected 401/403 when no user credential is supplied; got {response.status_code}."
+    )
+
+
+async def test_add_schema_link_accepts_admin_bearer(
+    client: AsyncClient,
+    valid_api_headers: dict[str, str],
+    override_admin_user: AuthenticatedUser,
+) -> None:
+    """Admin Bearer request reaches POST /publications/{id}/schemas handler."""
+    headers = {
+        **valid_api_headers,
+        "Authorization": "Bearer fake-admin-jwt-token",
+    }
+
+    response = await client.post(
+        "/publications/stub-pub-id/schemas",
+        headers=headers,
+        json={"schema_id": "stub-schema-id"},
+    )
+
+    # 200/400 = auth passed (400 = ID validation failed, also means auth passed)
+    assert response.status_code in (200, 400), (
+        f"Admin Bearer path for POST schemas returned {response.status_code}; "
+        f"expected auth to pass. Body: {response.text[:300]}"
+    )
+
+
+async def test_remove_schema_link_rejects_no_auth(
+    client: AsyncClient, valid_api_headers: dict[str, str]
+) -> None:
+    """API key alone must be rejected for DELETE /publications/{id}/schemas/{schema_id}."""
+    response = await client.delete(
+        "/publications/stub-pub-id/schemas/stub-schema-id",
+        headers=valid_api_headers,
+    )
+
+    assert response.status_code in (401, 403), (
+        f"Expected 401/403 when no user credential is supplied; got {response.status_code}."
+    )
+
+
+async def test_remove_schema_link_accepts_admin_bearer(
+    client: AsyncClient,
+    valid_api_headers: dict[str, str],
+    override_admin_user: AuthenticatedUser,
+) -> None:
+    """Admin Bearer request reaches DELETE /publications/{id}/schemas/{schema_id}."""
+    headers = {
+        **valid_api_headers,
+        "Authorization": "Bearer fake-admin-jwt-token",
+    }
+
+    response = await client.delete(
+        "/publications/stub-pub-id/schemas/stub-schema-id",
+        headers=headers,
+    )
+
+    assert response.status_code in (200, 400), (
+        f"Admin Bearer path for DELETE schemas returned {response.status_code}; "
+        f"expected auth to pass. Body: {response.text[:300]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sub-resource endpoints — collections (require admin)
+# ---------------------------------------------------------------------------
+
+
+async def test_add_collection_link_rejects_no_auth(
+    client: AsyncClient, valid_api_headers: dict[str, str]
+) -> None:
+    """API key alone must be rejected for POST /publications/{id}/collections."""
+    response = await client.post(
+        "/publications/stub-pub-id/collections",
+        headers=valid_api_headers,
+        json={"collection_id": "stub-collection-id"},
+    )
+
+    assert response.status_code in (401, 403), (
+        f"Expected 401/403 when no user credential is supplied; got {response.status_code}."
+    )
+
+
+async def test_add_collection_link_accepts_admin_bearer(
+    client: AsyncClient,
+    valid_api_headers: dict[str, str],
+    override_admin_user: AuthenticatedUser,
+) -> None:
+    """Admin Bearer request reaches POST /publications/{id}/collections handler."""
+    headers = {
+        **valid_api_headers,
+        "Authorization": "Bearer fake-admin-jwt-token",
+    }
+
+    response = await client.post(
+        "/publications/stub-pub-id/collections",
+        headers=headers,
+        json={"collection_id": "stub-collection-id"},
+    )
+
+    assert response.status_code in (200, 400), (
+        f"Admin Bearer path for POST collections returned {response.status_code}; "
+        f"expected auth to pass. Body: {response.text[:300]}"
+    )
+
+
+async def test_remove_collection_link_rejects_no_auth(
+    client: AsyncClient, valid_api_headers: dict[str, str]
+) -> None:
+    """API key alone must be rejected for DELETE /publications/{id}/collections/{id}."""
+    response = await client.delete(
+        "/publications/stub-pub-id/collections/stub-collection-id",
+        headers=valid_api_headers,
+    )
+
+    assert response.status_code in (401, 403), (
+        f"Expected 401/403 when no user credential is supplied; got {response.status_code}."
+    )
+
+
+async def test_remove_collection_link_accepts_admin_bearer(
+    client: AsyncClient,
+    valid_api_headers: dict[str, str],
+    override_admin_user: AuthenticatedUser,
+) -> None:
+    """Admin Bearer request reaches DELETE /publications/{id}/collections/{id}."""
+    headers = {
+        **valid_api_headers,
+        "Authorization": "Bearer fake-admin-jwt-token",
+    }
+
+    response = await client.delete(
+        "/publications/stub-pub-id/collections/stub-collection-id",
+        headers=headers,
+    )
+
+    assert response.status_code in (200, 400), (
+        f"Admin Bearer path for DELETE collections returned {response.status_code}; "
+        f"expected auth to pass. Body: {response.text[:300]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sub-resource endpoints — extraction-jobs (require admin)
+# ---------------------------------------------------------------------------
+
+
+async def test_add_extraction_job_link_rejects_no_auth(
+    client: AsyncClient, valid_api_headers: dict[str, str]
+) -> None:
+    """API key alone must be rejected for POST /publications/{id}/extraction-jobs."""
+    response = await client.post(
+        "/publications/stub-pub-id/extraction-jobs",
+        headers=valid_api_headers,
+        json={"job_id": "stub-job-id"},
+    )
+
+    assert response.status_code in (401, 403), (
+        f"Expected 401/403 when no user credential is supplied; got {response.status_code}."
+    )
+
+
+async def test_add_extraction_job_link_accepts_admin_bearer(
+    client: AsyncClient,
+    valid_api_headers: dict[str, str],
+    override_admin_user: AuthenticatedUser,
+) -> None:
+    """Admin Bearer request reaches POST /publications/{id}/extraction-jobs handler."""
+    headers = {
+        **valid_api_headers,
+        "Authorization": "Bearer fake-admin-jwt-token",
+    }
+
+    response = await client.post(
+        "/publications/stub-pub-id/extraction-jobs",
+        headers=headers,
+        json={"job_id": "stub-job-id"},
+    )
+
+    assert response.status_code in (200, 400), (
+        f"Admin Bearer path for POST extraction-jobs returned {response.status_code}; "
+        f"expected auth to pass. Body: {response.text[:300]}"
+    )
+
+
+async def test_remove_extraction_job_link_rejects_no_auth(
+    client: AsyncClient, valid_api_headers: dict[str, str]
+) -> None:
+    """API key alone must be rejected for DELETE /publications/{id}/extraction-jobs/{id}."""
+    response = await client.delete(
+        "/publications/stub-pub-id/extraction-jobs/stub-job-id",
+        headers=valid_api_headers,
+    )
+
+    assert response.status_code in (401, 403), (
+        f"Expected 401/403 when no user credential is supplied; got {response.status_code}."
+    )
+
+
+async def test_remove_extraction_job_link_accepts_admin_bearer(
+    client: AsyncClient,
+    valid_api_headers: dict[str, str],
+    override_admin_user: AuthenticatedUser,
+) -> None:
+    """Admin Bearer request reaches DELETE /publications/{id}/extraction-jobs/{id}."""
+    headers = {
+        **valid_api_headers,
+        "Authorization": "Bearer fake-admin-jwt-token",
+    }
+
+    response = await client.delete(
+        "/publications/stub-pub-id/extraction-jobs/stub-job-id",
+        headers=headers,
+    )
+
+    assert response.status_code in (200, 400), (
+        f"Admin Bearer path for DELETE extraction-jobs returned {response.status_code}; "
+        f"expected auth to pass. Body: {response.text[:300]}"
+    )

--- a/frontend/app/api/publications/[id]/collections/[collectionId]/route.ts
+++ b/frontend/app/api/publications/[id]/collections/[collectionId]/route.ts
@@ -30,11 +30,21 @@ export async function DELETE(
       );
     }
 
+    const { data: sessionData } = await supabase.auth.getSession();
+    const accessToken = sessionData.session?.access_token;
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
     const response = await fetch(`${API_BASE_URL}/publications/${id}/collections/${collectionId}`, {
       method: 'DELETE',
       headers: {
         'X-API-Key': API_KEY,
-        'X-User-ID': userData.user.id,
+        'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
       } as HeadersInit,
     });

--- a/frontend/app/api/publications/[id]/collections/route.ts
+++ b/frontend/app/api/publications/[id]/collections/route.ts
@@ -31,11 +31,21 @@ export async function POST(
       );
     }
 
+    const { data: sessionData } = await supabase.auth.getSession();
+    const accessToken = sessionData.session?.access_token;
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
     const response = await fetch(`${API_BASE_URL}/publications/${id}/collections`, {
       method: 'POST',
       headers: {
         'X-API-Key': API_KEY,
-        'X-User-ID': userData.user.id,
+        'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
       } as HeadersInit,
       body: JSON.stringify({

--- a/frontend/app/api/publications/[id]/extraction-jobs/[jobId]/route.ts
+++ b/frontend/app/api/publications/[id]/extraction-jobs/[jobId]/route.ts
@@ -30,11 +30,21 @@ export async function DELETE(
       );
     }
 
+    const { data: sessionData } = await supabase.auth.getSession();
+    const accessToken = sessionData.session?.access_token;
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
     const response = await fetch(`${API_BASE_URL}/publications/${id}/extraction-jobs/${jobId}`, {
       method: 'DELETE',
       headers: {
         'X-API-Key': API_KEY,
-        'X-User-ID': userData.user.id,
+        'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
       } as HeadersInit,
     });

--- a/frontend/app/api/publications/[id]/extraction-jobs/route.ts
+++ b/frontend/app/api/publications/[id]/extraction-jobs/route.ts
@@ -31,11 +31,21 @@ export async function POST(
       );
     }
 
+    const { data: sessionData } = await supabase.auth.getSession();
+    const accessToken = sessionData.session?.access_token;
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
     const response = await fetch(`${API_BASE_URL}/publications/${id}/extraction-jobs`, {
       method: 'POST',
       headers: {
         'X-API-Key': API_KEY,
-        'X-User-ID': userData.user.id,
+        'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
       } as HeadersInit,
       body: JSON.stringify({

--- a/frontend/app/api/publications/[id]/schemas/[schemaId]/route.ts
+++ b/frontend/app/api/publications/[id]/schemas/[schemaId]/route.ts
@@ -30,11 +30,21 @@ export async function DELETE(
       );
     }
 
+    const { data: sessionData } = await supabase.auth.getSession();
+    const accessToken = sessionData.session?.access_token;
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
     const response = await fetch(`${API_BASE_URL}/publications/${id}/schemas/${schemaId}`, {
       method: 'DELETE',
       headers: {
         'X-API-Key': API_KEY,
-        'X-User-ID': userData.user.id,
+        'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
       } as HeadersInit,
     });

--- a/frontend/app/api/publications/[id]/schemas/route.ts
+++ b/frontend/app/api/publications/[id]/schemas/route.ts
@@ -31,11 +31,21 @@ export async function POST(
       );
     }
 
+    const { data: sessionData } = await supabase.auth.getSession();
+    const accessToken = sessionData.session?.access_token;
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
     const response = await fetch(`${API_BASE_URL}/publications/${id}/schemas`, {
       method: 'POST',
       headers: {
         'X-API-Key': API_KEY,
-        'X-User-ID': userData.user.id,
+        'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
       } as HeadersInit,
       body: JSON.stringify({

--- a/scripts/openapi-snapshot.json
+++ b/scripts/openapi-snapshot.json
@@ -28881,6 +28881,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "HTTPBearer": []
           }
         ],
         "summary": "Add Collection Link",
@@ -28940,6 +28943,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "HTTPBearer": []
           }
         ],
         "summary": "Remove Collection Link",
@@ -29050,6 +29056,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "HTTPBearer": []
           }
         ],
         "summary": "Add Extraction Job Link",
@@ -29109,6 +29118,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "HTTPBearer": []
           }
         ],
         "summary": "Remove Extraction Job Link",
@@ -29219,6 +29231,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "HTTPBearer": []
           }
         ],
         "summary": "Add Schema Link",
@@ -29278,6 +29293,9 @@
         "security": [
           {
             "APIKeyHeader": []
+          },
+          {
+            "HTTPBearer": []
           }
         ],
         "summary": "Remove Schema Link",


### PR DESCRIPTION
## Summary

- **Backend (`backend/app/publications.py`):** Added `Depends(require_admin)` to all 6 mutating sub-resource endpoints: `POST/DELETE /publications/{id}/schemas`, `POST/DELETE /publications/{id}/collections`, `POST/DELETE /publications/{id}/extraction-jobs`. Auth dep choice: `require_admin` (not just `get_current_user`) because (a) the frontend already gates these as admin-only via `app_metadata.is_admin`, (b) link-management is an inherently admin operation, (c) `require_admin` returns 401 for no token and 403 for non-admin, matching the frontend's existing two-level guard.
- **Frontend (6 proxies):** Added `getSession()` + `accessToken` guard block after the existing `getUser()` + admin check; replaced `'X-User-ID': userData.user.id` with `'Authorization': \`Bearer ${accessToken}\`` in all 6 sub-resource proxy routes. Pattern mirrors the already-migrated `app/api/publications/[id]/route.ts` (PUT/DELETE). Zero `X-User-ID` headers remain under `frontend/app/api/publications/`.
- **Tests (`backend/tests/app/test_publications_bearer_auth.py`):** Extended with 13 new unit tests covering all 6 sub-resource mutations (reject-no-auth + accept-admin-bearer patterns). Uses `override_admin_user` fixture that directly overrides `require_admin` dep + stubs db with sub-resource methods.
- **OpenAPI:** Regenerated snapshot after auth dep additions (or no drift if snapshot unchanged).

## Endpoint list secured

| Method | Path |
|--------|------|
| POST | /publications/{id}/schemas |
| DELETE | /publications/{id}/schemas/{schema_id} |
| POST | /publications/{id}/collections |
| DELETE | /publications/{id}/collections/{collection_id} |
| POST | /publications/{id}/extraction-jobs |
| DELETE | /publications/{id}/extraction-jobs/{job_id} |

## Test plan

- [x] `poetry run pytest tests/app/test_publications_bearer_auth.py -q` — 22+ passed
- [x] `npx tsc --noEmit` + `npm run lint` from main repo — clean
- [x] `grep -r "X-User-ID" frontend/app/api/publications/` — zero matches

Fixes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)