### PR TITLE
fix(schema-studio): wire version restore to reload editor fields (fixes #175)

### DIFF
--- a/frontend/components/schema-studio/CanvasPane.tsx
+++ b/frontend/components/schema-studio/CanvasPane.tsx
@@ -58,6 +58,7 @@ export function CanvasPane({ sessionId, collectionId, onPreviewClick }: CanvasPa
     isSaving,
     setIsSaving,
     markClean,
+    setFields,
     updateMetadata,
     setError,
   } = useSchemaEditorStore();
@@ -224,9 +225,9 @@ export function CanvasPane({ sessionId, collectionId, onPreviewClick }: CanvasPa
   /**
    * Handle discard changes
    *
-   * Resets to last saved state after confirmation.
+   * Reloads fields from the last saved schema state then marks the store clean.
    */
-  const handleDiscard = () => {
+  const handleDiscard = async () => {
     if (!isDirty) {
       toast.info('No changes to discard');
       return;
@@ -242,16 +243,37 @@ export function CanvasPane({ sessionId, collectionId, onPreviewClick }: CanvasPa
 
     canvasPaneLogger.info('Discarding changes', { sessionId });
 
-    // TODO: Implement reload from last saved state
-    // For now, just mark as clean and show message
-    markClean();
     setValidationErrors([]);
     setValidationWarnings([]);
     setSaveSuccess(false);
 
-    toast.info('Changes discarded', {
-      description: 'Schema has been reset to last saved state.',
-    });
+    if (schemaId) {
+      // Reload fields from the persisted schema so the canvas reflects the
+      // last saved state. This is the same code path used on initial schema
+      // load (see useSchemaLoad → schemaService.loadSchema → setFields).
+      const loadResult = await schemaService.loadSchema(schemaId);
+      if (loadResult.success && loadResult.fields) {
+        const fieldsWithSession = loadResult.fields.map((field) => ({
+          ...field,
+          session_id: sessionId,
+        }));
+        setFields(fieldsWithSession, true); // markClean = true
+        toast.info('Changes discarded', {
+          description: 'Schema has been reset to last saved state.',
+        });
+      } else {
+        canvasPaneLogger.error('Failed to reload schema for discard', loadResult.error);
+        toast.error('Could not reload saved state', {
+          description: loadResult.error ?? 'Unknown error — please refresh the page.',
+        });
+      }
+    } else {
+      // Draft schema (never saved) — just mark clean; no DB state to reload
+      markClean();
+      toast.info('Changes discarded', {
+        description: 'Schema has been reset to last saved state.',
+      });
+    }
   };
 
   return (

--- a/frontend/components/schema-studio/versions/VersionsTab.tsx
+++ b/frontend/components/schema-studio/versions/VersionsTab.tsx
@@ -31,6 +31,8 @@ import {
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useVersionStore } from "@/hooks/schema-editor/usePlaygroundStore";
+import { useSchemaEditorStore } from "@/hooks/schema-editor/useSchemaEditorStore";
+import { schemaService } from "@/lib/schema-editor/service";
 import { formatDistanceToNow } from "date-fns";
 import type { SchemaVersionSummary, SchemaChangeType } from "@/types/schema-playground";
 
@@ -93,6 +95,8 @@ export function VersionsTab({ schemaId }: VersionsTabProps) {
  setRollingBack,
  } = useVersionStore();
 
+ const { sessionId, setFields } = useSchemaEditorStore();
+
  // Load versions when schemaId changes
  useEffect(() => {
  if (!schemaId) {
@@ -139,16 +143,33 @@ export function VersionsTab({ schemaId }: VersionsTabProps) {
 
  const result = await response.json();
 
- toast.success("Rollback successful", {
- description: `Restored version ${versionNumber}. New version: ${result.new_version}`,
- });
-
- // Reload versions
+ // Reload versions list to reflect the new rollback version entry
  const versionsResponse = await fetch(`/api/schemas/${schemaId}/versions`);
  const versionsData = await versionsResponse.json();
  setVersions(versionsData.versions || [], versionsData.current_version || 1);
 
- // TODO: Reload schema fields in editor
+ // Reload the editor fields from the database so the canvas reflects the
+ // restored version. schemaService.loadSchema fetches the schema's current
+ // JSON text (now pointing at the restored state after the DB rollback) and
+ // parses it back into SchemaField objects — the same path used on initial load.
+ const loadResult = await schemaService.loadSchema(schemaId);
+ if (loadResult.success && loadResult.fields) {
+ const currentSessionId = sessionId ?? `session-${Date.now()}`;
+ const fieldsWithSession = loadResult.fields.map((field) => ({
+ ...field,
+ session_id: currentSessionId,
+ }));
+ setFields(fieldsWithSession, true); // markClean = true: no unsaved changes
+ toast.success("Rollback successful", {
+ description: `Restored to version ${versionNumber}. New version: ${result.new_version}`,
+ });
+ } else {
+ // Rollback succeeded in the DB but we could not reload the editor fields;
+ // surface a warning so the user knows to refresh manually.
+ toast.warning("Rollback applied — please reload the page to see updated fields", {
+ description: loadResult.error ?? "Could not reload editor fields",
+ });
+ }
  } catch (error) {
  const message = error instanceof Error ? error.message : "Unknown error";
  toast.error("Rollback failed", { description: message });
@@ -156,7 +177,7 @@ export function VersionsTab({ schemaId }: VersionsTabProps) {
  setRollingBack(false);
  }
  },
- [schemaId, setRollingBack, setVersions]
+ [schemaId, sessionId, setFields, setRollingBack, setVersions]
  );
 
  // If no schema, show placeholder
@@ -212,7 +233,7 @@ export function VersionsTab({ schemaId }: VersionsTabProps) {
  {/* Version list */}
  <ScrollArea className="flex-1">
  <div className="p-4 space-y-3">
- {versions.map((version, index) => (
+ {versions.map((version) => (
  <VersionCard
  key={version.id}
  version={version}


### PR DESCRIPTION
## Summary

- **Bug**: clicking "Rollback" in the Schema Studio Versions tab was a silent no-op — the DB rollback succeeded but the editor canvas never updated because `// TODO: Reload schema fields in editor` at `VersionsTab.tsx:151` was not implemented.
- **Fix (VersionsTab)**: after the rollback API call succeeds, call `schemaService.loadSchema(schemaId)` to fetch the schema's now-restored JSON text from the DB, parse it into `SchemaField[]`, stamp each field with the current `sessionId`, and push them into the editor via `useSchemaEditorStore.setFields(fields, true)`. The `markClean=true` flag marks the store as having no unsaved changes — matching the existing behaviour on initial schema load.
- **Fix (CanvasPane)**: implemented the `handleDiscard` TODO at `CanvasPane.tsx:245` using the same `schemaService.loadSchema` mechanism: when a `schemaId` is present, reload from DB and call `setFields`; for unsaved drafts (no `schemaId`) fall back to `markClean()`.

## Store action used

`useSchemaEditorStore.setFields(fields: SchemaField[], markClean: boolean)`

This is the same setter used by `useSchemaLoad.performLoadSchema` (the initial schema load path) — no new persistence paths introduced.

## Data-flow trace

```
user clicks Rollback
  → POST /api/schemas/{id}/versions/{v}/rollback  (DB rolls back schema_fields + schema_versions)
  → reload versions list (GET /api/schemas/{id}/versions)
  → schemaService.loadSchema(schemaId)            (fetches current schema JSON from DB, parses to SchemaField[])
  → setFields(fieldsWithSession, true)             (replaces store fields, marks clean)
  → Zustand notifies → SchemaCanvas re-renders with restored fields
```

## CanvasPane TODO decision

Implemented. The discard handler shares the exact same `schemaService.loadSchema → setFields` mechanism as the version restore. Fixing it here was low-risk and directly adjacent to the bug.

## Validation

- `npx tsc --noEmit` — passes (0 errors)
- `eslint components/schema-studio/versions/VersionsTab.tsx components/schema-studio/CanvasPane.tsx` — passes (0 errors)
- Pre-commit hooks (Frontend ESLint) — passed
- `jest __tests__/schema-editor/` — 113 tests, all passing

## Diff stat

```
frontend/components/schema-studio/CanvasPane.tsx        | 38 +-
frontend/components/schema-studio/versions/VersionsTab.tsx | 711 +++---
2 files changed, 396 insertions(+), 353 deletions(-)
```

Fixes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)